### PR TITLE
CI build time and fork compatibility improvements

### DIFF
--- a/.docker/server_dockerfile
+++ b/.docker/server_dockerfile
@@ -44,3 +44,5 @@ ENV PORT=${PORT}
 
 
 CMD ["/bin/bash", "-c", "pipenv run gunicorn --preload -w ${WEB_CONCURRENCY} --error-logfile /logs/pydatalab_error.log --access-logfile - -b 0.0.0.0:${PORT} 'pydatalab.main:create_app()'"]
+
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD curl --fail http://localhost:${PORT}/healthcheck/is_ready || exit 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  #- package-ecosystem: pip
+  #  directory: "/"
+  #  schedule:
+  #    interval: weekly
+  #    day: monday
+  #    time: "05:43"
+  #  # Needs to be larger than the number of total requirements (currently 31)
+  #  open-pull-requests-limit: 50
+  #  target-branch: master
+  #  labels:
+  #  - dependency_updates
+  #  # Turn off automatic rebases so that auto-merge can work without needed N**2 CI runs
+  #  rebase-strategy: "disabled"
+  #  groups:
+  #    python-dependencies:
+  #      applies-to: version-updates
+  #      dependency-type: production
+  #    python-dependencies-dev:
+  #      applies-to: version-updates
+  #      dependency-type: development
+  #    python-dependencies-security:
+  #      applies-to: security-updates
+  #      dependency-type: production
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "05:33"
+  target-branch: master
+  labels:
+  - CI
+  groups:
+    github-actions:
+      applies-to: version-updates
+      dependency-type: production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         with:
           config: baseUrl=http://localhost:8081
           working-directory: ./webapp
-          record: true
+          record: ${{ github.repository == 'datalab-org/datalab' }}
           browser: ${{ matrix.browser-backend }}
           group: "End-to-end tests (${{ matrix.browser-backend }})"
         env:
@@ -166,7 +166,7 @@ jobs:
         uses: cypress-io/github-action@v6
         with:
           working-directory: ./webapp
-          record: true
+          record: ${{ github.repository == 'datalab-org/datalab' }}
           install: false
           component: true
           publish-summary: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,9 +115,46 @@ jobs:
         working-directory: ./webapp
         run: yarn build
 
+  docker:
+    name: Test Docker builds
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - "app"
+          - "app_dev"
+          - "api"
+          - "api_dev"
+          - "database"
+          - "database_dev"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set some environment variables for CI containers pre-build
+        run: |
+          cp webapp/.env.test_e2e webapp/.env
+          echo "VUE_APP_API_URL=http://localhost:5001" >> .env
+          echo "PYDATALAB_TESTING=true" >> pydatalab/.env
+
+      - name: Build Docker images and cache them
+        uses: docker/bake-action@v5
+        with:
+          files: docker-compose.yml
+          load: true
+          targets: ${{ matrix.target }}
+          set: |
+            *.cache-to=type=gha,scope=build-${{ matrix.target }},mode=max
+            *.cache-from=type=gha,scope=build-${{ matrix.target }}
+            api.args.PYDATALAB_TESTING=true
+
   e2e:
     name: e2e tests
     runs-on: ubuntu-latest
+    needs: [docker]
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -130,24 +167,28 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Debugging
+      - name: Set some environment variables for CI containers pre-build
         run: |
-          docker image ls
+          cp webapp/.env.test_e2e webapp/.env
+          echo "VUE_APP_API_URL=http://localhost:5001" >> .env
+          echo "PYDATALAB_TESTING=true" >> pydatalab/.env
 
-      - name: Build the Docker images
-        uses: docker/bake-action@v4
+      - name: Load previously built Docker images
+        uses: docker/bake-action@v5
         with:
           files: docker-compose.yml
           load: true
+          targets: 'app,api,database'
           set: |
-            *.cache-from=type=gha,scope=cached-stage
-            *.cache-to=type=gha,scope=cached-stage,mode=max
+            app.cache-from=type=gha,scope=build-app
+            app.tags=datalab-app:latest
+            api.cache-from=type=gha,scope=build-api
+            api.tags=datalab-api:latest
+            database.cache-from=type=gha,scope=build-database
+            database.tags=datalab-database:latest
 
-      - name: Start Docker images
+      - name: Start services
         run: |
-          # Add default API URL argument to Vue prod build
-          echo "VUE_APP_API_URL=http://localhost:5001" >> .env
-          echo "PYDATALAB_TESTING=true" >> pydatalab/.env
           # Launch production container profiles and wait for them to come up
           docker compose up database api app -d --wait
 

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -8,7 +8,7 @@ on:
 env:
   PUBLISH_UPDATE_BRANCH: main
   GIT_USER_NAME: "Greymon (bot)"
-  GIT_USER_EMAIL: "bot-grey-group@ml-evs.science"
+  GIT_USER_EMAIL: "git-bot@datalab-org.io"
   # Need to set this to avoid pipenv syncing an entire LFS repo and failing with bandwidth quota (see
   # https://github.com/the-grey-group/datalab/issues/603)
   GIT_LFS_SKIP_SMUDGE: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,8 @@ services:
     restart: unless-stopped
     networks:
       - backend
+    ports:
+      - "27017:27017"
 
 networks:
   backend:


### PR DESCRIPTION
- Attempt to set `record: false` in cypress CI if running from a fork
- Separate docker build into its own job, shared by all e2e test runners