### PR TITLE
Use node v20 in build, CI and dev environments

### DIFF
--- a/.docker/app_dockerfile
+++ b/.docker/app_dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:experimental
-FROM node:16-bullseye as base
+FROM node:20-bullseye as base
 SHELL ["/bin/bash", "--login", "-c"]
 
 WORKDIR /app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         env:
           FORCE_COLOR: 0
         with:
-          node-version: "16.15.0"
+          node-version: "20"
           cache: "yarn"
           cache-dependency-path: ./webapp/yarn.lock
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 default_language_version:
   python: python3.10
-  node: 16.14.2
+  node: "20.17.0"
 
 ci:
   skip:


### PR DESCRIPTION
Some deps now need node v20+, which we have always recommended anyway. This PR updates our docker, CI and dev envs to use node 20.