### PR TITLE
Change docker compose restart policy to "unless-stopped"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       target: production
     volumes:
       - ./logs:/logs
-    restart: always
+    restart: unless-stopped
     environment:
       - VUE_APP_API_URL
       - VUE_APP_LOGO_URL
@@ -39,7 +39,7 @@ services:
         - WEB_CONCURRENCY=4
     depends_on:
       - database
-    restart: always
+    restart: unless-stopped
     volumes:
       - ./logs:/logs
       - /data/files:/app/files
@@ -76,7 +76,7 @@ services:
       dockerfile: .docker/mongo_dockerfile
     volumes:
       - ./logs:/var/logs/mongod
-    restart: always
+    restart: unless-stopped
     networks:
       - backend
     ports:
@@ -90,7 +90,7 @@ services:
     volumes:
       - ./logs:/var/logs/mongod
       - /data/db:/data/db
-    restart: always
+    restart: unless-stopped
     networks:
       - backend
 


### PR DESCRIPTION
This PR updates the restart policy for the services in the compose file to `unless-stopped`, which prevents them from clashing and attempting to restart after a reboot (or docker daemon restart).