### PR TITLE
Add generic error handlers and specific user registration error template

### DIFF
--- a/pydatalab/pydatalab/errors.py
+++ b/pydatalab/pydatalab/errors.py
@@ -1,0 +1,62 @@
+from typing import Any, Callable, Iterable, Tuple
+
+from flask import Response, jsonify
+from werkzeug.exceptions import Forbidden, HTTPException
+
+
+class UserRegistrationForbidden(Forbidden):
+    """Raised when a user tries to register via OAuth without the appropriate
+    properties/credentials, e.g., public membership of a GitHub organization
+    that is on the allow list.
+    """
+
+    description: str = """<html><head></head>
+    <body>
+    <h1>403 Forbidden</h1>
+
+<h2>Unable to create account</h2>
+
+<p>No user data will be stored as a result of this interaction, but you may wish to clear your cookies for this site.</p>
+
+<p>
+The OAuth identity used for registration is not on the allow list.
+If you believe this to be an error, please first verify that your membership of the allowed
+group (e.g., a GitHub organization) is public, and verify with the deployment manager that
+the organization is indeed on the allow list.
+</p>
+
+<p>If this was not an error, you may wish to revoke any permissions given to the datalab OAuth application.</p>
+</body>
+</html>
+"""
+
+
+def handle_http_exception(exc: HTTPException) -> Tuple[Response, int]:
+    """Return a specific error message and status code if the exception stores them."""
+    response = {
+        "title": exc.__class__.__name__,
+        "message": exc.description,
+    }
+    status_code = exc.code if exc.code else 400
+    return jsonify(response), status_code
+
+
+def render_unauthorised_user_template(exc: UserRegistrationForbidden) -> Tuple[Response, int]:
+    """Return a rich HTML page on user account creation failure."""
+    return Response(response=exc.description), exc.code
+
+
+def handle_generic_exception(exc: Exception) -> Tuple[Response, int]:
+    """Return a specific error message and status code if the exception stores them."""
+    response = {
+        "title": exc.__class__.__name__,
+        "message": exc.args[0] if exc.args else "",
+    }
+    return jsonify(response), 500
+
+
+ERROR_HANDLERS: Iterable[Tuple[Any, Callable[[Any], Tuple[Response, int]]]] = [
+    (UserRegistrationForbidden, render_unauthorised_user_template),
+    (HTTPException, handle_http_exception),
+    (Exception, handle_generic_exception),
+]

--- a/pydatalab/pydatalab/main.py
+++ b/pydatalab/pydatalab/main.py
@@ -197,7 +197,8 @@ def create_app(config_override: Dict[str, Any] = None) -> Flask:
 
 
 def register_endpoints(app: Flask):
-    """Loops through the implemented endpoints and blueprints and adds them to the app."""
+    """Loops through the implemented endpoints, blueprints and error handlers adds them to the app."""
+    from pydatalab.errors import ERROR_HANDLERS
     from pydatalab.routes import ENDPOINTS
     from pydatalab.routes.auth import OAUTH_BLUEPRINTS
 
@@ -206,6 +207,9 @@ def register_endpoints(app: Flask):
 
     for bp in OAUTH_BLUEPRINTS:
         app.register_blueprint(OAUTH_BLUEPRINTS[bp], url_prefix="/login")
+
+    for exception_type, handler in ERROR_HANDLERS:
+        app.register_error_handler(exception_type, handler)
 
 
 if __name__ == "__main__":

--- a/pydatalab/pydatalab/routes/auth.py
+++ b/pydatalab/pydatalab/routes/auth.py
@@ -16,6 +16,7 @@ from flask_login import current_user, login_user
 from flask_login.utils import LocalProxy
 
 from pydatalab.config import CONFIG
+from pydatalab.errors import UserRegistrationForbidden
 from pydatalab.logger import LOGGER
 from pydatalab.login import LoginUser
 from pydatalab.models.people import Identity, IdentityType, Person
@@ -158,7 +159,7 @@ def find_create_or_modify_user(
         # If there is no current authenticated user, make one with the current OAuth identity
         else:
             if not create_account:
-                raise RuntimeError("Cannot make account: given identity was not on allow list.")
+                raise UserRegistrationForbidden
 
             user = Person.new_user_from_identity(identity, use_display_name=True)
             login_user(LoginUser(_id=user.immutable_id, data=user))


### PR DESCRIPTION
Adds generic error handling to app -- any Python exception to the server will now yield a specific error message.

Also add a specific HTML response when someone tries to make a user account without being on the allow list.

Closes #247.