### PR TITLE
Address CI failure for post setup node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
 
       - name: Set up Node
         uses: actions/setup-node@v3
+        env:
+          FORCE_COLOR: 0
         with:
           node-version: "16.15.0"
           cache: "yarn"


### PR DESCRIPTION
The CI is failing after all tests past due to some issue in the cleanup for setup-node, which apparently is discussed here:
 https://github.com/actions/setup-node/issues/317

Trying a suggested fix from that thread, disabling colors for setup-node.
