### PR TITLE
Use uv and deps lockfiles in CI & pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,19 +26,21 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Set up uv (latest)
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
       - name: Install dependencies
         working-directory: ./pydatalab
         run: |
-          python -m pip install --upgrade pip
-          pip install -U setuptools
-          pip install pipenv
-          pipenv sync --dev
-          pipenv run pip install -e .
+          uv venv
+          uv pip install -r requirements/requirements-all-dev.txt
+          uv pip install -e '.[all, dev]'
 
       - name: Run pre-commit
         working-directory: ./pydatalab
         run: |
-          pipenv run pre-commit run --all-files --show-diff-on-failure
+          source .venv/bin/activate
+          pre-commit run --all-files --show-diff-on-failure
 
   pytest:
     name: Run Python unit tests
@@ -72,20 +74,21 @@ jobs:
         run: |
           wget https://fastdl.mongodb.org/tools/db/mongodb-database-tools-ubuntu2204-x86_64-100.9.0.deb && sudo apt install ./mongodb-database-tools-*-100.9.0.deb
 
-      - name: Install latest compatible versions of immediate dependencies
+      - name: Set up uv (latest)
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Install locked versions of dependencies
         working-directory: ./pydatalab
         run: |
-          python -m pip install --upgrade pip
-          pip install -U setuptools
-          pip install pipenv
-          pipenv sync --dev
-          pipenv run pip install -e .
-          pipenv graph
+          uv venv
+          uv pip install -r requirements/requirements-all-dev.txt
+          uv pip install -e '.[all, dev]'
 
       - name: Run all tests
         working-directory: ./pydatalab
         run: |
-          pipenv run pytest -rs -vvv --cov-report=term --cov-report=xml --cov ./pydatalab ./tests
+          source .venv/bin/activate
+          pytest -rs -vvv --cov-report=term --cov-report=xml --cov ./pydatalab ./tests
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.10' && github.repository == 'datalab-org/datalab'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,6 @@ repos:
         name: Regenerate item model JSONSchemas
         files: "^pydatalab/pydatalab/models/.*.$"
         description: Check if the current code changes have enacted changes to the resulting JSONSchemas
-        entry: bash -c "PIPENV_PIPFILE=pydatalab/Pipfile pipenv run invoke -r pydatalab dev.generate-schemas"
+        entry: invoke -r pydatalab dev.generate-schemas
         pass_filenames: false
         language: system


### PR DESCRIPTION
This should be the final step following #582, which strips pipenv from the CI.

We could consider adding a new job that also ensures the pipenv lock is consistent, but this can easily be done manually for now (and is tested indirectly by the `api_dev` docker build which uses `pipenv` for this reason).