### PR TITLE
Add routes for resolving items by refcode

### DIFF
--- a/pydatalab/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/pydatalab/routes/v0_1/items.py
@@ -630,14 +630,13 @@ def delete_sample():
     )
 
 
-@ITEMS.route("/items/by-refcode/<refcode>", methods=["GET"])
-@ITEMS.route("/items/by-id/<item_id>", methods=["GET"])
+@ITEMS.route("/items/<refcode>", methods=["GET"])
 @ITEMS.route("/get-item-data/<item_id>", methods=["GET"])
 def get_item_data(
     item_id: str | None = None, refcode: str | None = None, load_blocks: bool = False
 ):
     """Generates a JSON response for the item with the given `item_id`,
-    additionally resolving relationships to files and other items.
+    or `refcode` additionally resolving relationships to files and other items.
 
     Parameters:
        load_blocks: Whether to regenerate any data blocks associated with this

--- a/pydatalab/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/pydatalab/routes/v0_1/items.py
@@ -16,7 +16,7 @@ from pydatalab.models.items import Item
 from pydatalab.models.relationships import RelationshipType
 from pydatalab.models.utils import generate_unique_refcode
 from pydatalab.mongo import flask_mongo
-from pydatalab.permissions import active_users_or_get_only, get_default_permissions
+from pydatalab.permissions import PUBLIC_USER_ID, active_users_or_get_only, get_default_permissions
 
 ITEMS = Blueprint("items", __name__)
 
@@ -423,10 +423,10 @@ def _create_sample(
         )
 
     sample_dict.pop("refcode", None)
-    type = sample_dict["type"]
-    if type not in ITEM_MODELS:
+    type_ = sample_dict["type"]
+    if type_ not in ITEM_MODELS:
         raise RuntimeError("Invalid type")
-    model = ITEM_MODELS[type]
+    model = ITEM_MODELS[type_]
 
     ## the following code was used previously to explicitely check schema properties.
     ## it doesn't seem to be necessary now, with extra = "ignore" turned on in the pydantic models,
@@ -436,7 +436,7 @@ def _create_sample(
     # new_sample = {k: sample_dict[k] for k in schema["properties"] if k in sample_dict}
     new_sample = sample_dict
 
-    if type in ("starting_materials", "equipment"):
+    if type_ in ("starting_materials", "equipment"):
         # starting_materials and equipment are open to all in the deploment at this point,
         # so no creators are assigned
         new_sample["creator_ids"] = []
@@ -444,7 +444,7 @@ def _create_sample(
     elif CONFIG.TESTING:
         # Set fake ID to ObjectId("000000000000000000000000") so a dummy user can be created
         # locally for testing creator UI elements
-        new_sample["creator_ids"] = [24 * "0"]
+        new_sample["creator_ids"] = [PUBLIC_USER_ID]
         new_sample["creators"] = [
             {
                 "display_name": "Public testing user",

--- a/pydatalab/tests/server/test_items.py
+++ b/pydatalab/tests/server/test_items.py
@@ -1,0 +1,18 @@
+def test_single_item_endpoints(client, inserted_default_items):
+    for item in inserted_default_items:
+        response = client.get(f"/items/by-refcode/{item.refcode}")
+        assert response.status_code == 200, response.json
+        assert response.json["status"] == "success"
+
+        test_ref = item.refcode.split(":")[1]
+        response = client.get(f"/items/by-refcode/{test_ref}")
+        assert response.status_code == 200, response.json
+        assert response.json["status"] == "success"
+
+        response = client.get(f"/items/by-id/{item.item_id}")
+        assert response.status_code == 200, response.json
+        assert response.json["status"] == "success"
+
+        response = client.get(f"/get-item-data/{item.item_id}")
+        assert response.status_code == 200, response.json
+        assert response.json["status"] == "success"

--- a/pydatalab/tests/server/test_items.py
+++ b/pydatalab/tests/server/test_items.py
@@ -1,15 +1,11 @@
 def test_single_item_endpoints(client, inserted_default_items):
     for item in inserted_default_items:
-        response = client.get(f"/items/by-refcode/{item.refcode}")
+        response = client.get(f"/items/{item.refcode}")
         assert response.status_code == 200, response.json
         assert response.json["status"] == "success"
 
         test_ref = item.refcode.split(":")[1]
-        response = client.get(f"/items/by-refcode/{test_ref}")
-        assert response.status_code == 200, response.json
-        assert response.json["status"] == "success"
-
-        response = client.get(f"/items/by-id/{item.item_id}")
+        response = client.get(f"/items/{test_ref}")
         assert response.status_code == 200, response.json
         assert response.json["status"] == "success"
 

--- a/pydatalab/tests/server/test_users.py
+++ b/pydatalab/tests/server/test_users.py
@@ -19,7 +19,7 @@ def test_get_current_user_admin(admin_client):
     """Test that the API key for the demo admin has been set correctly."""
     resp = admin_client.get("/get-current-user/")
     assert (resp_json := resp.json)
-    assert resp_json["immutable_id"] == 24 * "0"
+    assert resp_json["immutable_id"] == 24 * "8"
     assert resp_json["role"] == "admin"
 
 


### PR DESCRIPTION
First steps on #803 

~This PR adds `/items/by-refcode/<refcode>` and `/items/by-id/<id>` endpoints that essentially replace `/get_item_data/<item_id>`. I'm not entirely happy with the routes yet, and would like to find some examples of how other APIs deal with what are essentially multiple canonical IDs. Having `by-id` and `by-refcode` feels natural, but perhaps simply `/items/refcode/<refcode>` is more extensible and compatible with e.g. JSON:API to other fields in the future.~

Went with this in the end: having `/items/<refcode>` be the canonical URL is appealing, with the "legacy" endpoint being the only way to refer to items by item ID -- this would also allow us to promote refcode at some point to simply be the top-level `id` field in JSON:API parlance, which has some nice properties.