### PR TITLE
Add config options to automatically activate accounts from GitHub, email or any auth source

### DIFF
--- a/pydatalab/pydatalab/config.py
+++ b/pydatalab/pydatalab/config.py
@@ -205,6 +205,21 @@ class ServerConfig(BaseSettings):
         description="Whether to automatically activate accounts created via ORCID registration.",
     )
 
+    GITHUB_AUTO_ACTIVATE_ACCOUNTS: bool = Field(
+        False,
+        description="Whether to automatically activate accounts created via GitHub registration.",
+    )
+
+    EMAIL_AUTO_ACTIVATE_ACCOUNTS: bool = Field(
+        False,
+        description="Whether to automatically activate accounts created via GitHub registration.",
+    )
+
+    AUTO_ACTIVATE_ACCOUNTS: bool = Field(
+        False,
+        description="Whether to automatically activate accounts created via any registration method.",
+    )
+
     EMAIL_DOMAIN_ALLOW_LIST: Optional[List[str]] = Field(
         [],
         description="A list of domains for which users will be able to register accounts if they have a matching verified email address, which still need to be verified by an admin. Setting the value to `None` will allow any email addresses at any domain to register *and activate* an account, otherwise the default `[]` will not allow any email addresses registration.",

--- a/pydatalab/pydatalab/config.py
+++ b/pydatalab/pydatalab/config.py
@@ -212,7 +212,7 @@ class ServerConfig(BaseSettings):
 
     EMAIL_AUTO_ACTIVATE_ACCOUNTS: bool = Field(
         False,
-        description="Whether to automatically activate accounts created via GitHub registration.",
+        description="Whether to automatically activate accounts created via email registration.",
     )
 
     AUTO_ACTIVATE_ACCOUNTS: bool = Field(

--- a/pydatalab/pydatalab/routes/v0_1/auth.py
+++ b/pydatalab/pydatalab/routes/v0_1/auth.py
@@ -373,7 +373,11 @@ def email_logged_in():
         raise UserRegistrationForbidden
 
     create_account = AccountStatus.UNVERIFIED
-    if CONFIG.EMAIL_DOMAIN_ALLOW_LIST is None:
+    if (
+        CONFIG.EMAIL_DOMAIN_ALLOW_LIST is None
+        or CONFIG.EMAIL_AUTO_ACTIVATE_ACCOUNTS
+        or CONFIG.AUTO_ACTIVATE_ACCOUNTS
+    ):
         create_account = AccountStatus.ACTIVE
 
     find_create_or_modify_user(
@@ -426,6 +430,9 @@ def github_logged_in(blueprint, token):
     elif CONFIG.GITHUB_ORG_ALLOW_LIST is None:
         create_account = True
 
+    if CONFIG.GITHUB_AUTO_ACTIVATE_ACCOUNTS or CONFIG.AUTO_ACTIVATE_ACCOUNTS:
+        create_account = AccountStatus.ACTIVE
+
     find_create_or_modify_user(
         github_user_id,
         IdentityType.GITHUB,
@@ -452,7 +459,7 @@ def orcid_logged_in(_, token):
 
     # New ORCID accounts must be activated by an admin unless configured otherwise
     create_account = AccountStatus.UNVERIFIED
-    if CONFIG.ORCID_AUTO_ACTIVATE_ACCOUNTS:
+    if CONFIG.ORCID_AUTO_ACTIVATE_ACCOUNTS or CONFIG.AUTO_ACTIVATE_ACCOUNTS:
         create_account = AccountStatus.ACTIVE
 
     find_create_or_modify_user(


### PR DESCRIPTION
This brings the three auth mechanisms into parity, and can be helpful for e.g., the demo deployment.