### PR TITLE
Reset unsaved warning after `getSampleData()` receives data

### DIFF
--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -136,6 +136,7 @@ export default {
       next();
     } else {
       if (window.confirm("Unsaved changes present. Would you like to leave without saving?")) {
+        this.$store.commit("setItemSaved", { item_id: this.item_id, isSaved: true });
         next();
       } else {
         next(false);
@@ -276,13 +277,15 @@ export default {
       if (this.item_id == null) {
         getItemByRefcode(this.refcode).then(() => {
           this.itemDataLoaded = true;
+          this.$store.commit("setItemSaved", { item_id: this.item_id, isSaved: true });
           this.item_id = this.$store.state.refcode_to_id[this.refcode];
           this.updateBlocks();
         });
       } else {
         getItemData(this.item_id).then(() => {
-          this.itemDataLoaded = true;
+          this.itemDataLoaded = true;          
           this.refcode = this.item_data.refcode;
+          this.$store.commit("setItemSaved", { item_id: this.item_id, isSaved: true });
           this.updateBlocks();
         });
       }
@@ -290,6 +293,7 @@ export default {
 
     async updateBlocks() {
       if (this.itemDataLoaded) {
+
         // update each block asynchronously
         this.item_data.display_order.forEach((block_id) => {
           console.log(`calling update on block ${block_id}`);

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -277,15 +277,19 @@ export default {
       if (this.item_id == null) {
         getItemByRefcode(this.refcode).then(() => {
           this.itemDataLoaded = true;
-          this.$store.commit("setItemSaved", { item_id: this.item_id, isSaved: true });
+          this.$nextTick(() => {
+            this.$store.commit("setItemSaved", { item_id: this.item_id, isSaved: true });
+          });
           this.item_id = this.$store.state.refcode_to_id[this.refcode];
           this.updateBlocks();
         });
       } else {
         getItemData(this.item_id).then(() => {
-          this.itemDataLoaded = true;          
+          this.itemDataLoaded = true;
           this.refcode = this.item_data.refcode;
-          this.$store.commit("setItemSaved", { item_id: this.item_id, isSaved: true });
+          this.$nextTick(() => {
+            this.$store.commit("setItemSaved", { item_id: this.item_id, isSaved: true });
+          });
           this.updateBlocks();
         });
       }
@@ -293,7 +297,6 @@ export default {
 
     async updateBlocks() {
       if (this.itemDataLoaded) {
-
         // update each block asynchronously
         this.item_data.display_order.forEach((block_id) => {
           console.log(`calling update on block ${block_id}`);


### PR DESCRIPTION
Simple fix to prevent the annoying bug where the unsaved warning erroneously appears whenever a sample or cell page is loaded a second time without a refresh.

closes #601 