### PR TITLE
Set up custom primevue theme

### DIFF
--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -236,6 +236,15 @@ export default {
 
       if (event.originalEvent.target.classList.contains("checkbox")) {
         return null;
+      } else if (event.originalEvent.target.classList.contains("p-checkbox-input")) {
+        const selectedIndex = this.itemsSelected.findIndex((item) => item.item_id === row.item_id);
+
+        if (selectedIndex === -1) {
+          this.itemsSelected.push(row);
+        } else {
+          this.itemsSelected.splice(selectedIndex, 1);
+        }
+        return null;
       }
 
       if (
@@ -314,7 +323,11 @@ export default {
         return false;
       }
       return visibleItems.every((currentItem) =>
-        this.itemsSelected.some((selectedItem) => selectedItem.item_id === currentItem.item_id),
+        this.itemsSelected.some(
+          (selectedItem) =>
+            (selectedItem.item_id || selectedItem.collection_id) ===
+            (currentItem.item_id || currentItem.collection_id),
+        ),
       );
     },
     onFilter(event) {
@@ -326,15 +339,21 @@ export default {
       const itemsToSelect = this.getVisibleItems();
 
       if (this.allSelected) {
-        const selectedIds = new Set(this.itemsSelected.map((item) => item.item_id));
+        const selectedIds = new Set(
+          this.itemsSelected.map((item) => item.item_id || item.collection_id),
+        );
         itemsToSelect.forEach((item) => {
-          if (!selectedIds.has(item.item_id)) {
+          if (!selectedIds.has(item.item_id || item.collection_id)) {
             this.itemsSelected.push(item);
           }
         });
       } else {
-        const idsToRemove = new Set(itemsToSelect.map((item) => item.item_id));
-        this.itemsSelected = this.itemsSelected.filter((item) => !idsToRemove.has(item.item_id));
+        const idsToRemove = new Set(
+          itemsToSelect.map((item) => item.item_id || item.collection_id),
+        );
+        this.itemsSelected = this.itemsSelected.filter(
+          (item) => !idsToRemove.has(item.item_id || item.collection_id),
+        );
       }
     },
     deleteSelectedItems() {
@@ -351,38 +370,3 @@ export default {
   },
 };
 </script>
-
-<style scoped>
-.customize-table .ag-header {
-  font-size: 1rem;
-}
-
-.p-datatable-column-header-content .p-datatable-sort-icon {
-  visibility: hidden !important;
-}
-.p-datatable-column-header-content:hover .p-datatable-sort-icon {
-  visibility: visible !important;
-}
-
-.p-datatable .p-datatable-tbody > tr > td {
-  min-width: 1em;
-  max-width: 200px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.p-datatable .p-datatable-thead > tr > th {
-  min-width: 1em;
-  max-width: 200px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.p-datatable-header-cell.filter-active svg {
-  color: #10b981;
-}
-.p-datatable-header-cell.filter-active {
-  color: #047857;
-}
-</style>

--- a/webapp/src/main.js
+++ b/webapp/src/main.js
@@ -118,7 +118,7 @@ import "vue-select/dist/vue-select.css";
 
 // import "primevue";
 import PrimeVue from "primevue/config";
-import Aura from "@primevue/themes/aura";
+import DatalabPreset from "./primevue-theme-preset.js";
 
 const app = createApp(App);
 
@@ -126,12 +126,7 @@ app
   .use(store)
   .use(router)
   .use(PrimeVue, {
-    theme: {
-      preset: Aura,
-      options: {
-        darkModeSelector: "none",
-      },
-    },
+    theme: DatalabPreset,
   })
   .component("font-awesome-icon", FontAwesomeIcon)
   .component("editor", Editor)

--- a/webapp/src/primevue-theme-preset.js
+++ b/webapp/src/primevue-theme-preset.js
@@ -1,0 +1,57 @@
+import Aura from "@primevue/themes/aura";
+import { definePreset } from "@primevue/themes";
+
+const DatalabPreset = definePreset(Aura, {
+  semantic: {
+    transitionDuration: "0.05s",
+  },
+  components: {
+    datatable: {
+      extend: {
+        filterActiveBackground: "{primary.50}",
+        filterActiveColor: "{primary.700}",
+        maxWidth: "1rem",
+        whitespace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+      },
+      bodyCellPadding: "0.4rem",
+      sortIconColor: "transparent",
+    },
+    checkbox: {
+      checkedBackground: "#fff",
+      checkedBorderColor: "#ccc",
+      iconCheckedColor: "#ccc",
+      checkedHoverBackground: "#ccc",
+      checkedHoverBorderColor: "#fff",
+      iconCheckedHoverColor: "#fff",
+    },
+    button: {
+      extend: {
+        activeSVG: "{primary.700}",
+      },
+    },
+  },
+  css: ({ dt }) => `
+        .p-datatable-thead tr th.filter-active {
+          background: ${dt("datatable.filterActiveBackground")};
+          color: ${dt("datatable.filterActiveColor")}
+        }
+        th.filter-active .p-button-text.p-button-secondary {
+          color: ${dt("datatable.activeSVG")};
+        }
+        .p-datatable-tbody tr td {
+          max-width: ${dt("datatable.maxWidth")};
+          white-space: ${dt("datatable.whitespace")};
+          overflow: ${dt("datatable.overflow")};
+          text-overflow: ${dt("datatable.textOverflow")};
+s        }
+      `,
+});
+
+export default {
+  preset: DatalabPreset,
+  options: {
+    darkModeSelector: "none",
+  },
+};

--- a/webapp/src/primevue-theme-preset.js
+++ b/webapp/src/primevue-theme-preset.js
@@ -14,17 +14,20 @@ const DatalabPreset = definePreset(Aura, {
         whitespace: "nowrap",
         overflow: "hidden",
         textOverflow: "ellipsis",
+        divCheckboxHover: "#6C757D",
+        divCheckboxCheckedHover: "#5A6268",
       },
       bodyCellPadding: "0.4rem",
       sortIconColor: "transparent",
     },
     checkbox: {
-      checkedBackground: "#fff",
-      checkedBorderColor: "#ccc",
-      iconCheckedColor: "#ccc",
-      checkedHoverBackground: "#ccc",
-      checkedHoverBorderColor: "#fff",
-      iconCheckedHoverColor: "#fff",
+      hoverBorderColor: "#6C757D",
+      checkedBackground: "#6C757D",
+      checkedBorderColor: "#6C757D",
+      iconCheckedColor: "#F8F9FA",
+      checkedHoverBackground: "#5A6268",
+      checkedHoverBorderColor: "#5A6268",
+      iconCheckedHoverColor: "#F8F9FA",
     },
     button: {
       extend: {
@@ -45,7 +48,14 @@ const DatalabPreset = definePreset(Aura, {
           white-space: ${dt("datatable.whitespace")};
           overflow: ${dt("datatable.overflow")};
           text-overflow: ${dt("datatable.textOverflow")};
-s        }
+        }
+        .checkbox:hover .p-checkbox-box {
+          border-color: ${dt("datatable.divCheckboxHover")};
+        }
+        .checkbox:hover .p-checkbox-checked .p-checkbox-box {
+          border-color: ${dt("datatable.divCheckboxCheckedHover")};
+          background: ${dt("datatable.divCheckboxCheckedHover")};
+        }
       `,
 });
 


### PR DESCRIPTION
Setting up a custom theme for primevue instead of applying global css to primevue components 

- Set transition time to 0.05s (default: 0.2s)
- Set the padding of datatable headers and cells to 0.5rem (default: offset between header and bodycell)
- Hides the sorting icon until the header is hovered
- Make the text in the cells appear on a single line (nowrap and overflow hidden)
- Make the filter icon change color when a filter is active
- Checkboxes color grey

