### PR TITLE
Fix docs formatting and update versioning scheme

### DIFF
--- a/.docker/server_dockerfile
+++ b/.docker/server_dockerfile
@@ -44,9 +44,6 @@ RUN [ "uv", "pip", "install", "gunicorn" ]
 WORKDIR /app
 COPY ./pydatalab/ ./
 
-# Install the local version of the package and mount the repository data to get version info
- RUN --mount=type=bind,target=/app/.git,source=./.git ["uv", "pip", "install", "--python", "/opt/.venv/bin/python", "."]
-
 # This will define the number of gunicorn workers
 ARG WEB_CONCURRENCY=4
 ENV WEB_CONCURRENCY=${WEB_CONCURRENCY}
@@ -54,6 +51,10 @@ ENV WEB_CONCURRENCY=${WEB_CONCURRENCY}
 ARG PORT=5001
 EXPOSE ${PORT}
 ENV PORT=${PORT}
+
+# Install the local version of the package and mount the repository data to get version info
+RUN git config --global --add safe.directory /
+RUN --mount=type=bind,target=/.git,source=./.git ["uv", "pip", "install", "--python", "/opt/.venv/bin/python", "."]
 
 CMD ["/bin/bash", "-c", "/opt/.venv/bin/python -m gunicorn --preload -w ${WEB_CONCURRENCY} --error-logfile /logs/pydatalab_error.log --access-logfile - -b 0.0.0.0:${PORT} 'pydatalab.main:create_app()'"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # tests need an unshallowed version of the repository to check the version
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,7 +8,7 @@ instance, in which case please check out the separate Python API package at
 [datalab-org/datalab-api](https://github.com/datalab-org/datalab-python-api).
 
 The instructions below outline how to make a development installation on your local machine.
-We strongly recommend following the [deployment instructions](deployment.md) on [docs.datalab-org.io](docs.datalab-org.io/en/stable/deployment/) if you are deploying for use in production.
+We strongly recommend following the [deployment instructions](deployment.md) on [docs.datalab-org.io](https://docs.datalab-org.io/en/stable/deployment/) if you are deploying for use in production.
 These instructions are also useful for developers who want to use Docker to create a reproducible development environment.
 
 This repository consists of two components:
@@ -35,7 +35,7 @@ This requires a MongoDB server to be running on your desired host machine.
 
 1. Install the free MongoDB community edition (full instructions on the [MongoDB website](https://docs.mongodb.com/manual/installation/)).
     * For Mac users, MongoDB is available via [HomeBrew](https://github.com/mongodb/homebrew-brew).
-    - You can alternatively run the MongoDB via Docker using the config in this package with `docker compose up database` (see further instructions [below](#deployment-with-docker).
+    - You can alternatively run the MongoDB via Docker using the config in this package with `docker compose up database` (see [deployment instructions](deploy.md).
     * If you wish to view the database directly, MongoDB has several GUIs, e.g. [MongoDB Compass](https://www.mongodb.com/products/compass) or [Studio 3T](https://robomongo.org/).
     - For persistence, you will need to set up MongoDB to run as a service on your computer (or run manually each time you run the `pydatalab` server).
 
@@ -59,23 +59,25 @@ standard library Python `venv` module.
       environment.
 2. Activate the virtual environment (optional for `uv`) and install dependencies. One can either use the loosely pinned dependencies in `pyproject.toml`, or the locked versions in the `requirements/requirements-all-dev.txt` and `requirements/requirements-all.txt` files.
 
-=== "`uv`"
+=== "Installation with `uv`"
 
     ```shell
-    # EITHER: Install all dependencies with locked versions
+    # EITHER: Install all dependencies with locked versions, then install the local package
     uv pip install -r requirements/requirements-all-dev.txt
+    uv pip install -e '.[all,dev]'
     # OR: Install all dependencies with loosely pinned versions
-    uv pip install -e '.[all]'
+    uv pip install -e '.[all,dev]'
     ```
 
-=== "`venv`"
+=== "Installation with `venv`"
 
     ```shell
     source .venv/bin/activate
-    # EITHER: Install all dependencies with locked versions
+    # EITHER: Install all dependencies with locked versions, then install the local package
     pip install -r requirements/requirements-all-dev.txt
+    pip install -e '.[all, dev]'
     # OR: Install all dependencies with loosely pinned versions
-    pip install -e '.[all]'
+    pip install -e '.[all, dev]'
     ```
 
 ##### Using `pipenv` (DEPRECATED)
@@ -98,14 +100,15 @@ To make use of this file:
 
 1. Run the server from the `pydatalab` folder with either:
 
-=== "`uv` or `venv`
+=== "Launching with `uv` or `venv`"
+
     ```shell
     cd pydatalab
     source .venv/bin/activate
     flask --app 'pydatalab:main.create_app()' --reload run
     ```
 
-=== "`pipenv`"
+=== "Launching with `pipenv`"
 
     ```shell
     cd pydatalab

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - database_dev
     volumes:
       - ./logs:/logs
+      - ./.git:/.git
       - ./pydatalab:/app
     ports:
       - "5001:5001"

--- a/pydatalab/docs/config.md
+++ b/pydatalab/docs/config.md
@@ -4,7 +4,8 @@ This document describes the different options for configuring a *datalab*
 instance.
 It is primarily intended for those who are *deploying* *datalab* on persistent
 hardware, but may also be useful for developers.
-Deployment instructions can be found under [](deployment.md).
+Deployment instructions can be found under ["Deploying datalab and server
+administration"](deployment.md).
 
 *datalab* has 3 main configuration sources.
 

--- a/pydatalab/mkdocs.yml
+++ b/pydatalab/mkdocs.yml
@@ -32,6 +32,9 @@ theme:
     features:
       - content.code.copy
 
+  features:
+    - content.tabs.link
+
 repo_name: datalab-org/datalab
 repo_url: https://github.com/datalab-org/datalab
 
@@ -54,7 +57,8 @@ markdown_extensions:
           format: !!python/name:pymdownx.superfences.fence_code_format
 
   - pymdownx.inlinehilite
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.tasklist
   - pymdownx.snippets
   - toc:

--- a/pydatalab/pydatalab/main.py
+++ b/pydatalab/pydatalab/main.py
@@ -11,6 +11,7 @@ from flask_login import current_user, logout_user
 from werkzeug.middleware.proxy_fix import ProxyFix
 
 import pydatalab.mongo
+from pydatalab import __version__
 from pydatalab.config import CONFIG, FEATURE_FLAGS
 from pydatalab.logger import LOGGER, setup_log
 from pydatalab.login import LOGIN_MANAGER
@@ -148,7 +149,9 @@ def create_app(
 
     app.config.update(dotenv_values(dotenv_path=env_file))
 
+    LOGGER.info("Launching datalab version %s", __version__)
     LOGGER.info("Starting app with Flask app.config: %s", app.config)
+
     _check_feature_flags(app)
 
     if CONFIG.BEHIND_REVERSE_PROXY:

--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -38,7 +38,8 @@ include = ["pydatalab"]
 namespaces = false
 
 [tool.setuptools_scm]
-fallback_version = "0.1"
+root = ".."
+fallback_version = "0.1.0"
 
 [project.optional-dependencies]
 dev = [

--- a/pydatalab/tests/test_version.py
+++ b/pydatalab/tests/test_version.py
@@ -2,3 +2,5 @@ def test_version():
     from pydatalab import __version__
 
     assert isinstance(__version__, str)
+    assert int(__version__.split(".")[0]) == 0
+    assert int(__version__.split(".")[1]) >= 4


### PR DESCRIPTION
The setup-tools-scm version was not being picked up outside of docker as the `.git` folder is one level up. This PR fixes that, adds a simple test, and also makes some docs formatting fixes.