### PR TITLE
Close database ports by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,8 +96,6 @@ services:
     restart: unless-stopped
     networks:
       - backend
-    ports:
-      - "27017:27017"
 
 networks:
   backend:


### PR DESCRIPTION
Changes recently introduced to make borg set up easier assumed that an external firewall was blocking 27017. This is probably not a safe assumption to make, instead lets close it by default.