### PR TITLE
Add caching to remote server functionality

### DIFF
--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -1,14 +1,18 @@
 <template>
-  <div id="nav">
+  <!-- <div id="nav"> -->
     <!-- <router-link to="/">Home</router-link> | -->
-    <router-link to="/about">About</router-link> |
+    <!-- <router-link to="/about">About</router-link> | -->
     <!-- <router-link to="/test">Test Page</router-link> |  -->
-    <router-link to="/samples">Samples</router-link>
-  </div>
+    <!-- <router-link to="/samples">Samples</router-link> -->
+  <!-- </div> -->
   <router-view/>
 </template>
 
 <style>
+body {
+  margin: 0rem !important; /* for some reason, tinymce sets margin 1rem globally :o */
+}
+
 #app {
   font-family: Avenir, Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;

--- a/webapp/src/components/TreeMenu.vue
+++ b/webapp/src/components/TreeMenu.vue
@@ -12,7 +12,6 @@
 			<span class="toplevel-name" :class="{'search-match':searchMatched}">
 				{{ entry.name }}
 			</span>
-
 		</div>
 		<div v-else-if='entry.type == "directory"' @click="toggleChildren" >
 			<span :class="{expanded: showChildren}" class="directory-arrow">&#9656;</span>
@@ -41,6 +40,17 @@
 				&#8249; &#8250;
 			</span>
 			<span class="filename" :class="{'search-match':searchMatched}">
+				{{entry.name}}
+			</span>
+		</div>
+
+		<div v-else-if="entry.type == 'error'"
+			class="error-entry alert alert-warning">
+			<font-awesome-icon
+				:icon='["fas","exclamation-circle"]'
+				class="mr-2"
+			/>
+			<span>
 				{{entry.name}}
 			</span>
 		</div>
@@ -202,6 +212,10 @@
 .filename {
 	color: #4a4a4a;
 	margin-right: 10px;
+}
+
+.error-entry {
+	/*color: #b90000;*/
 }
 
 .selected {

--- a/webapp/src/main.js
+++ b/webapp/src/main.js
@@ -8,10 +8,10 @@ import App from './App.vue'
 import router from './router'
 
 import { library } from '@fortawesome/fontawesome-svg-core';
-import { faSave, faChevronRight, faArrowUp, faArrowDown, faTimes, faSync, faFolderOpen, faFolder, faHdd, faLink, faUnlink} from '@fortawesome/free-solid-svg-icons';
+import { faSave, faChevronRight, faArrowUp, faArrowDown, faTimes, faSync, faFolderOpen, faFolder, faHdd, faLink, faUnlink, faExclamationCircle} from '@fortawesome/free-solid-svg-icons';
 // import { faHdd } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
-library.add(faSave, faChevronRight, faArrowUp, faArrowDown, faTimes, faSync, faFolder, faFolderOpen, faHdd, faLink, faUnlink)
+library.add(faSave, faChevronRight, faArrowUp, faArrowDown, faTimes, faSync, faFolder, faFolderOpen, faHdd, faLink, faUnlink, faExclamationCircle)
 
 
 // Import TinyMCE

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -200,6 +200,16 @@ export async function fetchRemoteTree() {
 	return fetch_get(`${SERVER_ADDRESS}/list-remote-directories/`)
 	.then( function (response_json) {
 		store.commit('setRemoteDirectoryTree', response_json)
+		return response_json
+	})
+}
+
+export async function fetchCachedRemoteTree() {
+	console.log("fetchCachedRemoteTree called!")
+	return fetch_get(`${SERVER_ADDRESS}/list-remote-directories-cached/`)
+	.then( function (response_json) {
+		store.commit('setRemoteDirectoryTree', response_json.cached_dir_structures)
+		return response_json
 	})
 }
 

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -8,6 +8,7 @@ export default createStore({
 		saved_status: {},
 		updating: {},
 		remoteDirectoryTree: {},
+		remoteDirectoryTreeSecondsSinceLastUpdate: null,
 		files: {},
 	},
 	mutations: {
@@ -54,6 +55,9 @@ export default createStore({
 		},
 		setRemoteDirectoryTree(state, remoteDirectoryTree) {
 			state.remoteDirectoryTree = remoteDirectoryTree
+		},
+		setRemoteDirectoryTreeSecondsSinceLastUpdate(state, secondsSinceLastUpdate) {
+			state.remoteDirectoryTreeSecondsSinceLastUpdate = secondsSinceLastUpdate
 		},
 		addABlock(state, payload) {
 			// payload: sample_id, new_block_obj, new_display_order

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -149,7 +149,7 @@ import FileSelectDropdown from "@/components/FileSelectDropdown"
 import SelectableFileTree from "@/components/SelectableFileTree"
 import Modal from "@/components/Modal"
 
-import { getSampleData,addABlock, saveSample, deleteFileFromSample, fetchRemoteTree, addRemoteFileToSample } from "@/server_fetch_utils"
+import { getSampleData,addABlock, saveSample, deleteFileFromSample, fetchRemoteTree, fetchCachedRemoteTree, addRemoteFileToSample } from "@/server_fetch_utils"
 
 import setupUppy from '@/file_upload.js'
 
@@ -223,6 +223,17 @@ export default {
 		async getSampleData() {
 			await getSampleData(this.sample_id);
 			this.sample_data_loaded = true;
+		},
+		async loadCachedTree() {
+			var response_json = await fetchCachedRemoteTree()
+			// What happens if the reponse is an error? 
+			console.log(`loadCachedTree received, ${response_json.seconds_since_last_update} seconds out of date:`)
+			if (response_json.seconds_since_last_update > 3600) {
+				console.log("cache more than 1 hr out of date. Fetching new sample tree")
+				this.updateRemoteTree()
+			}
+
+			// console.log(response_json)
 		},
 		async updateRemoteTree() {
 			this.isLoadingRemoteTree = true
@@ -303,8 +314,8 @@ export default {
 		};
 		document.addEventListener('keydown', this._keyListener.bind(this));
 
-		// start retreiving the file tree. Currently commented out so we aren't constantly polling the 
-		// chemistry data servers every time we reload
+		// Retreive the cached file tree
+		this.loadCachedTree()
 		// this.updateRemoteTree()
 
 		// setup the uppy instsance

--- a/webapp/src/views/Samples.vue
+++ b/webapp/src/views/Samples.vue
@@ -1,4 +1,8 @@
 <template>
+<div id="nav">
+	<router-link to="/about">About</router-link> |
+	<router-link to="/samples">Samples</router-link>
+</div>
 <div id="tableContainer" class="container">
 	<div class="row">
 		<div class="col-sm-10 mx-auto mb-3">


### PR DESCRIPTION
This pull request adds caching to the remote filesystems. A new collection is added to the database which holds the file tree for each remote server. When the EditPage loads, the cached tree is loaded. If it is more than 1 hour out of date, then the remote server is automatically queried for a more up-to-date tree, which is loaded asynchronously.

Currently, error handling is a little wonky. 