### PR TITLE
JDB Addressing SynthesisBlock import error

### DIFF
--- a/webapp/src/resources.js
+++ b/webapp/src/resources.js
@@ -4,6 +4,7 @@ import ImageBlock from "@/components/datablocks/ImageBlock"
 import XRDBlock from "@/components/datablocks/XRDBlock"
 import CycleBlock from "@/components/datablocks/CycleBlock"
 // import SynthesisBlock from "@/components/datablocks/SynthesisBlock"
+// note: SynthesisBlock not yet implemented
 
 export const blockKinds = {
    test: { description:"Test Block", component: DataBlockBase },


### PR DESCRIPTION
I'm not ready to commit the code for the Synthesis Block quite yet, so I am commenting out the SynthesisBlock import in resources.js so that it stops throwing an error.