### PR TITLE
Fix block errors caused by seemingly defunct theme options in bokeh 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.10' && github.repository == 'datalab-org/datalab'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: datalab-org/datalab

--- a/pydatalab/pydatalab/apps/tga/blocks.py
+++ b/pydatalab/pydatalab/apps/tga/blocks.py
@@ -43,49 +43,56 @@ class MassSpecBlock(DataBlock):
                 return
 
             ms_data = parse_mt_mass_spec_ascii(Path(file_info["location"]))
+            if ms_data:
+                self.data["bokeh_plot_data"] = self._plot_ms_data(ms_data)
 
+    @classmethod
+    def _plot_ms_data(cls, ms_data):
         x_options = ["Time Relative [s]"]
 
-        if ms_data:
-            # collect the maximum value of the data key for each species for plot ordering
-            max_vals: List[Tuple[str, float]] = []
+        # collect the maximum value of the data key for each species for plot ordering
+        max_vals: List[Tuple[str, float]] = []
 
-            for species in ms_data["data"]:
-                data_key = (
-                    "Partial Pressure [mbar]"
-                    if "Partial Pressure [mbar]" in ms_data["data"][species]
-                    else "Ion Current [A]"
+        data_key: str = (
+            "Partial pressure [mbar] or Ion Current [A]"  # default value for data key if missing
+        )
+
+        for species in ms_data["data"]:
+            data_key = (
+                "Partial Pressure [mbar]"
+                if "Partial Pressure [mbar]" in ms_data["data"][species]
+                else "Ion Current [A]"
+            )
+            data = ms_data["data"][species][data_key].to_numpy()
+
+            ms_data["data"][species][f"{data_key} (Savitzky-Golay)"] = savgol_filter(
+                data, len(data) // 10, 3
+            )
+
+            max_vals.append((species, ms_data["data"][species][data_key].max()))
+
+        plots = []
+        for ind, (species, _) in enumerate(sorted(max_vals, key=lambda x: x[1], reverse=True)):
+            plots.append(
+                selectable_axes_plot(
+                    {species: ms_data["data"][species]},
+                    x_options=x_options,
+                    y_options=[data_key],
+                    y_default=[
+                        f"{data_key} (Savitzky-Golay)",
+                        f"{data_key}",
+                    ],
+                    label_x=(ind == 0),
+                    label_y=(ind == 0),
+                    plot_line=True,
+                    plot_points=False,
+                    plot_title=f"Channel name: {species}",
+                    plot_index=ind,
+                    aspect_ratio=1.5,
                 )
-                data = ms_data["data"][species][data_key].to_numpy()
+            )
 
-                ms_data["data"][species][f"{data_key} (Savitzky-Golay)"] = savgol_filter(
-                    data, len(data) // 10, 3
-                )
-
-                max_vals.append((species, ms_data["data"][species][data_key].max()))
-
-            plots = []
-            for ind, (species, _) in enumerate(sorted(max_vals, key=lambda x: x[1], reverse=True)):
-                plots.append(
-                    selectable_axes_plot(
-                        {species: ms_data["data"][species]},
-                        x_options=x_options,
-                        y_options=[data_key],
-                        y_default=[
-                            f"{data_key} (Savitzky-Golay)",
-                            f"{data_key}",
-                        ],
-                        label_x=(ind == 0),
-                        label_y=(ind == 0),
-                        plot_line=True,
-                        plot_points=False,
-                        plot_title=f"Channel name: {species}",
-                        plot_index=ind,
-                        aspect_ratio=1.5,
-                    )
-                )
-
-                plots[-1].children[0].xaxis[0].ticker.desired_num_ticks = 2
+            plots[-1].children[0].xaxis[0].ticker.desired_num_ticks = 2
 
             # construct MxN grid of all species
             M = 3
@@ -94,4 +101,4 @@ class MassSpecBlock(DataBlock):
                 grid.append(plots[i : i + M])
             p = gridplot(grid, sizing_mode="scale_width", toolbar_location="below")
 
-            self.data["bokeh_plot_data"] = bokeh.embed.json_item(p, theme=DATALAB_BOKEH_GRID_THEME)
+            return bokeh.embed.json_item(p, theme=DATALAB_BOKEH_GRID_THEME)

--- a/pydatalab/pydatalab/bokeh_plots.py
+++ b/pydatalab/pydatalab/bokeh_plots.py
@@ -112,8 +112,6 @@ grid_style = {
         "Axis": {
             "axis_label_text_font": TYPEFACE,
             "axis_label_text_font_style": "normal",
-            "major_label_text_font": TYPEFACE,
-            "minor_label_text_font": TYPEFACE,
             "major_tick_in": 0,
             "minor_tick_out": 0,
             "minor_tick_in": 0,

--- a/pydatalab/tests/apps/test_tga.py
+++ b/pydatalab/tests/apps/test_tga.py
@@ -3,7 +3,8 @@ from pathlib import Path
 import pytest
 
 
-def test_ms_parse():
+def test_ms_parse_and_plot():
+    from pydatalab.apps.tga.blocks import MassSpecBlock
     from pydatalab.apps.tga.parsers import parse_mt_mass_spec_ascii
 
     ms = parse_mt_mass_spec_ascii(
@@ -40,6 +41,8 @@ def test_ms_parse():
         assert ms["data"][k].shape == expected_shapes[ind]
 
     assert all(k in ms["meta"] for k in ("Start Time", "End Time", "Sourcefile", "Exporttime"))
+
+    assert MassSpecBlock._plot_ms_data(ms)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I've been encountering block issues with an unknown theme option `"major/minor_label_text_font"` that prevents blocks that use the grid plot from being created. There is no mention of these options anywhere in the Bokeh github repo history, which is perplexing, and they were added long enough ago that I guess we should have seen issues before now, especially as we have not updated bokeh for a little while.

