### PR TITLE
Add Docker and docker-compose support

### DIFF
--- a/.docker/app_dockerfile
+++ b/.docker/app_dockerfile
@@ -1,0 +1,11 @@
+FROM node
+SHELL ["/bin/bash", "--login", "-c"]
+
+WORKDIR /app
+
+# copy repo contents and install deps
+#
+COPY webapp /app/
+
+RUN npm install
+CMD ["npm", "run", "serve"]

--- a/.docker/datalab_dockerfile
+++ b/.docker/datalab_dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.8
+SHELL ["/bin/bash", "--login", "-c"]
+
+# Install Pipenv and use it to grab dependencies
+WORKDIR /app
+RUN pip install pipenv
+
+COPY ./server/Pipfile /app
+RUN pipenv install --deploy
+
+# Copy all server code into workdir
+COPY ./server/ /app
+
+# Run flask server
+CMD ["pipenv", "run", "python", "main.py"]

--- a/.docker/mongo_dockerfile
+++ b/.docker/mongo_dockerfile
@@ -1,0 +1,3 @@
+FROM mongo:3.6-xenial
+
+COPY .docker/mongod.conf /etc/mongod.conf

--- a/.docker/mongod.conf
+++ b/.docker/mongod.conf
@@ -1,0 +1,34 @@
+# mongod.conf
+
+# for documentation of all options, see:
+#   http://docs.mongodb.org/manual/reference/configuration-options/
+
+# network interfaces
+net:
+  port: 27017
+  # bindIp: /tmp/mongod-datalab.sock
+  # bindIpAll: false
+
+# where to write logging data.
+#systemLog:
+#  destination: file
+#  logAppend: true
+#  path: /var/log/mongod/mongod.log
+
+# Where and how to store data.
+storage:
+  dbPath: /data/db
+  journal:
+    enabled: true
+#  engine:
+#  mmapv1:
+#  wiredTiger:
+
+# how the process runs
+#processManagement:
+  #fork: false # fork and run in background
+  #pidFilePath: /var/run/mongodb/mongod.pid  # location of pidfile
+  #timeZoneInfo: /usr/share/zoneinfo
+
+security:
+  authorization: disabled

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ If you don't have any data you want to keep, just delete all the documents in "d
 In order to use remote filesystems, you will have to (connect to the chem VPN and) mount Grey group data backup servers on your computer. Then, go into `resources.py` and change the folders to the folders you are interested in. The remote access is currently very slow, so I recommend you restrict the folders to be as small as possible- i.e. just your personal folder on each given server. 
 
 ## Installation:
+
 Before starting, be warned– the javascript app environment installation will take up at least 300 mb.
 Choose where you would like to put the direcotry, and `git clone https://github.com/the-grey-group/datalab.git` 
 
@@ -50,3 +51,12 @@ NOTE: You may have to chage the `MONGO_URI` config in `main.py` depending on you
 `npm run serve`
 
 Similar to the flask development server, this will provide a development environment that serves the web app and automatically reloads it as changes are made to the source.
+
+## Alternative installation with Docker
+
+These instructions assume that both Docker and docker-compose are installed (and that the Docker daemon is running).
+
+Dockerfiles for the web app, server and database can be found in the `.docker` directory.
+- `docker-compose build` will pull each of the base Docker images (`mongo`, `node` and `python:3.8`) and build the corresponding apps on top of them.
+- `docker-compose up` will launch a container for each component, such that the web app can be accessed at `localhost:8080`, the server at `localhost:5001` and the database at `localhost:27017`. The source files for the server and the web app are copied at the build stage, so no hot-reloading will occur by default (so `docker-compose build` will need to be called again).
+- `docker-compose stop` will stop all running containers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3'
+
+services:
+
+  app:
+    restart: always
+    build:
+      context: .
+      dockerfile: .docker/app_dockerfile
+    depends_on:
+      - datalab
+    volumes:
+      - ./logs:/var/logs/mongod/
+    ports:
+      - "8080:8080"
+
+  datalab:
+    restart: always
+    build:
+      context: .
+      dockerfile: .docker/datalab_dockerfile
+    depends_on:
+      - mongo
+    volumes:
+      - sockets:/tmp/
+      - ./logs:/app/logs/
+    ports:
+      - "5001:5001"
+
+  mongo:
+    restart: always
+    build:
+      context: .
+      dockerfile: .docker/mongo_dockerfile
+    command: ["mongod", "-f", "/etc/mongod.conf"]
+    volumes:
+      - sockets:/tmp/
+      - ./logs:/var/logs/mongod/
+    ports:
+      - "27017:27017"
+
+volumes:
+    sockets:

--- a/server/main.py
+++ b/server/main.py
@@ -435,7 +435,7 @@ def list_remote_directories_cached():
 
 
 if __name__ == '__main__':
-	app.run(debug=True, port=5001)
+	app.run(host="0.0.0.0", debug=True, port=5001)
 
 
 


### PR DESCRIPTION
This PR adds support for building and launching each of the datalab components as Docker containers. Eventually we can use this to run tests on pushes inside the GitHub Actions CI.