### PR TITLE
Reload echem data by default, unless disabled

### DIFF
--- a/pydatalab/Pipfile
+++ b/pydatalab/Pipfile
@@ -27,7 +27,7 @@ flask-compress = "*"
 pillow = "*"
 tiktoken = "~= 0.7, < 0.8"
 galvani = "~= 0.4"
-navani = {git = "git+https://github.com/the-grey-group/navani.git@v0.1.6"}
+navani = {git = "git+https://github.com/the-grey-group/navani.git@v0.1.7"}
 NewareNDA = ">= 2024"
 python-dateutil = "*"
 pybaselines = "*"

--- a/pydatalab/Pipfile.lock
+++ b/pydatalab/Pipfile.lock
@@ -1413,8 +1413,8 @@
             "version": "==6.0.5"
         },
         "navani": {
-            "git": "git+https://github.com/the-grey-group/navani.git@v0.1.6",
-            "ref": "4947f3c9fbf730e783800a58c9689936ed273eb2"
+            "git": "git+https://github.com/the-grey-group/navani.git@v0.1.7",
+            "ref": "d171781b483f0a17a0ada7a043c8f1e243499245"
         },
         "newarenda": {
             "hashes": [

--- a/pydatalab/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/pydatalab/apps/echem/blocks.py
@@ -62,7 +62,7 @@ class CycleBlock(DataBlock):
             return characteristic_mass_mg / 1000.0
         return None
 
-    def _load(self, file_id: Union[str, ObjectId], reload: bool = False):
+    def _load(self, file_id: Union[str, ObjectId], reload: bool = True):
         """Loads the echem data using navani, summarises it, then caches the results
         to disk with suffixed names.
 


### PR DESCRIPTION
Closes #839 with a hotfix, will need to be solved more generally in the future.