### PR TITLE
User select and sharing of sample page with creators

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -996,6 +996,7 @@ def search_users():
                     "_id": 1,
                     "identities": 1,
                     "display_name": 1,
+                    "contact_email": 1,
                 }
             },
         ]

--- a/pydatalab/tests/server/test_permissions.py
+++ b/pydatalab/tests/server/test_permissions.py
@@ -7,7 +7,7 @@ def test_unverified_user_permissions(unverified_client):
     response = client.get("/samples/")
     assert response.status_code == 200
 
-    response = client.post("/new-sample/", json={"item_id": "test"})
+    response = client.post("/new-sample/", json={"type": "samples", "item_id": "test"})
     assert response.status_code == 401
 
     response = client.get("/starting-materials/")
@@ -20,7 +20,7 @@ def test_deactivated_user_permissions(deactivated_client):
     response = client.get("/samples/")
     assert response.status_code == 200
 
-    response = client.post("/new-sample/", json={"item_id": "test"})
+    response = client.post("/new-sample/", json={"type": "samples", "item_id": "test"})
     assert response.status_code == 401
 
     response = client.get("/starting-materials/")
@@ -33,8 +33,52 @@ def test_unauthenticated_user_permissions(unauthenticated_client):
     response = client.get("/samples/")
     assert response.status_code == 401
 
-    response = client.post("/new-sample/", json={"item_id": "test"})
+    response = client.post("/new-sample/", json={"type": "samples", "item_id": "test"})
     assert response.status_code == 401
 
     response = client.get("/starting-materials/")
     assert response.status_code == 401
+
+
+def test_basic_permissions_update(admin_client, admin_user_id, client, user_id):
+    """Test that an admin can share an item with a normal user."""
+
+    response = admin_client.post(
+        "/new-sample/", json={"type": "samples", "item_id": "test-admin-sample"}
+    )
+    assert response.status_code == 201
+
+    response = admin_client.get("/get-item-data/test-admin-sample")
+    assert response.status_code == 200
+    refcode = response.json["item_data"]["refcode"]
+
+    response = client.get(f"/items/{refcode}")
+    assert response.status_code == 404
+
+    # Add normal user to the item
+    response = admin_client.patch(
+        f"/items/{refcode}/permissions", json={"creators": [{"immutable_id": str(user_id)}]}
+    )
+    assert response.status_code == 200
+
+    # Check that they can now see it
+    response = client.get(f"/items/{refcode}")
+    assert response.status_code == 200
+
+    # Check that they cannot remove themselves/the admin from the creators
+    client.patch(f"/items/{refcode}/permissions", json={"creators": []})
+    assert response.status_code == 200
+
+    response = client.get(f"/items/{refcode}")
+    assert response.status_code == 200
+
+    # Check that the admin can remove the user from the permissions
+    response = admin_client.patch(f"/items/{refcode}/permissions", json={"creators": []})
+    assert response.status_code == 200
+
+    response = client.get(f"/items/{refcode}")
+    assert response.status_code == 404
+
+    # but that the admin still remains the creator
+    response = admin_client.get(f"/items/{refcode}")
+    assert response.status_code == 200

--- a/pydatalab/tests/server/test_permissions.py
+++ b/pydatalab/tests/server/test_permissions.py
@@ -73,7 +73,9 @@ def test_basic_permissions_update(admin_client, admin_user_id, client, user_id):
     assert response.status_code == 200
 
     # Check that the admin can remove the user from the permissions
-    response = admin_client.patch(f"/items/{refcode}/permissions", json={"creators": []})
+    response = admin_client.patch(
+        f"/items/{refcode}/permissions", json={"creators": [{"immutable_id": str(admin_user_id)}]}
+    )
     assert response.status_code == 200
 
     response = client.get(f"/items/{refcode}")

--- a/webapp/cypress/e2e/editPage.cy.js
+++ b/webapp/cypress/e2e/editPage.cy.js
@@ -205,12 +205,12 @@ describe("Edit Page", () => {
     cy.findByText("editable_sample").click();
 
     cy.findByText("Add a block").click();
-    cy.get(".dropdown-menu").findByText("Comment").click();
+    cy.get('[data-testid="add-block-dropdown"]').findByText("Comment").click();
 
     cy.contains("Unsaved changes").should("not.exist");
 
     cy.findByText("Add a block").click();
-    cy.get(".dropdown-menu").findByText("Comment").click();
+    cy.get('[data-testid="add-block-dropdown"]').findByText("Comment").click();
 
     cy.contains("Unsaved changes").should("not.exist");
 
@@ -258,7 +258,6 @@ describe("Edit Page", () => {
 
     cy.findByText("Add files from server...").click();
     cy.findByText("Select files to add").should("exist");
-    cy.findAllByLabelText("Close").eq(1).click();
   });
 
   it("Uploads an XRD file, makes an XRD block and checks that the plot works", () => {
@@ -268,7 +267,7 @@ describe("Edit Page", () => {
     cy.findByText("editable_sample").click();
 
     cy.findByText("Add a block").click();
-    cy.get(".dropdown-menu").findByText("Powder XRD").click();
+    cy.get('[data-testid="add-block-dropdown"]').findByText("Powder XRD").click();
 
     cy.findByText("Select a file:").should("exist");
     cy.get("select.file-select-dropdown").select("example_data_XRD_example_bmb.xye");
@@ -285,7 +284,7 @@ describe("Edit Page", () => {
     cy.findByText("editable_sample").click();
 
     cy.findByText("Add a block").click();
-    cy.get(".dropdown-menu").findByText("Media").click();
+    cy.get('[data-testid="add-block-dropdown"]').findByText("Media").click();
     cy.findAllByText("Select a file:").eq(1).should("exist");
     cy.get("select.file-select-dropdown").eq(1).select(test_fname);
 

--- a/webapp/src/components/CellInformation.vue
+++ b/webapp/src/components/CellInformation.vue
@@ -25,11 +25,8 @@
               <FormattedRefcode :refcode="Refcode" />
             </div>
           </div>
-          <div class="form-group col-md-3 col-sm-3 col-6 pb-3 pr-2">
-            <label id="cell-creators">Creators</label>
-            <div aria-labelledby="cell-creators" class="mx-auto">
-              <Creators :creators="ItemCreators" :size="36" />
-            </div>
+          <div class="form-group col-md-3 col-sm-3 col-6 pb-3">
+            <ToggleableCreatorsFormGroup v-model="ItemCreators" :refcode="Refcode" />
           </div>
           <div class="col-md-6 col-sm-7 pr-2">
             <ToggleableCollectionFormGroup v-model="Collections" />
@@ -115,7 +112,7 @@ import TableOfContents from "@/components/TableOfContents";
 import ItemRelationshipVisualization from "@/components/ItemRelationshipVisualization";
 import FormattedRefcode from "@/components/FormattedRefcode";
 import ToggleableCollectionFormGroup from "@/components/ToggleableCollectionFormGroup";
-import Creators from "@/components/Creators";
+import ToggleableCreatorsFormGroup from "@/components/ToggleableCreatorsFormGroup";
 import { cellFormats } from "@/resources.js";
 
 export default {
@@ -127,7 +124,7 @@ export default {
     ItemRelationshipVisualization,
     FormattedRefcode,
     ToggleableCollectionFormGroup,
-    Creators,
+    ToggleableCreatorsFormGroup,
   },
   props: {
     item_id: {

--- a/webapp/src/components/Creators.vue
+++ b/webapp/src/components/Creators.vue
@@ -26,7 +26,7 @@ export default {
     },
     showNames: {
       type: Boolean,
-      default: false,
+      default: true,
       required: false,
     },
     showBubble: {

--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -459,12 +459,16 @@ export default {
 
       const config = propsConfig[componentName] || {};
 
-      const props = Object.entries(config).reduce((acc, [prop, dataKey]) => {
-        if (dataKey !== true) {
+      const props = Object.entries(config).reduce((acc, [prop, setting]) => {
+        if (typeof setting === "object" && setting !== null && "value" in setting) {
+          acc[prop] = setting.value;
+        } else if (typeof setting === "boolean") {
+          acc[prop] = setting;
+        } else if (typeof setting === "string") {
           if (prop === "itemType") {
             acc[prop] = data.type !== undefined ? data.type : "starting_materials";
-          } else if (data[dataKey] !== undefined) {
-            acc[prop] = data[dataKey];
+          } else if (data[setting] !== undefined) {
+            acc[prop] = data[setting];
           }
         }
         return acc;

--- a/webapp/src/components/SampleInformation.vue
+++ b/webapp/src/components/SampleInformation.vue
@@ -30,10 +30,7 @@
             </div>
           </div>
           <div class="form-group col-md-3 col-sm-3 col-6 pb-3">
-            <label id="samp-creators">Creators</label>
-            <div aria-labelledby="samp-creators" class="mx-auto">
-              <Creators :creators="ItemCreators" :size="36" />
-            </div>
+            <ToggleableCreatorsFormGroup v-model="ItemCreators" :refcode="Refcode" />
           </div>
           <div class="col-md-6 col-sm-7 pr-2">
             <ToggleableCollectionFormGroup v-model="Collections" />
@@ -62,11 +59,11 @@ import { createComputedSetterForItemField } from "@/field_utils.js";
 import ChemFormulaInput from "@/components/ChemFormulaInput";
 import FormattedRefcode from "@/components/FormattedRefcode";
 import ToggleableCollectionFormGroup from "@/components/ToggleableCollectionFormGroup";
+import ToggleableCreatorsFormGroup from "@/components/ToggleableCreatorsFormGroup";
 import TinyMceInline from "@/components/TinyMceInline";
 import SynthesisInformation from "@/components/SynthesisInformation";
 import TableOfContents from "@/components/TableOfContents";
 import ItemRelationshipVisualization from "@/components/ItemRelationshipVisualization";
-import Creators from "@/components/Creators";
 
 export default {
   components: {
@@ -77,7 +74,7 @@ export default {
     ItemRelationshipVisualization,
     FormattedRefcode,
     ToggleableCollectionFormGroup,
-    Creators,
+    ToggleableCreatorsFormGroup,
   },
   props: {
     item_id: { type: String, required: true },

--- a/webapp/src/components/ToggleableCreatorsFormGroup.vue
+++ b/webapp/src/components/ToggleableCreatorsFormGroup.vue
@@ -1,0 +1,122 @@
+<template>
+  <div
+    ref="outerdiv"
+    class="h-100 form-group clickable"
+    @click="isEditingCreators = !isEditingCreators"
+  >
+    <label id="creators" class="clickable">
+      Creators
+      <font-awesome-icon
+        id="edit-icon"
+        class="pl-1"
+        icon="pen"
+        size="xs"
+        :fade="isEditingCreators"
+      />
+    </label>
+    <div>
+      <Creators
+        v-if="!isEditingCreators"
+        :show-names="value.length <= 1"
+        aria-labelledby="creators"
+        :creators="shadowValue"
+      />
+      <OnClickOutside
+        v-if="isEditingCreators"
+        :options="{ ignore: [outerDivRef] }"
+        @trigger="isEditingCreators = false"
+      >
+        <UserSelect v-model="shadowValue" aria-labelledby="creators" multiple @click.stop />
+      </OnClickOutside>
+    </div>
+  </div>
+</template>
+
+<script>
+import Creators from "@/components/Creators";
+import UserSelect from "@/components/UserSelect";
+import { OnClickOutside } from "@vueuse/components";
+import { updateItemPermissions } from "@/server_fetch_utils.js";
+
+export default {
+  components: {
+    UserSelect,
+    Creators,
+    OnClickOutside,
+  },
+  props: {
+    refcode: { type: String, required: true },
+    modelValue: {
+      type: Array,
+      required: true,
+    },
+  },
+  emits: ["update:modelValue"],
+  data() {
+    return {
+      isEditingCreators: false,
+      outerDivRef: null,
+      shadowValue: [],
+    };
+  },
+  computed: {
+    // computed setter to pass v-model through  component:
+    value: {
+      get() {
+        return this.modelValue;
+      },
+      set(newValue) {
+        this.$emit("update:modelValue", newValue);
+      },
+    },
+  },
+  watch: {
+    isEditingCreators(newValue, oldValue) {
+      // Check we are leaving the editing state
+      if (newValue === false && oldValue === true) {
+        // Check that the permissions have actually changed
+        if (this.shadowValue === this.value) {
+          return;
+        }
+        try {
+          let answer = confirm("Are you sure you want to update the permissions of this item?");
+          if (answer) {
+            updateItemPermissions(this.refcode, this.shadowValue);
+            this.$emit("update:modelValue", [...this.shadowValue]);
+          } else {
+            this.shadowValue = [...this.value];
+          }
+        } catch (error) {
+          // Reset value to original
+          this.shadowValue = [...this.value];
+        }
+      }
+    },
+    modelValue: {
+      immediate: true,
+      handler(newVal) {
+        if (this.shadowValue !== newVal) {
+          this.shadowValue = [...newVal];
+        }
+      },
+    },
+  },
+  async mounted() {
+    this.outerDivRef = this.$refs.outerdiv; // we need to get the editIcon's ref to be accessible in the template so we can exclude it from the ClickOutside
+  },
+};
+</script>
+
+<style scoped>
+.text-italic {
+  opacity: 0.7;
+}
+
+#edit-icon {
+  color: grey;
+}
+
+.text-heavy {
+  font-weight: 600;
+}
+</style>

--- a/webapp/src/components/UserSelect.vue
+++ b/webapp/src/components/UserSelect.vue
@@ -2,7 +2,7 @@
   <vSelect
     ref="selectComponent"
     v-model="value"
-    :options="users"
+    :options="filteredUsers"
     multiple
     label="immutable_id"
     :filterable="false"
@@ -55,6 +55,10 @@ export default {
       set(newValue) {
         this.$emit("update:modelValue", newValue);
       },
+    },
+    filteredUsers() {
+      const selectedUserIds = this.modelValue.map((user) => user.immutable_id);
+      return this.users.filter((user) => !selectedUserIds.includes(user.immutable_id));
     },
   },
   methods: {

--- a/webapp/src/components/UserSelect.vue
+++ b/webapp/src/components/UserSelect.vue
@@ -1,0 +1,81 @@
+<template>
+  <vSelect
+    ref="selectComponent"
+    v-model="value"
+    :options="users"
+    multiple
+    label="immutable_id"
+    :filterable="false"
+    @search="debouncedAsyncSearch"
+  >
+    <template #no-options="{ searching }">
+      <span v-if="searching"> Sorry, no matches found. </span>
+      <span v-else class="empty-search"> Search for a user by name, email, ORCID or GitHub </span>
+    </template>
+    <template #option="user">
+      <Creators :show-bubble="true" :creators="[user]" />
+    </template>
+    <template #selected-option="user">
+      <Creators :show-bubble="true" :creators="[user]" />
+    </template>
+  </vSelect>
+</template>
+
+<script>
+import vSelect from "vue-select";
+import { searchUsers } from "@/server_fetch_utils.js";
+import { debounceTime } from "@/resources.js";
+import Creators from "@/components/Creators.vue";
+
+export default {
+  components: {
+    vSelect,
+    Creators,
+  },
+  props: {
+    modelValue: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  emits: ["update:modelValue"],
+  data() {
+    return {
+      debounceTimeout: null,
+      users: [],
+      isSearchFetchError: false,
+    };
+  },
+  computed: {
+    // computed setter to pass v-model through  component:
+    value: {
+      get() {
+        return this.modelValue;
+      },
+      set(newValue) {
+        this.$emit("update:modelValue", newValue);
+      },
+    },
+  },
+  methods: {
+    async debouncedAsyncSearch(query, loading) {
+      loading(true);
+      clearTimeout(this.debounceTimeout); // reset the timer
+      // start the timer
+      this.debounceTimeout = setTimeout(async () => {
+        await searchUsers(query, 100)
+          .then((users) => {
+            this.users = users;
+            console.log(users);
+          })
+          .catch((error) => {
+            console.error("Fetch error");
+            console.error(error);
+            this.isSearchFetchError = true;
+          });
+        loading(false);
+      }, debounceTime);
+    },
+  },
+};
+</script>

--- a/webapp/src/components/UserSelect.vue
+++ b/webapp/src/components/UserSelect.vue
@@ -4,6 +4,7 @@
     v-model="value"
     :options="filteredUsers"
     multiple
+    :min="minimumOptions"
     label="immutable_id"
     :filterable="false"
     @search="debouncedAsyncSearch"
@@ -36,6 +37,10 @@ export default {
     modelValue: {
       type: Array,
       default: () => [],
+    },
+    minimumOptions: {
+      type: Number,
+      default: 0,
     },
   },
   emits: ["update:modelValue"],

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -328,6 +328,7 @@ export async function getUserInfo() {
   return fetch_get(`${API_URL}/get-current-user/`)
     .then((response_json) => {
       store.commit("setDisplayName", response_json.display_name);
+      store.commit("setCurrentUserID", response_json.immutable_id);
       store.commit("setIsUnverified", response_json.account_status == "unverified" ? true : false);
       return response_json;
     })
@@ -505,6 +506,21 @@ export function addABlock(item_id, block_type, index = null) {
     })
     .catch((error) => console.error("Error in addABlock:", error));
   return block_id_promise;
+}
+
+export function updateItemPermissions(refcode, creators) {
+  console.log("updateItemPermissions called with", refcode, creators);
+  fetch_patch(`${API_URL}/items/${refcode}/permissions`, {
+    creators: creators,
+  })
+    .then(function (response_json) {
+      if (response_json.status === "error") {
+        throw new Error(response_json.message);
+      }
+    })
+    .catch(function (error) {
+      throw new Error(error);
+    });
 }
 
 export function saveItem(item_id) {

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -510,17 +510,14 @@ export function addABlock(item_id, block_type, index = null) {
 
 export function updateItemPermissions(refcode, creators) {
   console.log("updateItemPermissions called with", refcode, creators);
-  fetch_patch(`${API_URL}/items/${refcode}/permissions`, {
+  return fetch_patch(`${API_URL}/items/${refcode}/permissions`, {
     creators: creators,
-  })
-    .then(function (response_json) {
-      if (response_json.status === "error") {
-        throw new Error(response_json.message);
-      }
-    })
-    .catch(function (error) {
-      throw new Error(error);
-    });
+  }).then(function (response_json) {
+    if (response_json.status === "error") {
+      throw new Error(response_json.message);
+    }
+    return response_json;
+  });
 }
 
 export function saveItem(item_id) {

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -223,7 +223,11 @@ export default createStore({
       //requires the following fields in payload:
       // item_id, item_data
       Object.assign(state.all_item_data[payload.item_id], payload.item_data);
-      state.saved_status_items[payload.item_id] = false;
+      if (payload.item_data.creators && state.saved_status_items[payload.item_id] == true) {
+        state.saved_status_items[payload.item_id] = true;
+      } else {
+        state.saved_status_items[payload.item_id] = false;
+      }
     },
     updateCollectionData(state, payload) {
       //requires the following fields in payload:

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -27,6 +27,7 @@ export default createStore({
     remoteDirectoryTreeIsLoading: false,
     fileSelectModalIsOpen: false,
     currentUserDisplayName: null,
+    currentUserID: null,
     serverInfo: null,
     blocksInfos: {},
     currentUserIsUnverified: false,
@@ -69,6 +70,9 @@ export default createStore({
     },
     setDisplayName(state, displayName) {
       state.currentUserDisplayName = displayName;
+    },
+    setCurrentUserID(state, userID) {
+      state.currentUserID = userID;
     },
     setIsUnverified(state, isUnverified) {
       state.currentUserIsUnverified = isUnverified;
@@ -324,6 +328,9 @@ export default createStore({
     },
     getCurrentUserDisplayName(state) {
       return state.currentUserDisplayName;
+    },
+    getCurrentUserID(state) {
+      return state.currentUserID;
     },
     getCurrentUserIsUnverified(state) {
       return state.currentUserIsUnverified;

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -5,7 +5,6 @@
     :style="{ backgroundColor: navbarColor }"
   >
     <div v-show="false" class="navbar-nav"><LoginDetails /></div>
-    <div v-show="false" class="navbar-nav"><LoginDetails /></div>
     <span class="navbar-brand clickable" @click="scrollToID($event, 'topScrollPoint')"
       >{{ itemTypeEntry?.navbarName || "loading..." }}&nbsp;&nbsp;|&nbsp;&nbsp;
       <FormattedItemName :item_id="item_id" :item-type="itemType" />
@@ -28,6 +27,7 @@
           v-if="blockInfoLoaded"
           v-show="isMenuDropdownVisible"
           class="dropdown-menu"
+          data-testid="add-block-dropdown"
           style="display: block"
           aria-labelledby="navbarDropdown"
         >

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -4,6 +4,8 @@
     class="navbar navbar-expand sticky-top navbar-dark py-0 editor-navbar"
     :style="{ backgroundColor: navbarColor }"
   >
+    <div v-show="false" class="navbar-nav"><LoginDetails /></div>
+    <div v-show="false" class="navbar-nav"><LoginDetails /></div>
     <span class="navbar-brand clickable" @click="scrollToID($event, 'topScrollPoint')"
       >{{ itemTypeEntry?.navbarName || "loading..." }}&nbsp;&nbsp;|&nbsp;&nbsp;
       <FormattedItemName :item_id="item_id" :item-type="itemType" />
@@ -103,6 +105,7 @@ import {
   updateBlockFromServer,
   getBlocksInfos,
 } from "@/server_fetch_utils";
+import LoginDetails from "@/components/LoginDetails";
 import FormattedItemName from "@/components/FormattedItemName";
 
 import setupUppy from "@/file_upload.js";
@@ -121,6 +124,7 @@ export default {
     TinyMceInline,
     SelectableFileTree,
     FileList,
+    LoginDetails,
     FileSelectModal,
     FormattedItemName,
     StyledBlockHelp,


### PR DESCRIPTION
This PR adds a user select and toggleable editable option to the creator list for items.

It should prevent the user from removing themselves, and should potentially prevent the user from removing other people (i.e. append-only share), or some more tortured logic where the "first" creator in the list takes precedence.

This also adds a new API route `PATCH /items/<refcode>/permissions` for this use case, with some tests.

Works similarly to the toggleable collection block, except that API call is made when the editing state is completed, and has a confirmation dialog.

Some outstanding things (for this PR or otherwise):

- [x] Error handling when the API update fails, e.g., if the creator tries to remove themselves. For me, the the error seems to get caught by the dev server before it gets back to the component to reset the value.
- [ ] Cypress testing... tricky since we're not ever logged in during the current e2e tests