### PR TITLE
Rearrange dependencies and update navani

### DIFF
--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -18,8 +18,14 @@ classifiers = [
 requires-python = ">= 3.10, < 3.12"
 
 dependencies = [
+    "bokeh ~= 2.4, < 3.0",
+    "matplotlib ~= 3.8",
     # Slightly confusing, but git dependencies cannot be included as extra by uv at the moment
     "navani @ git+https://github.com/the-grey-group/navani.git@v0.1.5",
+    "periodictable ~= 1.7",
+    "pydantic[email, dotenv] < 2.0",
+    "pint ~= 0.24",
+    "pandas[excel] ~= 2.2",
 ]
 
 [project.urls]
@@ -55,9 +61,7 @@ dev = [
 ]
 
 server = [
-    "pydantic[email, dotenv] < 2.0",
     "pymongo ~= 4.7",
-    "bokeh ~= 2.4, < 3.0",
     "Flask ~= 3.0",
     "Flask-Login ~= 0.6",
     "Flask-Cors ~= 5.0",
@@ -66,11 +70,7 @@ server = [
     "Flask-Mail ~= 0.10",
     "Flask-Compress ~= 1.15",
     "Werkzeug ~= 3.0",
-    "pandas[excel] ~= 2.2",
-    "matplotlib ~= 3.8",
     "python-dotenv ~= 1.0",
-    "pint ~= 0.24",
-    "periodictable ~= 1.7",
     "pillow ~= 10.4",
     "pyjwt ~= 2.9",
     "invoke ~= 2.2",

--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -20,8 +20,6 @@ requires-python = ">= 3.10, < 3.12"
 dependencies = [
     "bokeh ~= 2.4, < 3.0",
     "matplotlib ~= 3.8",
-    # Slightly confusing, but git dependencies cannot be included as extra by uv at the moment
-    "navani @ git+https://github.com/the-grey-group/navani.git@v0.1.5",
     "periodictable ~= 1.7",
     "pydantic[email, dotenv] < 2.0",
     "pint ~= 0.24",
@@ -83,6 +81,7 @@ apps = [
     # NMR
     "nmrglue ~= 0.10",
     # Electrochemistry
+    "navani @ git+https://github.com/the-grey-group/navani.git@v0.1.7",
     "galvani ~= 0.4, < 0.5",
     "NewareNDA >= 2024",
     # Raman

--- a/pydatalab/requirements/requirements-all-dev.txt
+++ b/pydatalab/requirements/requirements-all-dev.txt
@@ -260,7 +260,7 @@ multidict==6.1.0
     #   yarl
 natsort==8.4.0
     # via mkdocs-awesome-pages-plugin
-navani @ git+https://github.com/the-grey-group/navani.git@32aa742c3b84aa63fb4e3bd7b1824acb89e2b61d
+navani @ git+https://github.com/the-grey-group/navani.git@d171781b483f0a17a0ada7a043c8f1e243499245
     # via datalab-server (pyproject.toml)
 newarenda==2024.10.1
     # via

--- a/pydatalab/requirements/requirements-all.txt
+++ b/pydatalab/requirements/requirements-all.txt
@@ -191,7 +191,7 @@ multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-navani @ git+https://github.com/the-grey-group/navani.git@32aa742c3b84aa63fb4e3bd7b1824acb89e2b61d
+navani @ git+https://github.com/the-grey-group/navani.git@d171781b483f0a17a0ada7a043c8f1e243499245
     # via datalab-server (pyproject.toml)
 newarenda==2024.10.1
     # via

--- a/pydatalab/uv.lock
+++ b/pydatalab/uv.lock
@@ -662,12 +662,11 @@ array = [
 
 [[package]]
 name = "datalab-server"
-version = "0.5.0rc5.dev49+gce95aea.d20241007"
+version = "0.5.0rc5.dev49+gc73904f.d20241007"
 source = { editable = "." }
 dependencies = [
     { name = "bokeh" },
     { name = "matplotlib" },
-    { name = "navani" },
     { name = "pandas", extra = ["excel"] },
     { name = "periodictable" },
     { name = "pint" },
@@ -688,6 +687,7 @@ all = [
     { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-openai" },
+    { name = "navani" },
     { name = "newarenda" },
     { name = "nmrglue" },
     { name = "paramiko" },
@@ -705,6 +705,7 @@ all = [
 ]
 apps = [
     { name = "galvani" },
+    { name = "navani" },
     { name = "newarenda" },
     { name = "nmrglue" },
     { name = "pybaselines" },
@@ -769,7 +770,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = "~=9.5" },
     { name = "mkdocstrings", extras = ["python-legacy"], marker = "extra == 'dev'", specifier = "~=0.25" },
     { name = "mongomock", marker = "extra == 'dev'", specifier = "~=4.1" },
-    { name = "navani", git = "https://github.com/the-grey-group/navani.git?rev=v0.1.5" },
+    { name = "navani", marker = "extra == 'apps'", git = "https://github.com/the-grey-group/navani.git?rev=v0.1.7" },
     { name = "newarenda", marker = "extra == 'apps'", specifier = ">=2024" },
     { name = "nmrglue", marker = "extra == 'apps'", specifier = "~=0.10" },
     { name = "pandas", extras = ["excel"], specifier = "~=2.2" },
@@ -1880,7 +1881,7 @@ wheels = [
 [[package]]
 name = "navani"
 version = "0.1.5"
-source = { git = "https://github.com/the-grey-group/navani.git?rev=v0.1.5#32aa742c3b84aa63fb4e3bd7b1824acb89e2b61d" }
+source = { git = "https://github.com/the-grey-group/navani.git?rev=v0.1.7#d171781b483f0a17a0ada7a043c8f1e243499245" }
 dependencies = [
     { name = "galvani" },
     { name = "matplotlib" },

--- a/pydatalab/uv.lock
+++ b/pydatalab/uv.lock
@@ -662,15 +662,20 @@ array = [
 
 [[package]]
 name = "datalab-server"
-version = "0.5.0rc5.dev33+g788a185.d20241001"
+version = "0.5.0rc5.dev49+gce95aea.d20241007"
 source = { editable = "." }
 dependencies = [
+    { name = "bokeh" },
+    { name = "matplotlib" },
     { name = "navani" },
+    { name = "pandas", extra = ["excel"] },
+    { name = "periodictable" },
+    { name = "pint" },
+    { name = "pydantic", extra = ["dotenv", "email"] },
 ]
 
 [package.optional-dependencies]
 all = [
-    { name = "bokeh" },
     { name = "flask" },
     { name = "flask-compress" },
     { name = "flask-cors" },
@@ -683,16 +688,11 @@ all = [
     { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-openai" },
-    { name = "matplotlib" },
     { name = "newarenda" },
     { name = "nmrglue" },
-    { name = "pandas", extra = ["excel"] },
     { name = "paramiko" },
-    { name = "periodictable" },
     { name = "pillow" },
-    { name = "pint" },
     { name = "pybaselines" },
-    { name = "pydantic", extra = ["dotenv", "email"] },
     { name = "pyjwt" },
     { name = "pymongo" },
     { name = "python-dateutil" },
@@ -731,7 +731,6 @@ dev = [
     { name = "pytest-dependency" },
 ]
 server = [
-    { name = "bokeh" },
     { name = "flask" },
     { name = "flask-compress" },
     { name = "flask-cors" },
@@ -740,13 +739,8 @@ server = [
     { name = "flask-mail" },
     { name = "flask-pymongo" },
     { name = "invoke" },
-    { name = "matplotlib" },
-    { name = "pandas", extra = ["excel"] },
     { name = "paramiko" },
-    { name = "periodictable" },
     { name = "pillow" },
-    { name = "pint" },
-    { name = "pydantic", extra = ["dotenv", "email"] },
     { name = "pyjwt" },
     { name = "pymongo" },
     { name = "python-dotenv" },
@@ -755,7 +749,7 @@ server = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bokeh", marker = "extra == 'server'", specifier = "~=2.4,<3.0" },
+    { name = "bokeh", specifier = "~=2.4,<3.0" },
     { name = "datalab-server", extras = ["apps", "chat", "server"], marker = "extra == 'all'" },
     { name = "flask", marker = "extra == 'server'", specifier = "~=3.0" },
     { name = "flask-compress", marker = "extra == 'server'", specifier = "~=1.15" },
@@ -769,7 +763,7 @@ requires-dist = [
     { name = "langchain", marker = "extra == 'chat'", specifier = "==0.2.6" },
     { name = "langchain-anthropic", marker = "extra == 'chat'", specifier = "~=0.1" },
     { name = "langchain-openai", marker = "extra == 'chat'", specifier = "~=0.1" },
-    { name = "matplotlib", marker = "extra == 'server'", specifier = "~=3.8" },
+    { name = "matplotlib", specifier = "~=3.8" },
     { name = "mkdocs", marker = "extra == 'dev'", specifier = "~=1.6" },
     { name = "mkdocs-awesome-pages-plugin", marker = "extra == 'dev'", specifier = "~=2.9" },
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = "~=9.5" },
@@ -778,14 +772,14 @@ requires-dist = [
     { name = "navani", git = "https://github.com/the-grey-group/navani.git?rev=v0.1.5" },
     { name = "newarenda", marker = "extra == 'apps'", specifier = ">=2024" },
     { name = "nmrglue", marker = "extra == 'apps'", specifier = "~=0.10" },
-    { name = "pandas", extras = ["excel"], marker = "extra == 'server'", specifier = "~=2.2" },
+    { name = "pandas", extras = ["excel"], specifier = "~=2.2" },
     { name = "paramiko", marker = "extra == 'server'", specifier = "~=3.4" },
-    { name = "periodictable", marker = "extra == 'server'", specifier = "~=1.7" },
+    { name = "periodictable", specifier = "~=1.7" },
     { name = "pillow", marker = "extra == 'server'", specifier = "~=10.4" },
-    { name = "pint", marker = "extra == 'server'", specifier = "~=0.24" },
+    { name = "pint", specifier = "~=0.24" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "~=3.7" },
     { name = "pybaselines", marker = "extra == 'apps'", specifier = "~=1.1" },
-    { name = "pydantic", extras = ["dotenv", "email"], marker = "extra == 'server'", specifier = "<2.0" },
+    { name = "pydantic", extras = ["dotenv", "email"], specifier = "<2.0" },
     { name = "pyjwt", marker = "extra == 'server'", specifier = "~=2.9" },
     { name = "pymongo", marker = "extra == 'server'", specifier = "~=4.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "~=8.2" },


### PR DESCRIPTION
This PR moves more deps to 'core', which was previously unused. I think this may help dependabot figure out which deps need to be installed alongside each other.

This PR also updates navani to 0.1.7, which includes important fixes for Neware.