### PR TITLE
Install datalab as editable inside docker build to make env passing simpler

### DIFF
--- a/.docker/server_dockerfile
+++ b/.docker/server_dockerfile
@@ -32,7 +32,8 @@ WORKDIR /app
 # Install the local version of the package and mount the repository data to get version info
 COPY ./pydatalab/ ./
 RUN git config --global --add safe.directory /
-RUN --mount=type=bind,target=/.git,source=./.git uv pip install --python /opt/.venv/bin/python --no-deps .
+# Install editable mode so that the server runs from a sensible place where we can stuff .env files
+RUN --mount=type=bind,target=/.git,source=./.git uv pip install --python /opt/.venv/bin/python --no-deps --editable .
 
 # This will define the number of gunicorn workers
 ARG WEB_CONCURRENCY=4


### PR DESCRIPTION
In #914 we switched to a non-editable install inside the docker containers, which means that datalab runs from the installed module (`/opt/.venv/lib/python3.10/site-packages/...` etc), but the dotenv loader only looks in that folder and above (rather than the datalab source folder).

Long term, 
- [ ] We should add a way to specify where the .env file is as a config (and error if it is missing)

but short-term, we can just got back to an editable install (makes no difference inside the container) so that the current deployment `.env` path is still found.