### PR TITLE
Ensure that new collection `immutable_id` is returned upon creation

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/collections.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/collections.py
@@ -164,7 +164,7 @@ def create_collection():
             400,
         )
 
-    immutable_id = result.inserted_id
+    data_model.immutable_id = result.inserted_id
 
     errors = []
     if starting_members:
@@ -177,7 +177,14 @@ def create_collection():
                 "item_id": {"$in": list(item_ids)},
                 **get_default_permissions(user_only=True),
             },
-            {"$push": {"relationships": {"type": "collections", "immutable_id": immutable_id}}},
+            {
+                "$push": {
+                    "relationships": {
+                        "type": "collections",
+                        "immutable_id": data_model.immutable_id,
+                    }
+                }
+            },
         )
 
         data_model.num_items = results.modified_count

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -485,12 +485,14 @@ def test_create_collections(client, default_collection):
     assert response.json["data"]["collection_id"] == "test_collection"
     assert response.json["data"]["title"] == "My Test Collection"
     assert response.json["data"]["num_items"] == 0
+    assert response.json["data"]["immutable_id"]
 
     response = client.get("/collections")
     assert response.status_code == 200
     assert len(response.json["data"]) == 1
     assert response.json["data"][0]["collection_id"] == "test_collection"
     assert response.json["data"][0]["title"] == "My Test Collection"
+    assert response.json["data"]["immutable_id"]
     assert response.status_code == 200
 
     # Create a collection with initial items

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -492,7 +492,6 @@ def test_create_collections(client, default_collection):
     assert len(response.json["data"]) == 1
     assert response.json["data"][0]["collection_id"] == "test_collection"
     assert response.json["data"][0]["title"] == "My Test Collection"
-    assert response.json["data"][0]["immutable_id"]
     assert response.status_code == 200
 
     # Create a collection with initial items

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -492,7 +492,7 @@ def test_create_collections(client, default_collection):
     assert len(response.json["data"]) == 1
     assert response.json["data"][0]["collection_id"] == "test_collection"
     assert response.json["data"][0]["title"] == "My Test Collection"
-    assert response.json["data"]["immutable_id"]
+    assert response.json["data"][0]["immutable_id"]
     assert response.status_code == 200
 
     # Create a collection with initial items


### PR DESCRIPTION
Previously, when creating a collection the `immutable_id` is returned as `None`, as we do not set the database-assigned ID back to the creation model. As collection relationships work from this ID, it is very helpful to return it, so that another request to `get_collection` does not need to be made to get the ID (see https://github.com/datalab-org/datalab-api/pull/35) for the required Python API workaround for this).