### PR TITLE
Add Login Splash Screen

### DIFF
--- a/webapp/src/router/index.js
+++ b/webapp/src/router/index.js
@@ -10,12 +10,14 @@ import ExampleGraph from "@/views/ExampleGraph.vue";
 import ItemGraphPage from "@/views/ItemGraphPage.vue";
 import Admin from "@/views/Admin.vue";
 import Login from "../views/Login.vue";
-import { getUserInfo } from "@/server_fetch_utils.js";
+import Login2 from "../views/Login2.vue";
+import Login3 from "../views/Login3.vue";
+// import { getUserInfo } from "@/server_fetch_utils.js";
 
-const isAuthenticated = async () => {
-  const user = await getUserInfo();
-  return user !== null;
-};
+//const isAuthenticated = async () => {
+//  const user = await getUserInfo();
+//  return user !== null;
+//};
 
 const routes = [
   {
@@ -33,10 +35,22 @@ const routes = [
     component: Samples,
   },
   {
-    path: "/login",
+    path: "/next/login",
     name: "login",
     alias: "/",
     component: Login,
+  },
+  {
+    path: "/next/login2",
+    name: "login2",
+    alias: "/",
+    component: Login2,
+  },
+  {
+    path: "/next/login3",
+    name: "login3",
+    alias: "/",
+    component: Login3,
   },
   {
     path: "/equipment",
@@ -94,17 +108,17 @@ const router = createRouter({
   routes,
 });
 
-router.beforeEach(async (to, from, next) => {
-  const isPublicRoute = to.name === "login" || to.name === "About";
-  const authenticated = await isAuthenticated();
-
-  if (isPublicRoute && authenticated) {
-    next({ name: "samples" });
-  } else if (!isPublicRoute && !authenticated) {
-    next({ name: "login" });
-  } else {
-    next();
-  }
-});
+//router.beforeEach(async (to, from, next) => {
+//  const isPublicRoute = to.name === "login" || to.name === "About";
+//  const authenticated = await isAuthenticated();
+//
+//  if (isPublicRoute && authenticated) {
+//    next({ name: "samples" });
+//  } else if (!isPublicRoute && !authenticated) {
+//    next({ name: "login" });
+//  } else {
+//    next();
+//  }
+//});
 
 export default router;

--- a/webapp/src/router/index.js
+++ b/webapp/src/router/index.js
@@ -9,6 +9,13 @@ import CollectionPage from "../views/CollectionPage.vue";
 import ExampleGraph from "@/views/ExampleGraph.vue";
 import ItemGraphPage from "@/views/ItemGraphPage.vue";
 import Admin from "@/views/Admin.vue";
+import Login from "../views/Login.vue";
+import { getUserInfo } from "@/server_fetch_utils.js";
+
+const isAuthenticated = async () => {
+  const user = await getUserInfo();
+  return user !== null;
+};
 
 const routes = [
   {
@@ -24,6 +31,12 @@ const routes = [
     name: "samples",
     alias: "/",
     component: Samples,
+  },
+  {
+    path: "/login",
+    name: "login",
+    alias: "/",
+    component: Login,
   },
   {
     path: "/equipment",
@@ -79,6 +92,19 @@ const routes = [
 const router = createRouter({
   history: createWebHistory(process.env.BASE_URL),
   routes,
+});
+
+router.beforeEach(async (to, from, next) => {
+  const isPublicRoute = to.name === "login" || to.name === "About";
+  const authenticated = await isAuthenticated();
+
+  if (isPublicRoute && authenticated) {
+    next({ name: "samples" });
+  } else if (!isPublicRoute && !authenticated) {
+    next({ name: "login" });
+  } else {
+    next();
+  }
 });
 
 export default router;

--- a/webapp/src/views/Login.vue
+++ b/webapp/src/views/Login.vue
@@ -1,0 +1,175 @@
+<template>
+  <div class="login-container">
+    <div class="welcome-section">
+      <h1 style="font-size: 4rem">Welcome to Datalab</h1>
+      <p>datalab is a place to store experimental data and the connections between them.</p>
+      <p>
+        datalab is open source (MIT license) and development occurs on GitHub at
+        <a href="https://github.com/datalab-org/datalab"
+          ><font-awesome-icon :icon="['fab', 'github']" />&nbsp;datalab-org/datalab</a
+        >
+        with documentation available on
+        <a href="https://the-datalab.readthedocs.io"
+          ><font-awesome-icon icon="book" />&nbsp;ReadTheDocs</a
+        >.
+      </p>
+      <router-link to="/about" class="btn btn-default">Learn More</router-link>
+    </div>
+
+    <div class="login-options">
+      <div
+        v-if="logo_url != null"
+        class="pt-3 logo-container"
+        style="display: flex; justify-content: center; align-items: center"
+      >
+        <a
+          v-if="homepage_url != null"
+          :href="homepage_url"
+          style="display: inline-block"
+          target="_blank"
+        >
+          <img class="logo-banner" :src="logo_url" />
+        </a>
+        <img v-else class="logo-banner" :src="logo_url" />
+      </div>
+
+      <!-- <pre style="white-space: pre-wrap">{{ ASCII }}</pre> -->
+      <div class="login-button">
+        <a
+          type="button"
+          :class="{ disabled: !showGitHub }"
+          class="btn btn-default btn-login p-3"
+          aria-label="Login via GitHub"
+          :href="apiUrl + '/login/github'"
+        >
+          <font-awesome-icon :icon="['fab', 'github']" /> Login via GitHub
+        </a>
+        <a
+          type="button"
+          :class="{ disabled: !showORCID }"
+          class="btn btn-default btn-login p-3"
+          aria-label="Login via ORCID"
+          :href="apiUrl + '/login/orcid'"
+        >
+          <font-awesome-icon class="orcid-icon" :icon="['fab', 'orcid']" /> Login via ORCID
+        </a>
+        <a
+          type="button"
+          :class="{ disabled: !showEmail }"
+          class="btn btn-default btn-login p-3"
+          aria-label="Login via email"
+          @click="emailModalIsOpen = true"
+        >
+          <font-awesome-icon :icon="['fa', 'envelope']" /> Login via email
+        </a>
+      </div>
+    </div>
+  </div>
+  <GetEmailModal v-model="emailModalIsOpen" />
+</template>
+
+<script>
+import GetEmailModal from "@/components/GetEmailModal.vue";
+import { getInfo } from "@/server_fetch_utils.js";
+import { API_URL, LOGO_URL, HOMEPAGE_URL } from "@/resources.js";
+
+export default {
+  components: {
+    GetEmailModal,
+  },
+  data() {
+    return {
+      emailModalIsOpen: false,
+      apiUrl: API_URL,
+      logo_url: LOGO_URL,
+      homepage_url: HOMEPAGE_URL,
+      ASCII: `
+              oooo              o8              o888             oooo
+           ooooo888    ooooooo o888oo  ooooooo    888   ooooooo    888ooooo
+         888    888    ooooo888 888    ooooo888   888   ooooo888   888    888
+         888    888  888    888 888  888    888   888 888    888   888    888
+           88ooo888o  88ooo88 8o 888o 88ooo88 8o o888o 88ooo88 8o o888ooo88
+      `,
+    };
+  },
+  computed: {
+    showGitHub() {
+      return this.$store.state.serverInfo?.features?.auth_mechanisms?.github ?? false;
+    },
+    showORCID() {
+      return this.$store.state.serverInfo?.features?.auth_mechanisms?.orcid ?? false;
+    },
+    showEmail() {
+      return this.$store.state.serverInfo?.features?.auth_mechanisms?.email ?? false;
+    },
+  },
+  async mounted() {
+    getInfo();
+  },
+};
+</script>
+
+<style scoped>
+.login-container {
+  display: flex;
+  flex-direction: row;
+  height: 100vh;
+}
+
+.welcome-section {
+  flex: 1;
+  gap: 1.5em;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+  align-items: center;
+  background-color: lightblue;
+}
+
+.login-options {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 2rem;
+}
+
+.login-button {
+  display: flex;
+  flex-direction: column;
+  width: 50%;
+  gap: 2em;
+}
+
+.logo-container {
+  position: fixed;
+  top: 0;
+}
+
+.logo-banner {
+  max-width: 200px;
+  width: 100px;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  filter: alpha(opacity=100);
+  opacity: 1;
+}
+
+.btn-login {
+  font-size: 1.3rem;
+}
+
+a > .logo-banner:hover {
+  filter: alpha(opacity=40);
+  opacity: 0.4;
+}
+
+.orcid-icon {
+  color: #a6ce39;
+}
+</style>

--- a/webapp/src/views/Login2.vue
+++ b/webapp/src/views/Login2.vue
@@ -1,0 +1,178 @@
+<template>
+  <div class="login-container">
+    <div
+      v-if="logo_url != null"
+      class="pt-3 logo-container"
+      style="display: flex; justify-content: center; align-items: center"
+    >
+      <a
+        v-if="homepage_url != null"
+        :href="homepage_url"
+        style="display: inline-block"
+        target="_blank"
+      >
+        <img class="logo-banner" :src="logo_url" />
+      </a>
+      <img v-else class="logo-banner" :src="logo_url" />
+    </div>
+    <div class="login-box">
+      <div class="ascii-section">
+        <pre style="color: green; white-space: pre-wrap">{{ ASCII }}</pre>
+      </div>
+      <p class="description">
+        Welcome to Datalab - Your place to store experimental data and the connections between them.
+      </p>
+      <div class="login-buttons">
+        <a
+          type="button"
+          :class="{ disabled: !showGitHub }"
+          class="btn btn-default btn-login pt-3"
+          aria-label="Login via GitHub"
+          :href="apiUrl + '/login/github'"
+        >
+          <font-awesome-icon :icon="['fab', 'github']" /> Login via GitHub
+        </a>
+        <a
+          type="button"
+          :class="{ disabled: !showORCID }"
+          class="btn btn-default btn-login pt-3"
+          aria-label="Login via ORCID"
+          :href="apiUrl + '/login/orcid'"
+        >
+          <font-awesome-icon class="orcid-icon" :icon="['fab', 'orcid']" /> Login via ORCID
+        </a>
+        <a
+          type="button"
+          :class="{ disabled: !showEmail }"
+          class="btn btn-default btn-login pt-3"
+          aria-label="Login via email"
+          @click="emailModalIsOpen = true"
+        >
+          <font-awesome-icon :icon="['fa', 'envelope']" /> Login via email
+        </a>
+      </div>
+    </div>
+  </div>
+  <GetEmailModal v-model="emailModalIsOpen" />
+</template>
+
+<script>
+import GetEmailModal from "@/components/GetEmailModal.vue";
+import { getInfo } from "@/server_fetch_utils.js";
+import { API_URL, LOGO_URL, HOMEPAGE_URL } from "@/resources.js";
+
+export default {
+  components: {
+    GetEmailModal,
+  },
+  data() {
+    return {
+      emailModalIsOpen: false,
+      apiUrl: API_URL,
+      logo_url: LOGO_URL,
+      homepage_url: HOMEPAGE_URL,
+      ASCII: `
+              oooo              o8              o888             oooo
+           ooooo888    ooooooo o888oo  ooooooo    888   ooooooo    888ooooo
+         888    888    ooooo888 888    ooooo888   888   ooooo888   888    888
+         888    888  888    888 888  888    888   888 888    888   888    888
+           88ooo888o  88ooo88 8o 888o 88ooo88 8o o888o 88ooo88 8o o888ooo88
+      `,
+    };
+  },
+  computed: {
+    showGitHub() {
+      return this.$store.state.serverInfo?.features?.auth_mechanisms?.github ?? false;
+    },
+    showORCID() {
+      return this.$store.state.serverInfo?.features?.auth_mechanisms?.orcid ?? false;
+    },
+    showEmail() {
+      return this.$store.state.serverInfo?.features?.auth_mechanisms?.email ?? false;
+    },
+  },
+  async mounted() {
+    getInfo();
+  },
+};
+</script>
+
+<style scoped>
+.login-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+}
+
+.logo-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+}
+
+.ascii-section {
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  white-space: pre-wrap;
+  font-family: monospace;
+  width: 100%;
+  animation: fadeIn 3s ease-in;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.logo-banner {
+  max-width: 200px;
+  width: 100px;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  filter: alpha(opacity=100);
+  opacity: 1;
+}
+
+.login-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+}
+
+.btn-login {
+  font-size: 1.3rem;
+  width: 20%;
+  text-align: center;
+}
+
+.orcid-icon {
+  color: #a6ce39;
+}
+
+.description {
+  font-size: 1.2rem;
+  color: black;
+  text-align: center;
+  margin-top: 1rem;
+}
+
+.login-box {
+  padding: 5rem;
+  border-radius: 15px;
+  border: 1px solid lightgray;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
+  text-align: center;
+  width: 100%;
+  max-width: 75%;
+}
+</style>

--- a/webapp/src/views/Login3.vue
+++ b/webapp/src/views/Login3.vue
@@ -1,0 +1,194 @@
+<template>
+  <div class="login-container">
+    <div class="background-animation"></div>
+
+    <div
+      v-if="logo_url != null"
+      class="pt-3 logo-container"
+      style="display: flex; justify-content: center; align-items: center"
+    >
+      <a
+        v-if="homepage_url != null"
+        :href="homepage_url"
+        style="display: inline-block"
+        target="_blank"
+      >
+        <img class="logo-banner" :src="logo_url" />
+      </a>
+      <img v-else class="logo-banner" :src="logo_url" />
+    </div>
+
+    <div class="login-box">
+      <h1>Welcome to Datalab</h1>
+      <p class="description">Choose your preferred login method to get started.</p>
+
+      <div class="login-cards">
+        <a
+          type="button"
+          :class="{ disabled: !showGitHub }"
+          class="btn btn-default btn-login p-3"
+          aria-label="Login via GitHub"
+          :href="apiUrl + '/login/github'"
+        >
+          <font-awesome-icon :icon="['fab', 'github']" /> Login via GitHub
+        </a>
+        <a
+          type="button"
+          :class="{ disabled: !showORCID }"
+          class="btn btn-default btn-login p-3"
+          aria-label="Login via ORCID"
+          :href="apiUrl + '/login/orcid'"
+        >
+          <font-awesome-icon class="orcid-icon" :icon="['fab', 'orcid']" /> Login via ORCID
+        </a>
+        <a
+          type="button"
+          :class="{ disabled: !showEmail }"
+          class="btn btn-default btn-login p-3"
+          aria-label="Login via email"
+          @click="emailModalIsOpen = true"
+        >
+          <font-awesome-icon :icon="['fa', 'envelope']" /> Login via email
+        </a>
+      </div>
+    </div>
+
+    <GetEmailModal v-model="emailModalIsOpen" />
+  </div>
+</template>
+
+<script>
+import GetEmailModal from "@/components/GetEmailModal.vue";
+import { API_URL, LOGO_URL } from "@/resources.js";
+
+export default {
+  components: {
+    GetEmailModal,
+  },
+  data() {
+    return {
+      emailModalIsOpen: false,
+      apiUrl: API_URL,
+      logo_url: LOGO_URL,
+      hoverGitHub: false,
+      hoverORCID: false,
+    };
+  },
+  computed: {
+    showGitHub() {
+      return this.$store.state.serverInfo?.features?.auth_mechanisms?.github ?? false;
+    },
+    showORCID() {
+      return this.$store.state.serverInfo?.features?.auth_mechanisms?.orcid ?? false;
+    },
+    showEmail() {
+      return this.$store.state.serverInfo?.features?.auth_mechanisms?.email ?? false;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.login-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(135deg, #6e45e2, #88d3ce);
+}
+
+.background-animation {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(45deg, #6e45e2, #88d3ce);
+  animation: gradientShift 10s ease infinite;
+  z-index: -1;
+}
+
+@keyframes gradientShift {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+.logo-container {
+  position: fixed;
+  top: 0;
+  text-align: center;
+  overflow: hidden;
+  background: white;
+  border-radius: 15px;
+  border: 1px solid lightgray;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
+  padding-left: 1em;
+  padding-right: 1em;
+  margin-top: 1em;
+}
+
+.logo-banner {
+  max-width: 150px;
+  background: transparent !important;
+}
+
+.login-box {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.description {
+  font-size: 1.5rem;
+  color: white;
+  margin-bottom: 2rem;
+}
+
+.login-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+}
+
+.login-card {
+  width: 200px;
+  padding: 1.5rem;
+  border-radius: 15px;
+  background: rgba(255, 255, 255, 0.1);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.5);
+  text-align: center;
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
+  cursor: pointer;
+}
+
+.login-card:hover {
+  transform: translateY(-10px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.6);
+}
+
+.login-card a {
+  display: block;
+  margin-top: 1rem;
+  font-size: 1rem;
+  color: white;
+  text-decoration: none;
+}
+
+.orcid-icon {
+  color: #a6ce39;
+}
+
+h1 {
+  font-size: 5em;
+}
+</style>


### PR DESCRIPTION
Closes #767 

- Login splash screen that displays the login options (GitHub, ORCID, and email)
- Updated route handling to redirect unauthenticated users to the /login page, with the exception of the /about page, which remains accessible without authentication.