### PR TITLE
Automerge dependabot PRs into auxiliary branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,14 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 50
-    target-branch: main
+    target-branch: dependabot_updates
     labels:
       - dependency_updates
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
-    target-branch: main
+    target-branch: dependabot_updates
     labels:
       - CI
+      - dependency_updates

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,16 @@
 name: CI tests
 on:
   pull_request:
+    branches-ignore:
+      - dependabot_updates
   push:
     branches:
       - main
+      - dependabot_updates
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   pre-commit:

--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -1,0 +1,30 @@
+# Lifted from https://github.com/Materials-Consortia/optimade-python-tools/blob/master/.github/workflows/ci_automerge_dependabot.yml
+# This enables a workflow where all incoming dependabot PRs are auto-merged into a auxiliary `dependabot_updates` branch, which can then be
+# merged into `main` once the tests pass. The `dependabot_updates` branch must then be reset to the same HEAD as `main` for future updates.
+
+name: CI - Activate auto-merging for Dependabot PRs and reset the base branch after merge
+
+on:
+  pull_request_target:
+    branches:
+      - dependabot_updates
+
+jobs:
+  update-dependabot-branch:
+    name: Activate auto-merge into `dependabot_updates`
+    if: github.repository_owner == 'the-grey-group' && startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Activate auto-merge
+        run: |
+          PR_ID="$(gh api graphql -F owner='{owner}' -F name='{repo}' -f query='query($owner: String!, $name: String!) {repository(owner: $owner, name: $name) {pullRequest(number: ${{ github.event.pull_request.number }}) {id}}}' --jq '.data.repository.pullRequest.id')"
+          gh api graphql -f pr_id="$PR_ID" -f query='mutation($pr_id: ID!) {enablePullRequestAutoMerge(input:{mergeMethod:SQUASH,pullRequestId:$pr_id }) {pullRequest {number}}}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}


### PR DESCRIPTION
Use automerge into a single new branch (`dependabot_updates`), then collect all dependabot updates into a single PR.

Requires automerge to be allowed on the branch `dependabot_updates` branch temporarily (as it is otherwise protected). This is achieved using GitHub API calls with the new @greymon-bot's personal access token (stored as a repo secret `BOT_PAT`). 

This is a bit fiddly to get right, so will merge this PR and monitor it myself.