### PR TITLE
Re-attempt to use lockfile-only strategy with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,5 @@
 version: 2
 updates:
-# Update rule for lockfiles only: will bump requirements within the
-# compatible versions found in pyproject.toml
-- package-ecosystem: pip
-  directory: "./pydatalab"
-  schedule:
-    interval: monthly
-    day: monday
-    time: "05:43"
-  # Needs to be larger than the number of total requirements (currently 31)
-  open-pull-requests-limit: 50
-  target-branch: main
-  labels:
-  - dependency_updates
-  versioning-strategy: "lockfile-only"
-  groups:
-    python-dependencies-compat:
-      applies-to: version-updates
-      dependency-type: production
-# Will make a separate PR to bump versions explicitly to the latest versions, in all cases
-# May trigger incompatibilities in many cases, in which case additional constraints may be needed here
 - package-ecosystem: pip
   directory: "./pydatalab"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,38 +1,15 @@
 version: 2
 updates:
-# Update rule for lockfiles only: will bump requirements within the
-# compatible versions found in pyproject.toml
 - package-ecosystem: pip
   directory: "./pydatalab"
   schedule:
     interval: monthly
     day: monday
     time: "05:43"
-  # Needs to be larger than the number of total requirements (currently 31)
-  open-pull-requests-limit: 50
   target-branch: main
+  versoining-strategy: lockfile-only
   labels:
   - dependency_updates
-  versioning-strategy: "lockfile-only"
-  groups:
-    python-dependencies-compat:
-      applies-to: version-updates
-      dependency-type: production
-# Will make a separate PR to bump versions explicitly to the latest versions, in all cases
-# May trigger incompatibilities in many cases, in which case additional constraints may be needed here
-- package-ecosystem: pip
-  directory: "./pydatalab"
-  schedule:
-    interval: monthly
-    day: monday
-    time: "05:43"
-  # Needs to be larger than the number of total requirements (currently 31)
-  open-pull-requests-limit: 50
-  target-branch: main
-  labels:
-  - dependency_updates
-  # Turn off automatic rebases so that auto-merge can work without needed N**2 CI runs
-  rebase-strategy: "disabled"
   groups:
     python-dependencies:
       applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     day: monday
     time: "05:43"
   target-branch: main
-  versoining-strategy: lockfile-only
+  versioning-strategy: lockfile-only
   labels:
   - dependency_updates
   groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,25 @@
 version: 2
 updates:
+# Update rule for lockfiles only: will bump requirements within the
+# compatible versions found in pyproject.toml
+- package-ecosystem: pip
+  directory: "./pydatalab"
+  schedule:
+    interval: monthly
+    day: monday
+    time: "05:43"
+  # Needs to be larger than the number of total requirements (currently 31)
+  open-pull-requests-limit: 50
+  target-branch: main
+  labels:
+  - dependency_updates
+  versioning-strategy: "lockfile-only"
+  groups:
+    python-dependencies-compat:
+      applies-to: version-updates
+      dependency-type: production
+# Will make a separate PR to bump versions explicitly to the latest versions, in all cases
+# May trigger incompatibilities in many cases, in which case additional constraints may be needed here
 - package-ecosystem: pip
   directory: "./pydatalab"
   schedule:
@@ -23,10 +43,12 @@ updates:
     python-dependencies-security:
       applies-to: security-updates
       dependency-type: production
+# Updates GH actions versions as often as needed
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: weekly
+    day: monday
+    interval: monthly
     time: "05:33"
   target-branch: main
   labels:


### PR DESCRIPTION
It seems that this is still slightly in flux, and we are unable to use multiple workflows per packaging ecosystem. This PR mostly undoes #853 and switches to purely lockfile only updates, avoiding the need for us to pin so heavily in the dependabot config file.