### PR TITLE
Explcitly set `OAUTHLIB_INSECURE_TRANSPORT` env var when present in `.env`

### DIFF
--- a/.docker/app_dockerfile
+++ b/.docker/app_dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:20-bullseye AS base
+FROM node:20-bullseye
 SHELL ["/bin/bash", "--login", "-c"]
 
 WORKDIR /app
@@ -10,9 +10,8 @@ COPY webapp/package.json webapp/yarn.lock ./
 
 # Using a custom node_modules location to avoid mounting it outside of docker
 RUN --mount=type=cache,target=/root/.cache/yarn yarn install --frozen-lockfile --modules-folder /node_modules
-ENV PATH=$PATH:/node_modules/.bin
 
-FROM base AS production
+ENV PATH=$PATH:/node_modules/.bin
 ENV NODE_ENV=production
 
 # These get replaced by the entrypoint script for production builds.

--- a/.docker/server_dockerfile
+++ b/.docker/server_dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.10 AS base
+FROM python:3.10
 SHELL ["/bin/bash", "--login", "-c"]
 
 # Useful for installing deps from git, preventing big downloads and bandwith quotas
@@ -11,8 +11,6 @@ RUN apt update && apt install -y gnupg curl tree mdbtools && apt clean
 # Install MongoDB tools in the official way
 WORKDIR /opt
 RUN wget https://fastdl.mongodb.org/tools/db/mongodb-database-tools-ubuntu2204-x86_64-100.9.0.deb && apt install ./mongodb-database-tools-*-100.9.0.deb
-
-FROM base AS app
 
 COPY --from=ghcr.io/astral-sh/uv:0.4 /uv /usr/local/bin/uv
 ENV UV_LINK_MODE=copy \
@@ -26,7 +24,6 @@ COPY ./pydatalab/pyproject.toml .
 COPY ./pydatalab/uv.lock .
 RUN uv sync --locked --no-dev --all-extras
 
-FROM app AS production
 WORKDIR /app
 
 # Install the local version of the package and mount the repository data to get version info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,14 +147,14 @@ jobs:
           load: true
           targets: 'app,api,database'
           set: |
-            app.cache-to=type=gha,scope=build-app,mode=max
             app.cache-from=type=gha,scope=build-app
+            app.cache-to=type=gha,scope=build-app,mode=max
             app.tags=datalab-app:latest
-            api.cache-to=type=gha,scope=build-api,mode=max
             api.cache-from=type=gha,scope=build-api
+            api.cache-to=type=gha,scope=build-api,mode=max
             api.tags=datalab-api:latest
-            database.cache-to=type=gha,scope=build-database,mode=max
             database.cache-from=type=gha,scope=build-database
+            database.cache-to=type=gha,scope=build-database,mode=max
             database.tags=datalab-database:latest
 
       - name: Start services

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     build:
       context: .
       dockerfile: .docker/app_dockerfile
-      target: production
     volumes:
       - ./logs:/logs
     restart: unless-stopped
@@ -24,7 +23,6 @@ services:
     build:
       context: .
       dockerfile: .docker/server_dockerfile
-      target: production
       args:
         - WEB_CONCURRENCY=4
     depends_on:

--- a/pydatalab/src/pydatalab/main.py
+++ b/pydatalab/src/pydatalab/main.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 import pathlib
 from typing import Any, Dict
 
@@ -147,7 +148,15 @@ def create_app(
         for key in mail_settings:
             app.config[key] = mail_settings[key]
 
+    # Load config values from a provided .env file into the flask app config
+    # This useful for non-datalab settings like OAuth secrets
     app.config.update(dotenv_values(dotenv_path=env_file))
+
+    # Testing config: to enable OAuth2 on dev servers without https, we need to control the
+    # OAUTHLIB_INSECURE_TRANSPORT setting. If this is provided in the .env file, we also need
+    # to set it as an environment variable for the underlying oauthlib library to pick it up
+    if app.config.get("OAUTHLIB_INSECURE_TRANSPORT"):
+        os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = app.config["OAUTHLIB_INSECURE_TRANSPORT"]
 
     LOGGER.info("Launching datalab version %s", __version__)
     LOGGER.info("Starting app with Flask app.config: %s", app.config)


### PR DESCRIPTION
Previously, the docker-based dev server implicitly called `load_dotenv` to load any environment variables into global state, as part of `flask run`. Since the dev containers have now been removed, it is useful to be able to control a few select env vars in this way through the gunicorn-based container.

This PR hardcodes the setting of `OAUTHLIB_INSECURE_TRANSPORT` as an env var, when specified in the `.env` file. This allows OAuth login to be used locally without https.