### PR TITLE
Add ability to add batch of cells

### DIFF
--- a/pydatalab/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/pydatalab/routes/v0_1/items.py
@@ -396,17 +396,16 @@ def _create_sample(
                 "negative_electrode",
                 "electrolyte",
             ):
-                if copied_doc.get(component):
-                    existing_consituent_ids = [
-                        constituent["item"].get("item_id", None)
-                        for constituent in copied_doc[component]
-                    ]
-                    copied_doc[component] += [
-                        constituent
-                        for constituent in sample_dict.get(component, [])
-                        if constituent["item"].get("item_id", None) is None
-                        or constituent["item"].get("item_id") not in existing_consituent_ids
-                    ]
+                existing_consituent_ids = [
+                    constituent["item"].get("item_id", None)
+                    for constituent in copied_doc[component]
+                ]
+                copied_doc[component] += [
+                    constituent
+                    for constituent in sample_dict.get(component, [])
+                    if constituent["item"].get("item_id", None) is None
+                    or constituent["item"].get("item_id") not in existing_consituent_ids
+                ]
 
             sample_dict = copied_doc
 

--- a/webapp/cypress/e2e/batchSampleFeature.cy.js
+++ b/webapp/cypress/e2e/batchSampleFeature.cy.js
@@ -58,6 +58,15 @@ let sample_ids = [
   "test103_unique",
   "test101_unique2",
   "test101_unique",
+  "cell_A",
+  "cell_B",
+  "cell_C",
+  "cell_D",
+  "comp1",
+  "comp2",
+  "cell_1",
+  "cell_2",
+  "cell_3",
 ];
 
 before(() => {
@@ -702,5 +711,141 @@ describe("Batch sample creation", () => {
     cy.verifySample("test102_unique", "", "2000-01-01T10:05");
     cy.verifySample("test103_unique");
     cy.verifySample("test101_unique2");
+  });
+});
+
+describe("Batch cell creation", () => {
+  beforeEach(() => {
+    cy.visit("/");
+  });
+
+  it("creates a simple batch of cells", () => {
+    cy.contains("Add batch of items").click();
+    cy.get("[data-testid=batch-modal-container]").findByLabelText("Type:").select("cell");
+    cy.findByLabelText("Number of rows:").clear().type(4);
+    cy.get("[data-testid=batch-add-table] > tbody > tr").should("have.length", 4);
+
+    getSubmitButton().should("be.disabled");
+    getBatchAddCell(1, 1, "input").type("cell_A");
+    // set positive electrode for the first cell
+    getBatchAddCell(1, 5, "input.vs__search").eq(0).type("abcdef");
+    cy.get(".vs__dropdown-menu").contains("abcdef").click();
+
+    getBatchAddCell(2, 1, "input").type("cell_B");
+    getBatchAddCell(2, 2, "input").type("this cell has a name");
+
+    getSubmitButton().should("be.disabled");
+    getBatchAddCell(3, 1, "input").type("cell_C");
+    getBatchAddCell(3, 3, "input").type("2017-06-01T08:30");
+    getBatchAddCell(4, 1, "input").type("cell_D");
+
+    getSubmitButton().click();
+
+    cy.verifySample("cell_A");
+    cy.verifySample("cell_B", "this cell has a name");
+    cy.verifySample("cell_C", null, "2017-06-01");
+    cy.verifySample("cell_D");
+  });
+
+  it("adds some component samples to be used for the next tests", () => {
+    cy.contains("Add batch of items").click();
+    cy.findByLabelText("Number of rows:").clear().type(2);
+
+    getBatchAddCell(1, 1).type("comp1");
+    getBatchAddCell(1, 2).type("comp1 name");
+    getBatchAddCell(2, 1).type("comp2");
+
+    getSubmitButton().click();
+    cy.get("[data-testid=batch-modal-container]").contains("a", "comp1");
+    cy.get("[data-testid=batch-modal-container]").contains("a", "comp2");
+  });
+
+  it("creates a batch of cells using the template id, name, date, copyFrom, and components", () => {
+    cy.contains("Add batch of items").click();
+
+    cy.get("[data-testid=batch-modal-container]").findByLabelText("Type:").select("cell");
+
+    getBatchTemplateCell(1, "input").eq(0).type("cell_{{}#{}}");
+    getBatchTemplateCell(2, "input").type("this is the test cell #{{}#{}}");
+    getBatchTemplateCell(3, "input").type("1980-02-01T23:59");
+
+    // select copyFrom sample, check that it is applied correctly
+    getBatchTemplateCell(4, ".vs__search").type("cell_B");
+    cy.get(".vs__dropdown-menu").contains(".badge", "cell_B").click();
+
+    getBatchAddCell(1, 4).contains("cell_B");
+    getBatchAddCell(2, 4).contains("cell_B");
+    getBatchAddCell(3, 4).contains("cell_B");
+
+    // change the copyFrom sample, check that it is applied correctly
+    getBatchTemplateCell(4, ".vs__search").type("cell_A");
+    cy.get(".vs__dropdown-menu").contains(".badge", "cell_A").click();
+
+    getBatchAddCell(1, 4).contains("cell_A");
+    getBatchAddCell(2, 4).contains("cell_A");
+    getBatchAddCell(3, 4).contains("cell_A");
+
+    // add a positive electrode, check that it is applied correctly
+    getBatchTemplateCell(5, ".vs__search").eq(0).type("comp1");
+    cy.get(".vs__dropdown-menu").contains(".badge", "comp1").click();
+
+    getBatchAddCell(1, 5).contains("comp1");
+    getBatchAddCell(2, 5).contains("comp1");
+    getBatchAddCell(3, 5).contains("comp1");
+
+    // add another component, this one tagged (i.e., not in the db) check that it is applied correctly
+    getBatchTemplateCell(5, ".vs__search").eq(0).type("tagged");
+    cy.get(".vs__dropdown-menu").eq(0).contains("tagged").click();
+
+    getBatchAddCell(1, 5).contains("comp1");
+    getBatchAddCell(1, 5).contains("tagged");
+    getBatchAddCell(2, 5).contains("comp1");
+    getBatchAddCell(2, 5).contains("tagged");
+    getBatchAddCell(3, 5).contains("comp1");
+    getBatchAddCell(3, 5).contains("tagged");
+
+    // add electrolyte
+    getBatchTemplateCell(5, ".vs__search").eq(1).type("elyte");
+    cy.get(".vs__dropdown-menu").eq(0).contains("elyte").click();
+    getBatchAddCell(1, 5).contains("elyte");
+    getBatchAddCell(2, 5).contains("elyte");
+    getBatchAddCell(3, 5).contains("elyte");
+
+    // add negative electrode
+    getBatchTemplateCell(5, ".vs__search").eq(2).type("comp2");
+    cy.get(".vs__dropdown-menu").eq(0).contains(".badge", "comp2").click();
+    getBatchAddCell(1, 5).contains("comp2");
+    getBatchAddCell(2, 5).contains("comp2");
+    getBatchAddCell(3, 5).contains("comp2");
+
+    getSubmitButton().click();
+    cy.get("[data-testid=batch-modal-container]").contains("a", "cell_1");
+    cy.get("[data-testid=batch-modal-container]").contains("a", "cell_2");
+    cy.get("[data-testid=batch-modal-container]").contains("a", "cell_3");
+
+    cy.findAllByText("Successfully created.").should("have.length", 3);
+
+    cy.get("[data-testid=batch-modal-container]").contains("Close").click();
+
+    cy.verifySample("cell_1", "this is the test cell #1", "1980-02-01T23:59");
+    cy.verifySample("cell_2", "this is the test cell #2", "1980-02-01T23:59");
+    cy.verifySample("cell_3", "this is the test cell #3", "1980-02-01T23:59");
+
+    function checkCreatedCell(item_id) {
+      cy.contains(item_id).click();
+      cy.get("#pos-electrode-table").contains("comp1");
+      cy.get("#pos-electrode-table").contains("tagged");
+      cy.get("#pos-electrode-table").contains("comp1 name");
+
+      cy.get("#electrolyte-table").contains("elyte");
+
+      cy.get("#neg-electrode-table").contains("comp2");
+
+      cy.findByText("Home").click();
+    }
+
+    checkCreatedCell("cell_1");
+    checkCreatedCell("cell_2");
+    checkCreatedCell("cell_3");
   });
 });

--- a/webapp/cypress/e2e/batchSampleFeature.cy.js
+++ b/webapp/cypress/e2e/batchSampleFeature.cy.js
@@ -75,7 +75,7 @@ describe("Batch sample creation", () => {
     cy.visit("/");
   });
   it("Adds 3 valid samples", () => {
-    cy.contains("Add batch of samples").click();
+    cy.contains("Add batch of items").click();
     getSubmitButton().should("be.disabled");
     getBatchAddCell(1, 1).type("testA");
     getBatchAddCell(2, 1).type("testB");
@@ -100,7 +100,7 @@ describe("Batch sample creation", () => {
   });
 
   it("adds two valid samples", () => {
-    cy.contains("Add batch of samples").click();
+    cy.contains("Add batch of items").click();
     cy.findByLabelText("Number of rows:").clear().type(2);
 
     cy.get('[data-testid="batch-modal-container"]').findByText("Submit").should("be.disabled");
@@ -119,7 +119,7 @@ describe("Batch sample creation", () => {
   });
 
   it("adds four base samples", () => {
-    cy.contains("Add batch of samples").click();
+    cy.contains("Add batch of items").click();
     cy.findByLabelText("Number of rows:").clear().type(4);
 
     cy.get('[data-testid="batch-modal-container"]').findByText("Submit").should("be.disabled");
@@ -180,7 +180,7 @@ describe("Batch sample creation", () => {
   });
 
   it("makes samples copied from others", () => {
-    cy.contains("Add batch of samples").click();
+    cy.contains("Add batch of items").click();
     getBatchAddCell(1, 1).type("baseA_copy");
     getBatchAddCell(1, 2).type("a copied sample");
     getBatchAddCell(1, 4, ".vs__search").type("BaseA");
@@ -244,7 +244,7 @@ describe("Batch sample creation", () => {
   });
 
   it("creates samples using components", () => {
-    cy.contains("Add batch of samples").click();
+    cy.contains("Add batch of items").click();
     cy.findByLabelText("Number of rows:").clear().type(4);
 
     // sample with two components
@@ -407,7 +407,7 @@ describe("Batch sample creation", () => {
   });
 
   it("uses the template id", () => {
-    cy.contains("Add batch of samples").click();
+    cy.contains("Add batch of items").click();
     getBatchTemplateCell(1).type("test_{{}#{}}");
 
     // manually type names and a date
@@ -434,7 +434,7 @@ describe("Batch sample creation", () => {
   });
 
   it("uses the template id, name, and date", () => {
-    cy.contains("Add batch of samples").click();
+    cy.contains("Add batch of items").click();
     getBatchTemplateCell(1).type("test_{{}#{}}");
     getBatchTemplateCell(2).type("this is the test sample #{{}#{}}");
     getBatchTemplateCell(3).type("1980-02-01T05:35");
@@ -459,7 +459,7 @@ describe("Batch sample creation", () => {
   });
 
   it("uses the template id, name, date, copyFrom, and components", () => {
-    cy.contains("Add batch of samples").click();
+    cy.contains("Add batch of items").click();
     getBatchTemplateCell(1).type("test_{{}#{}}");
     getBatchTemplateCell(2).type("this is the test sample #{{}#{}}");
     getBatchTemplateCell(3).type("1980-02-01T23:59");
@@ -539,7 +539,7 @@ describe("Batch sample creation", () => {
   });
 
   it("plays with the number of rows", () => {
-    cy.contains("Add batch of samples").click();
+    cy.contains("Add batch of items").click();
     cy.findByLabelText("Number of rows:").clear().type(3);
     cy.get("[data-testid=batch-add-table] > tbody > tr").should("have.length", 3);
 
@@ -648,7 +648,7 @@ describe("Batch sample creation", () => {
   });
 
   it("checks errors on the row", () => {
-    cy.contains("Add batch of samples").click();
+    cy.contains("Add batch of items").click();
     getBatchTemplateCell("1").type("test10{{}#{}}");
     cy.wait(100);
     getSubmitButton().should("be.disabled");

--- a/webapp/src/components/BatchCreateItemModal.vue
+++ b/webapp/src/components/BatchCreateItemModal.vue
@@ -3,16 +3,16 @@
     <Modal
       :model-value="modelValue"
       :disable-submit="
-        sampleIDValidationMessages.some((e) => e) ||
-        (!generateIDsAutomatically && samples.some((s) => !Boolean(s.item_id)))
+        itemIDValidationMessages.some((e) => e) ||
+        (!generateIDsAutomatically && items.some((s) => !Boolean(s.item_id)))
       "
       @update:model-value="$emit('update:modelValue', $event)"
     >
       <template #header>
-        <template v-if="beforeSubmit">Add new samples</template>
+        <template v-if="beforeSubmit">Add new items</template>
         <template v-else>
           <a id="back-arrow" role="button" @click="beforeSubmit = true">←</a>
-          Samples added
+          Items added
         </template>
       </template>
       <template #body>
@@ -20,7 +20,37 @@
           <transition name="slide-content-left">
             <div v-show="beforeSubmit" id="left-screen">
               <div class="row">
-                <div class="col-md-8 mt-2" @click="templateIsOpen = !templateIsOpen">
+                <div class="input-group col-lg-3 col-6">
+                  <label for="batch-item-type-select" class="blue-label col-form-label mr-3">
+                    Type:
+                  </label>
+                  <select
+                    id="batch-item-type-select"
+                    v-model="item_type"
+                    class="form-control"
+                    required
+                  >
+                    <option v-for="type in allowedTypes" :key="type" :value="type">
+                      {{ itemTypes[type].display }}
+                    </option>
+                  </select>
+                </div>
+                <div class="input-group col-lg-3 col-6">
+                  <label for="batchItemNRows" class="blue-label col-form-label text-left mb-2 mr-3">
+                    Number of rows:
+                  </label>
+                  <input
+                    id="batchItemNRows"
+                    v-model="nSamples"
+                    class="form-control"
+                    type="number"
+                    min="0"
+                    max="100"
+                  />
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-md-6 mt-2" @click="templateIsOpen = !templateIsOpen">
                   <font-awesome-icon
                     :icon="['fas', 'chevron-right']"
                     fixed-width
@@ -29,20 +59,6 @@
                   />
                   <label class="blue-label clickable pl-2"> Template: </label>
                 </div>
-                <label
-                  for="batchSampleNRows"
-                  class="blue-label col-md-2 col-3 col-form-label text-left mb-2"
-                >
-                  Number of rows:
-                </label>
-                <input
-                  id="batchSampleNRows"
-                  v-model="nSamples"
-                  class="form-control col-md-1 col-2"
-                  type="number"
-                  min="0"
-                  max="100"
-                />
               </div>
 
               <div
@@ -63,7 +79,7 @@
                   <tbody>
                     <td>
                       <input
-                        v-model="sampleTemplate.item_id"
+                        v-model="itemTemplate.item_id"
                         class="form-control"
                         :placeholder="generateIDsAutomatically ? null : 'ex_{#}'"
                         :disabled="generateIDsAutomatically"
@@ -88,7 +104,7 @@
                     </td>
                     <td>
                       <input
-                        v-model="sampleTemplate.name"
+                        v-model="itemTemplate.name"
                         class="form-control"
                         placeholder="Example name {#}"
                         @input="applyNameTemplate"
@@ -96,7 +112,7 @@
                     </td>
                     <td>
                       <input
-                        v-model="sampleTemplate.date"
+                        v-model="itemTemplate.date"
                         class="form-control"
                         type="datetime-local"
                         :min="epochStart"
@@ -106,18 +122,49 @@
                     </td>
                     <td>
                       <ItemSelect
-                        v-model="sampleTemplate.copyFrom"
+                        v-model="itemTemplate.copyFrom"
                         :formatted-item-name-max-length="8"
                         @update:model-value="applyCopyFromTemplate"
                       />
                     </td>
                     <td>
-                      <ItemSelect
-                        v-model="sampleTemplate.components"
-                        multiple
-                        :formatted-item-name-max-length="8"
-                        @update:model-value="applyComponentsTemplate"
-                      />
+                      <div v-if="item_type == 'samples'">
+                        <ItemSelect
+                          v-model="itemTemplate.components"
+                          multiple
+                          :formatted-item-name-max-length="8"
+                          taggable
+                          @update:model-value="applyComponentsTemplate"
+                        />
+                      </div>
+                      <div v-if="item_type == 'cells'">
+                        <ItemSelect
+                          v-model="itemTemplate.positiveElectrode"
+                          multiple
+                          :formatted-item-name-max-length="8"
+                          taggable
+                          placeholder="positive electrode"
+                          @update:model-value="applyPositiveElectrodeTemplate"
+                        />
+                        <ItemSelect
+                          v-model="itemTemplate.electrolyte"
+                          multiple
+                          :formatted-item-name-max-length="8"
+                          class="pt-1"
+                          taggable
+                          placeholder="electrolyte"
+                          @update:model-value="applyElectrolyteTemplate"
+                        />
+                        <ItemSelect
+                          v-model="itemTemplate.negativeElectrode"
+                          multiple
+                          :formatted-item-name-max-length="8"
+                          class="pt-1"
+                          taggable
+                          placeholder="negative electrode"
+                          @update:model-value="applyNegativeElectrodeTemplate"
+                        />
+                      </div>
                     </td>
                   </tbody>
                 </table>
@@ -153,26 +200,26 @@
                   </tr>
                 </thead>
                 <tbody>
-                  <template v-for="(sample, index) in samples" :key="index">
+                  <template v-for="(item, index) in items" :key="index">
                     <tr>
                       <td>
                         <input
-                          v-model="sample.item_id"
+                          v-model="item.item_id"
                           class="form-control"
                           :disabled="generateIDsAutomatically"
-                          @input="sampleTemplate.item_id = ''"
+                          @input="itemTemplate.item_id = ''"
                         />
                       </td>
                       <td>
                         <input
-                          v-model="sample.name"
+                          v-model="item.name"
                           class="form-control"
-                          @input="sampleTemplate.name = ''"
+                          @input="itemTemplate.name = ''"
                         />
                       </td>
                       <td>
                         <input
-                          v-model="sample.date"
+                          v-model="item.date"
                           class="form-control"
                           type="datetime-local"
                           :min="epochStart"
@@ -180,14 +227,42 @@
                         />
                       </td>
                       <td>
-                        <ItemSelect v-model="sample.copyFrom" :formatted-item-name-max-length="8" />
+                        <ItemSelect v-model="item.copyFrom" :formatted-item-name-max-length="8" />
                       </td>
                       <td>
-                        <ItemSelect
-                          v-model="sample.components"
-                          multiple
-                          :formatted-item-name-max-length="8"
-                        />
+                        <div v-if="item_type == 'samples'">
+                          <ItemSelect
+                            v-model="item.components"
+                            multiple
+                            :formatted-item-name-max-length="8"
+                            taggable
+                          />
+                        </div>
+                        <div v-if="item_type == 'cells'">
+                          <ItemSelect
+                            v-model="item.positiveElectrode"
+                            multiple
+                            :formatted-item-name-max-length="8"
+                            taggable
+                            placeholder="positive electrode"
+                          />
+                          <ItemSelect
+                            v-model="item.electrolyte"
+                            multiple
+                            :formatted-item-name-max-length="8"
+                            class="pt-1"
+                            taggable
+                            placeholder="electrolyte"
+                          />
+                          <ItemSelect
+                            v-model="item.negativeElectrode"
+                            multiple
+                            :formatted-item-name-max-length="8"
+                            class="pt-1"
+                            taggable
+                            placeholder="negative electrode"
+                          />
+                        </div>
                       </td>
                       <td>
                         <button
@@ -202,7 +277,7 @@
                     </tr>
                     <td colspan="3">
                       <!-- eslint-disable-next-line vue/no-v-html -->
-                      <span class="form-error" v-html="sampleIDValidationMessages[index]" />
+                      <span class="form-error" v-html="itemIDValidationMessages[index]" />
                     </td>
                   </template>
                 </tbody>
@@ -257,14 +332,19 @@
 import Modal from "@/components/Modal.vue";
 import ItemSelect from "@/components/ItemSelect.vue";
 import { createNewSamples } from "@/server_fetch_utils.js";
+import { itemTypes, SAMPLE_TABLE_TYPES } from "@/resources.js";
 export default {
-  name: "BatchCreateSampleModal",
+  name: "BatchCreateItemModal",
   components: {
     Modal,
     ItemSelect,
   },
   props: {
     modelValue: Boolean,
+    allowedTypes: {
+      type: Array,
+      default: () => SAMPLE_TABLE_TYPES,
+    },
   },
   emits: ["update:modelValue"],
   data() {
@@ -274,12 +354,16 @@ export default {
       oneYearOn: this.determineOneYearOn(),
       nSamples: 3,
       generateIDsAutomatically: false,
-      samples: [
+      item_type: "samples",
+      items: [
         {
           item_id: null,
           name: "",
           copyFrom: null,
           components: [],
+          positiveElectrode: [],
+          electrolyte: [],
+          negativeElectrode: [],
           date: this.now(),
         },
         {
@@ -287,6 +371,9 @@ export default {
           name: "",
           copyFrom: null,
           components: [],
+          positiveElectrode: [],
+          electrolyte: [],
+          negativeElectrode: [],
           date: this.now(),
         },
         {
@@ -294,18 +381,24 @@ export default {
           name: "",
           copyFrom: null,
           components: [],
+          positiveElectrode: [],
+          electrolyte: [],
+          negativeElectrode: [],
           date: this.now(),
         },
       ],
-      takenItemIds: [], // this holds ids that have been tried, whereas the computed takenSampleIds holds ids in the sample table
+      takenItemIds: [], // this holds ids that have been tried, whereas the computed takenSampleIds holds ids in the item table
 
       templateIsOpen: true,
       templateStartNumber: 1,
-      sampleTemplate: {
+      itemTemplate: {
         item_id: null,
         name: "",
         copyFrom: null,
         components: null,
+        positiveElectrode: null,
+        electrolyte: null,
+        negativeElectrode: null,
         date: this.now(),
       },
 
@@ -313,46 +406,49 @@ export default {
     };
   },
   computed: {
+    itemTypes() {
+      return itemTypes;
+    },
     takenSampleIds() {
       return this.$store.state.sample_list
         ? this.$store.state.sample_list.map((x) => x.item_id)
         : [];
     },
     someValidationMessagePresent() {
-      return this.sampleIDValidationMessages.some();
+      return this.itemIDValidationMessages.some();
     },
-    sampleIDValidationMessages() {
-      return this.samples.map((sample, index, samples) => {
-        if (sample.item_id == null) {
+    itemIDValidationMessages() {
+      return this.items.map((item, index, items) => {
+        if (item.item_id == null) {
           return "";
         } // Don't throw an error before the user starts typing
 
-        // check that sample id isn't repeated in this table
+        // check that item id isn't repeated in this table
         if (
-          samples
+          items
             .slice(0, index)
             .map((el) => el.item_id)
-            .includes(sample.item_id)
+            .includes(item.item_id)
         ) {
           return "ID is repeated from an above row.";
         }
 
         if (
-          this.takenItemIds.includes(sample.item_id) ||
-          this.takenSampleIds.includes(sample.item_id)
+          this.takenItemIds.includes(item.item_id) ||
+          this.takenSampleIds.includes(item.item_id)
         ) {
-          return `<a href='edit/${sample.item_id}'>${sample.item_id}</a> already in use.`;
+          return `<a href='edit/${item.item_id}'>${item.item_id}</a> already in use.`;
         }
-        if (!/^[a-zA-Z0-9._-]+$/.test(sample.item_id)) {
+        if (!/^[a-zA-Z0-9._-]+$/.test(item.item_id)) {
           return "ID can only contain alphanumeric characters, dashes ('-') and underscores ('_') and periods ('.')";
         }
-        if (/^[._-]/.test(sample.item_id) | /[._-]$/.test(sample.item_id)) {
+        if (/^[._-]/.test(item.item_id) | /[._-]$/.test(item.item_id)) {
           return "ID cannot start or end with puncutation";
         }
-        if (/\s/.test(sample.item_id)) {
+        if (/\s/.test(item.item_id)) {
           return "ID cannot have any spaces";
         }
-        if (sample.item_id.length < 1 || sample.item_id.length > 40) {
+        if (item.item_id.length < 1 || item.item_id.length > 40) {
           return "ID must be between 1 and 40 characters in length";
         }
         return "";
@@ -363,16 +459,16 @@ export default {
   watch: {
     nSamples(newValue, oldValue) {
       if (newValue < oldValue) {
-        this.samples = this.samples.slice(0, newValue);
+        this.items = this.items.slice(0, newValue);
       }
       if (newValue > oldValue) {
         for (let i = 0; i < newValue - oldValue; i++) {
-          this.samples.push({ ...this.sampleTemplate });
+          this.items.push({ ...this.itemTemplate });
         }
-        if (this.sampleTemplate.item_id) {
+        if (this.itemTemplate.item_id) {
           this.applyIdTemplate();
         }
-        if (this.sampleTemplate.name) {
+        if (this.itemTemplate.name) {
           this.applyNameTemplate();
         }
       }
@@ -389,69 +485,106 @@ export default {
       return d.toISOString().slice(0, -8);
     },
     applyIdTemplate() {
-      this.samples.forEach((sample, i) => {
-        sample.item_id = this.sampleTemplate.item_id.replace("{#}", i + this.templateStartNumber);
+      this.items.forEach((item, i) => {
+        item.item_id = this.itemTemplate.item_id.replace("{#}", i + this.templateStartNumber);
       });
     },
     applyNameTemplate() {
-      this.samples.forEach((sample, i) => {
-        sample.name = this.sampleTemplate.name.replace("{#}", i + this.templateStartNumber);
+      this.items.forEach((item, i) => {
+        item.name = this.itemTemplate.name.replace("{#}", i + this.templateStartNumber);
       });
     },
     applyIdAndNameTemplates() {
-      this.sampleTemplate.name && this.applyNameTemplate();
-      this.sampleTemplate.item_id && this.applyIdTemplate();
+      this.itemTemplate.name && this.applyNameTemplate();
+      this.itemTemplate.item_id && this.applyIdTemplate();
     },
     applyDateTemplate() {
-      this.samples.forEach((sample) => {
-        sample.date = this.sampleTemplate.date;
+      this.items.forEach((item) => {
+        item.date = this.itemTemplate.date;
       });
     },
     applyCopyFromTemplate() {
-      this.samples.forEach((sample) => {
-        sample.copyFrom = this.sampleTemplate.copyFrom;
+      this.items.forEach((item) => {
+        item.copyFrom = this.itemTemplate.copyFrom;
       });
     },
     applyComponentsTemplate() {
-      this.samples.forEach((sample) => {
-        sample.components = this.sampleTemplate.components;
+      this.items.forEach((item) => {
+        item.components = this.itemTemplate.components;
+      });
+    },
+    applyPositiveElectrodeTemplate() {
+      this.items.forEach((item) => {
+        item.positiveElectrode = this.itemTemplate.positiveElectrode;
+      });
+    },
+    applyElectrolyteTemplate() {
+      this.items.forEach((item) => {
+        item.electrolyte = this.itemTemplate.electrolyte;
+      });
+    },
+    applyNegativeElectrodeTemplate() {
+      this.items.forEach((item) => {
+        item.negativeElectrode = this.itemTemplate.negativeElectrode;
       });
     },
     removeRow(index) {
-      this.samples.splice(index, 1);
+      this.items.splice(index, 1);
       this.nSamples = this.nSamples - 1;
       // unless the removed row is the last one, reset the template and name id
-      if (index != this.samples.length) {
-        this.sampleTemplate.item_id = "";
-        this.sampleTemplate.name = "";
+      if (index != this.items.length) {
+        this.itemTemplate.item_id = "";
+        this.itemTemplate.name = "";
       }
     },
     setIDsNull() {
-      this.sampleTemplate["item_id"] = null;
-      this.samples.forEach((entry) => {
+      this.itemTemplate["item_id"] = null;
+      this.items.forEach((entry) => {
         entry["item_id"] = null;
       });
     },
     async submitForm() {
-      console.log("batch sample create form submit triggered");
+      console.log("batch item create form submit triggered");
 
-      const newSampleDatas = this.samples.map((sample) => {
-        return {
-          item_id: sample.item_id,
-          date: sample.date,
-          name: sample.name,
-          type: "samples",
-          synthesis_constituents: sample.components
-            ? sample.components.map((x) => ({ item: x, quantity: null }))
-            : [],
-        };
-      });
+      let newSampleDatas;
 
-      const copyFromItemIds = this.samples.map((sample) => sample.copyFrom?.item_id);
+      if (this.item_type == "samples") {
+        newSampleDatas = this.items.map((item) => {
+          return {
+            item_id: item.item_id,
+            date: item.date,
+            name: item.name,
+            type: "samples",
+            synthesis_constituents: item.components
+              ? item.components.map((x) => ({ item: x, quantity: null }))
+              : [],
+          };
+        });
+      } else {
+        newSampleDatas = this.items.map((item) => {
+          return {
+            item_id: item.item_id,
+            date: item.date,
+            name: item.name,
+            type: "cells",
+            positive_electrode: item.positiveElectrode
+              ? item.positiveElectrode.map((x) => ({ item: x, quantity: null }))
+              : [],
+            electrolyte: item.electrolyte
+              ? item.electrolyte.map((x) => ({ item: x, quantity: null }))
+              : [],
+            negative_electrode: item.negativeElectrode
+              ? item.negativeElectrode.map((x) => ({ item: x, quantity: null }))
+              : [],
+          };
+        });
+      }
+
+      const copyFromItemIds = this.items.map((item) => item.copyFrom?.item_id);
 
       await createNewSamples(newSampleDatas, copyFromItemIds, this.generateIDsAutomatically)
         .then((responses) => {
-          console.log("samples added");
+          console.log("items added");
           this.serverResponses = responses;
 
           document
@@ -460,7 +593,7 @@ export default {
           this.beforeSubmit = false;
         })
         .catch((error) => {
-          console.log("Error with creating new samples: " + error);
+          console.log("Error with creating new items: " + error);
         });
     },
     openEditPagesInNewTabs() {

--- a/webapp/src/components/BatchCreateItemModal.vue
+++ b/webapp/src/components/BatchCreateItemModal.vue
@@ -192,7 +192,7 @@
                 <thead>
                   <tr class="subheading">
                     <th style="width: calc(12%)">ID</th>
-                    <th>Name</th>
+                    <th style="width: calc(25%)">Name</th>
                     <th style="width: calc(15%)">Date</th>
                     <th style="width: calc(22%)">Copy from</th>
                     <th style="width: calc(22%) - 2rem">Components</th>

--- a/webapp/src/components/FormattedItemName.vue
+++ b/webapp/src/components/FormattedItemName.vue
@@ -36,11 +36,11 @@ export default {
     },
     name: {
       type: String,
-      default: null,
+      default: "",
     },
     chemform: {
       type: String,
-      default: null,
+      default: "",
     },
     enableClick: {
       type: Boolean,

--- a/webapp/src/components/ItemSelect.vue
+++ b/webapp/src/components/ItemSelect.vue
@@ -8,7 +8,7 @@
     :filterable="false"
     :create-option="createOption"
     :filter-by="() => true"
-    placeholder="type to search..."
+    :placeholder="placeholder"
     @search="debouncedAsyncSearch"
   >
     <template #no-options="{ searching }">
@@ -62,6 +62,10 @@ export default {
     typesToQuery: {
       type: Array,
       default: () => ["samples", "starting_materials", "cells"],
+    },
+    placeholder: {
+      type: String,
+      default: "type to search...",
     },
   },
   emits: ["update:modelValue"],

--- a/webapp/src/components/ItemSelect.vue
+++ b/webapp/src/components/ItemSelect.vue
@@ -52,7 +52,7 @@ export default {
   },
   props: {
     modelValue: {
-      type: String,
+      type: [String, Array],
       default: "",
     },
     formattedItemNameMaxLength: {

--- a/webapp/src/components/SampleTablePrime.vue
+++ b/webapp/src/components/SampleTablePrime.vue
@@ -36,7 +36,7 @@
             <button class="btn btn-default" @click="createItemModalIsOpen = true">
               Add an item
             </button>
-            <button class="btn btn-default ml-2" @click="batchCreateSampleModalIsOpen = true">
+            <button class="btn btn-default ml-2" @click="batchCreateItemModalIsOpen = true">
               Add batch of samples
             </button>
           </div>
@@ -110,12 +110,12 @@
     </DataTable>
   </div>
   <CreateItemModal v-model="createItemModalIsOpen" />
-  <BatchCreateSampleModal v-model="batchCreateSampleModalIsOpen" />
+  <BatchCreateItemModal v-model="batchCreateItemModalIsOpen" />
 </template>
 
 <script>
 import CreateItemModal from "@/components/CreateItemModal";
-import BatchCreateSampleModal from "@/components/BatchCreateSampleModal";
+import BatchCreateItemModal from "@/components/BatchCreateItemModal";
 
 import DataTable from "primevue/datatable";
 import Column from "primevue/column";
@@ -134,7 +134,7 @@ import Creators from "@/components/Creators";
 export default {
   components: {
     CreateItemModal,
-    BatchCreateSampleModal,
+    BatchCreateItemModal,
     DataTable,
     Column,
     IconField,
@@ -148,7 +148,7 @@ export default {
   data() {
     return {
       createItemModalIsOpen: false,
-      batchCreateSampleModalIsOpen: false,
+      batchCreateItemModalIsOpen: false,
       isSampleFetchError: false,
       itemsSelected: [],
       expandedRows: [],

--- a/webapp/src/views/Samples.vue
+++ b/webapp/src/views/Samples.vue
@@ -5,8 +5,8 @@
     <div class="row">
       <div class="col-sm-12 mx-auto mb-3">
         <button class="btn btn-default" @click="createItemModalIsOpen = true">Add an item</button>
-        <button class="btn btn-default ml-2" @click="batchCreateSampleModalIsOpen = true">
-          Add batch of samples
+        <button class="btn btn-default ml-2" @click="batchCreateItemModalIsOpen = true">
+          Add batch of items
         </button>
       </div>
     </div>
@@ -17,14 +17,14 @@
     </div>
   </div>
   <CreateItemModal v-model="createItemModalIsOpen" :allowed-types="allowedTypes" />
-  <BatchCreateSampleModal v-model="batchCreateSampleModalIsOpen" />
+  <BatchCreateItemModal v-model="batchCreateItemModalIsOpen" />
 </template>
 
 <script>
 import Navbar from "@/components/Navbar";
 import SampleTable from "@/components/SampleTable";
 import CreateItemModal from "@/components/CreateItemModal";
-import BatchCreateSampleModal from "@/components/BatchCreateSampleModal";
+import BatchCreateItemModal from "@/components/BatchCreateItemModal";
 import { SAMPLE_TABLE_TYPES } from "@/resources.js";
 
 export default {
@@ -33,12 +33,12 @@ export default {
     Navbar,
     SampleTable,
     CreateItemModal,
-    BatchCreateSampleModal,
+    BatchCreateItemModal,
   },
   data() {
     return {
       createItemModalIsOpen: false,
-      batchCreateSampleModalIsOpen: false,
+      batchCreateItemModalIsOpen: false,
       allowedTypes: SAMPLE_TABLE_TYPES,
     };
   },

--- a/webapp/src/views/SamplesNext.vue
+++ b/webapp/src/views/SamplesNext.vue
@@ -5,7 +5,7 @@
     <div class="row">
       <div class="col-sm-12 mx-auto mb-3">
         <button class="btn btn-default" @click="createItemModalIsOpen = true">Add an item</button>
-        <button class="btn btn-default ml-2" @click="batchCreateSampleModalIsOpen = true">
+        <button class="btn btn-default ml-2" @click="BatchCreateItemModalIsOpen = true">
           Add batch of samples
         </button>
       </div>
@@ -17,14 +17,14 @@
     </div>
   </div>
   <CreateItemModal v-model="createItemModalIsOpen" />
-  <BatchCreateSampleModal v-model="batchCreateSampleModalIsOpen" />
+  <BatchCreateItemModal v-model="BatchCreateItemModalIsOpen" />
 </template>
 
 <script>
 import Navbar from "@/components/Navbar";
 import FancySampleTable from "@/components/FancySampleTable";
 import CreateItemModal from "@/components/CreateItemModal";
-import BatchCreateSampleModal from "@/components/BatchCreateSampleModal";
+import BatchCreateItemModal from "@/components/BatchCreateItemModal";
 
 export default {
   name: "Samples",
@@ -32,12 +32,12 @@ export default {
     Navbar,
     FancySampleTable,
     CreateItemModal,
-    BatchCreateSampleModal,
+    BatchCreateItemModal,
   },
   data() {
     return {
       createItemModalIsOpen: false,
-      batchCreateSampleModalIsOpen: false,
+      BatchCreateItemModalIsOpen: false,
     };
   },
 };


### PR DESCRIPTION
Currently, the "batch add" feature only allows for adding samples. This PR adds the ability to also add cells, with a template option for positive electrode, electroylte, and negative electrode.


- [x] Functionality for adding a batch of cell and choosing electrodes
- [x] Figure out how to cleanly label positive electrode, electrolyte, and negative electrode fields
- [x] Rename "Add a batch of samples" -> "Add a batch of items"
- [x] Rename sample -> item in BatchCreateSampleModal.vue
- [x] Turn on `taggable` in the `ItemSelect` components in the batch sample modal 
- [x] update e2e tests
- [x] add test(s)






Closes #396