### PR TITLE
allow extra fields in items while figuring out relationships

### DIFF
--- a/pydatalab/pydatalab/models/items.py
+++ b/pydatalab/pydatalab/models/items.py
@@ -15,6 +15,14 @@ class Item(BaseModel):
         description="The timestamp at which this item was last modified."
     )
 
+    parent_items: List[str] = Field(
+        default=[], description="Items from which this sample is derived"
+    )
+
+    child_items: List[str] = Field(
+        default=[], description="Items that are derived from this sample"
+    )
+
     name: Optional[str] = Field(description="A human-readable/usable name for the item.")
 
     description: Optional[str] = Field(
@@ -39,7 +47,7 @@ class Item(BaseModel):
 
     class Config:
         # Do not let arbitrary data be added alongside this sample
-        extra = "forbid"
+        extra = "allow"
 
     @validator("last_modified", pre=True)
     def cast_to_datetime(cls, v):


### PR DESCRIPTION
While working on #185, we may add new fields to the database. This will cause a pydantic error when trying to run with the same db on any other branch, so this branch can be used if you would like to turn off that error (by allowing extra fields in the `Item` model)