### PR TITLE
Fix potential security vulnerability in files route

### DIFF
--- a/pydatalab/pydatalab/routes/files.py
+++ b/pydatalab/pydatalab/routes/files.py
@@ -12,7 +12,7 @@ from pydatalab.config import CONFIG
 
 
 def get_file(file_id, filename):
-    path = os.path.join(CONFIG.FILE_DIRECTORY, file_id)
+    path = os.path.join(CONFIG.FILE_DIRECTORY, secure_filename(file_id))
     return send_from_directory(path, filename)
 
 


### PR DESCRIPTION
We were concerned that files route may be exploitable by giving routes such as `/files/..%2F..%2Fsome_vulnerable_directory/some_vulnerable_file`,

so now the provided file_id is wrapped in `secure_filename`, which should fix this for now.

