### PR TITLE
Attempt to configure lockfile-only dependabot strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,25 @@
 version: 2
 updates:
+# Update rule for lockfiles only: will bump requirements within the
+# compatible versions found in pyproject.toml
+- package-ecosystem: pip
+  directory: "./pydatalab"
+  schedule:
+    interval: monthly
+    day: monday
+    time: "05:43"
+  # Needs to be larger than the number of total requirements (currently 31)
+  open-pull-requests-limit: 50
+  target-branch: main
+  labels:
+  - dependency_updates
+  versioning-strategy: "lockfile-only"
+  groups:
+    python-dependencies-compat:
+      applies-to: version-updates
+      dependency-type: production
+# Will make a separate PR to bump versions explicitly to the latest versions, in all cases
+# May trigger incompatibilities in many cases, in which case additional constraints may be needed here
 - package-ecosystem: pip
   directory: "./pydatalab"
   schedule:
@@ -23,10 +43,12 @@ updates:
     python-dependencies-security:
       applies-to: security-updates
       dependency-type: production
+# Updates GH actions versions as often as needed
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: weekly
+    day: monday
+    interval: monthly
     time: "05:33"
   target-branch: main
   labels:


### PR DESCRIPTION
After this PR, ideally, dependabot will keep ticking over and updating our lock files with the latest versions compatible with our pyproject.toml.

There will then be a second job that lets us know of new major incompatible versions; we can treat these on a case-by-case basis and roll the changes out ourselves, based on the dependabot PRs.

I am hoping the dependabot config is flexible enough for this, otherwise we will have to rewrite lots of the constraints from our pyproject into the dependabot config file, for now.

Dependabot groups are also magic to me, my guess is that for the `pip` ecosystem, any dependency under the extra `dev` is treated as development, and all the rest are production, but thats not entirely clear to me yet (and its not documented).