### PR TITLE
Fix logo link taking full screen width

### DIFF
--- a/webapp/src/components/Navbar.vue
+++ b/webapp/src/components/Navbar.vue
@@ -1,6 +1,15 @@
 <template>
-  <div v-if="logo_url != null" class="pt-3">
-    <a v-if="homepage_url != null" :href="homepage_url" target="_blank">
+  <div
+    v-if="logo_url != null"
+    class="pt-3"
+    style="display: flex; justify-content: center; align-items: center"
+  >
+    <a
+      v-if="homepage_url != null"
+      :href="homepage_url"
+      style="display: inline-block"
+      target="_blank"
+    >
       <img class="logo-banner" :src="logo_url" />
     </a>
     <img v-else class="logo-banner" :src="logo_url" />


### PR DESCRIPTION
Bit of an inline CSS hack, but closes #798