### PR TITLE
Tweak cache usage on docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,12 +131,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker images and cache them
+      - name: Build Docker containers
         uses: docker/bake-action@v5
         with:
           files: docker-compose.yml
           load: true
           targets: ${{ matrix.target }}
+          set: |
+            *.cache-to=type=gha,scope=build-${{ matrix.target }},mode=max
+            *.cache-from=type=gha,scope=build-${{ matrix.target }}
 
   e2e:
     name: e2e tests
@@ -179,7 +182,7 @@ jobs:
       - name: Start services
         run: |
           # Launch production container profiles and wait for them to come up
-          docker compose up database api app -d --wait
+          docker compose up database api app --no-build -d --wait
 
       - name: Run end-to-end tests
         uses: cypress-io/github-action@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,16 +116,13 @@ jobs:
         run: yarn build
 
   docker:
-    name: Test Docker builds
+    name: Test dev Docker builds
     runs-on: ubuntu-latest
     strategy:
       matrix:
         target:
-          - "app"
           - "app_dev"
-          - "api"
           - "api_dev"
-          - "database"
           - "database_dev"
 
     steps:
@@ -134,27 +131,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set some environment variables for CI containers pre-build
-        run: |
-          cp webapp/.env.test_e2e webapp/.env
-          echo "VUE_APP_API_URL=http://localhost:5001" >> .env
-          echo "PYDATALAB_TESTING=true" >> pydatalab/.env
-
       - name: Build Docker images and cache them
         uses: docker/bake-action@v5
         with:
           files: docker-compose.yml
           load: true
           targets: ${{ matrix.target }}
-          set: |
-            *.cache-to=type=gha,scope=build-${{ matrix.target }},mode=max
-            *.cache-from=type=gha,scope=build-${{ matrix.target }}
-            api.args.PYDATALAB_TESTING=true
 
   e2e:
     name: e2e tests
     runs-on: ubuntu-latest
-    needs: [docker]
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -180,10 +166,13 @@ jobs:
           load: true
           targets: 'app,api,database'
           set: |
+            app.cache-to=type=gha,scope=build-app,mode=max
             app.cache-from=type=gha,scope=build-app
             app.tags=datalab-app:latest
+            api.cache-to=type=gha,scope=build-api,mode=max
             api.cache-from=type=gha,scope=build-api
             api.tags=datalab-api:latest
+            database.cache-to=type=gha,scope=build-database,mode=max
             database.cache-from=type=gha,scope=build-database
             database.tags=datalab-database:latest
 


### PR DESCRIPTION
Follow-up from #833. Adjust the caching strategy by lumping prod builds with e2e tests so that the cache gets used between runs, but not within them.