### PR TITLE
Configure coverage for new src-layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Run all tests
         working-directory: ./pydatalab
         run: |
-          uv run pytest -rs -vvv --cov-report=term --cov-report=xml --cov ./pydatalab ./tests
+          uv run pytest -rs -vvv ./tests
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.10' && github.repository == 'datalab-org/datalab'

--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -117,3 +117,6 @@ dev-dependencies = [
     "mkdocstrings[python-legacy] ~= 0.25",
     "mkdocs-awesome-pages-plugin ~= 2.9",
 ]
+
+[tool.pytest.ini_options]
+addopts = "--cov-report=term --cov-report=xml --cov ./src/pydatalab"


### PR DESCRIPTION
Codecov uploads have been failing since #865, as the coverage directory is now incorrect. Hopefully this fixes that.