### PR TITLE
Pass auth headers through uppy

### DIFF
--- a/webapp/src/file_upload.js
+++ b/webapp/src/file_upload.js
@@ -6,7 +6,7 @@ import XHRUpload from "@uppy/xhr-upload";
 import Webcam from "@uppy/webcam";
 
 import store from "@/store/index.js";
-import construct_headers from "@/server_fetch_utils.js";
+import { construct_headers } from "@/server_fetch_utils.js";
 
 import { API_URL } from "@/resources.js";
 // file-upload loaded

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -7,7 +7,7 @@ import { API_URL, API_TOKEN } from "@/resources.js";
 // ****************************************************************************
 // A simple wrapper to simplify response handling for fetch calls
 // ****************************************************************************
-function construct_headers(additional_headers = null) {
+export function construct_headers(additional_headers = null) {
   let headers = {};
   if (additional_headers != null) {
     headers = additional_headers;


### PR DESCRIPTION
Fixes an issue where file uploads via the web app failed on deployments that use basic auth.