### PR TITLE
Re-enable dependabot for Python dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,36 +1,37 @@
 version: 2
 updates:
-  #- package-ecosystem: pip
-  #  directory: "/"
-  #  schedule:
-  #    interval: weekly
-  #    day: monday
-  #    time: "05:43"
-  #  # Needs to be larger than the number of total requirements (currently 31)
-  #  open-pull-requests-limit: 50
-  #  target-branch: master
-  #  labels:
-  #  - dependency_updates
-  #  # Turn off automatic rebases so that auto-merge can work without needed N**2 CI runs
-  #  rebase-strategy: "disabled"
-  #  groups:
-  #    python-dependencies:
-  #      applies-to: version-updates
-  #      dependency-type: production
-  #    python-dependencies-dev:
-  #      applies-to: version-updates
-  #      dependency-type: development
-  #    python-dependencies-security:
-  #      applies-to: security-updates
-  #      dependency-type: production
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: monthly
+    day: monday
+    time: "05:43"
+  # Needs to be larger than the number of total requirements (currently 31)
+  open-pull-requests-limit: 50
+  target-branch: main
+  labels:
+  - dependency_updates
+  # Turn off automatic rebases so that auto-merge can work without needed N**2 CI runs
+  rebase-strategy: "disabled"
+  groups:
+    python-dependencies:
+      applies-to: version-updates
+      dependency-type: production
+    python-dependencies-dev:
+      applies-to: version-updates
+      dependency-type: development
+    python-dependencies-security:
+      applies-to: security-updates
+      dependency-type: production
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
     time: "05:33"
-  target-branch: master
+  target-branch: main
   labels:
   - CI
+  - dependency_updates
   groups:
     github-actions:
       applies-to: version-updates


### PR DESCRIPTION
Now that we are relatively up to date, this PR re-enables dependabot, to see how it deals with the conflicting pipenv/pyproject/requirements file definitions. We may need to turn it off again pretty quickly.