### PR TITLE
Exclude pydantic from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
   target-branch: main
   labels:
   - dependency_updates
+  ignore:
+    - dependency-name: "pydantic"
+      versions: [ ">=2" ]
   groups:
     python-dependencies:
       applies-to: version-updates


### PR DESCRIPTION
c.f. #864 and #848 -- this PR excludes pydantic from the dependabot config so that other compatible deps can update without issue.