### PR TITLE
Re-enable lockfile only mode of dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
   target-branch: main
   labels:
   - dependency_updates
+  versioning-strategy: lockfile-only
   ignore:
     - dependency-name: "pydantic"
       versions: [ ">=2" ]


### PR DESCRIPTION
Dependabot simply can't cope with our repo and fails to even attempt to obey any versioning constraints. This PR re-enables lockfile only mode, which should at least explicitly ignore versions not allowed by `pyproject.toml` rules.

Probably once we have fully migrated we should roll our own scheduled `uv lock -U` action for our Python deps, and leave dependabot for security updates in npm only, or wait for better explicit `uv` support in dependabot (https://github.com/dependabot/dependabot-core/issues/10478)