### PR TITLE
Speed-up Docker CI builds (~x2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,11 +88,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Docker BuildKit
-        uses: docker/setup-buildx-action@v2
-        with:
-          install: true
-
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
@@ -113,23 +108,14 @@ jobs:
         run: yarn build
 
       - name: Build the Docker images
-        env:
-          COMPOSE_DOCKER_CLI_BUILD: 1
-          DOCKER_BUILDKIT: 1
         run: |
           docker compose --profile prod build
 
       - name: Start Docker images
-        env:
-          COMPOSE_DOCKER_CLI_BUILD: 1
-          DOCKER_BUILDKIT: 1
-        # Wait for port to open in docker image before next step
         run: |
           # Create a named docker network that all containers attach to
           docker network create nginx
-          docker compose --profile prod up --abort-on-container-exit &
-          sudo apt install -qq -y wait-for-it
-          wait-for-it localhost:8081 -t 240
+          docker compose --profile prod up -d --wait --no-build
 
       - name: Run end-to-end tests
         working-directory: ./webapp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       target: production
     volumes:
       - ./logs:/logs
+    ports:
+      - "8081:8081"
     networks:
       - nginx
 
@@ -37,6 +39,8 @@ services:
       - database
     volumes:
       - ./logs:/logs
+    ports:
+      - "5001:5001"
     networks:
       - nginx
       - backend


### PR DESCRIPTION
- Scrap buildx, seems to be bug on GH actions for fs performance with lots of files (e.g., npm install)
- Make sure ports are exposed for tests
- Scrap wait-for-it and use native docker compose flag
- Force no-build in docker compose up call (seems like sometimes it was being rebuilt)