### PR TITLE
Use git version inside app container build

### DIFF
--- a/.docker/app_dockerfile
+++ b/.docker/app_dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:20-bullseye
+FROM node:20-bullseye as app
 SHELL ["/bin/bash", "--login", "-c"]
 
 WORKDIR /app
@@ -14,6 +14,7 @@ RUN --mount=type=cache,target=/root/.cache/yarn yarn install --frozen-lockfile -
 ENV PATH=$PATH:/node_modules/.bin
 ENV NODE_ENV=production
 
+
 # These get replaced by the entrypoint script for production builds.
 # Set the real values in `.env` files or an external docker-compose.
 ARG VUE_APP_API_URL=magic-api-url
@@ -24,7 +25,7 @@ ARG VUE_APP_WEBSITE_TITLE=magic-title
 ARG VUE_APP_QR_CODE_RESOLVER_URL=magic-qr-code-resolver-url
 
 COPY webapp ./
-RUN /node_modules/.bin/vue-cli-service build
+RUN --mount=type=bind,target=/.git,src=./.git VUE_APP_GIT_VERSION=$(node scripts/get-version.js) /node_modules/.bin/vue-cli-service build
 
 COPY ./.docker/app_entrypoint.sh /app/
 CMD [ "/bin/bash", "-c", "/app/app_entrypoint.sh" ]

--- a/.docker/app_dockerfile
+++ b/.docker/app_dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:20-bullseye as app
+FROM node:20-bullseye AS app
 SHELL ["/bin/bash", "--login", "-c"]
 
 WORKDIR /app
@@ -13,7 +13,6 @@ RUN --mount=type=cache,target=/root/.cache/yarn yarn install --frozen-lockfile -
 
 ENV PATH=$PATH:/node_modules/.bin
 ENV NODE_ENV=production
-
 
 # These get replaced by the entrypoint script for production builds.
 # Set the real values in `.env` files or an external docker-compose.

--- a/.docker/app_entrypoint.sh
+++ b/.docker/app_entrypoint.sh
@@ -18,9 +18,17 @@ if [ -z "$VUE_APP_API_URL" ]; then
     exit 1
 fi
 
+# If the VUE_APP_GIT_VERSION has not been overridden, set it to the default
+# from package.json; the real `.git` version, if available, should still
+# take precedence.
+if [ -z "$VUE_APP_GIT_VERSION" ]; then
+    VUE_APP_GIT_VERSION="0.0.0-git"
+fi
+
 echo "Replacing env vars in Javascript files"
 echo "Settings:"
 echo ""
+echo "  APP_VERSION: ${VUE_APP_GIT_VERSION}"
 echo "  API_URL: ${VUE_APP_API_URL}"
 echo "  LOGO_URL: ${VUE_APP_LOGO_URL}"
 echo "  HOMEPAGE_URL: ${VUE_APP_HOMPAGE_URL}"
@@ -32,6 +40,7 @@ echo "Patching..."
 
 for file in $ROOT_DIR/js/app.*.js* $ROOT_DIR/*html; do
     echo "$file"
+    sed -i "s|0.0.0-git|${VUE_APP_GIT_VERSION}|g" $file
     sed -i "s|magic-api-url|${VUE_APP_API_URL}|g" $file
     sed -i "s|magic-logo-url|${VUE_APP_LOGO_URL}|g" $file
     sed -i "s|magic-homepage-url|${VUE_APP_HOMEPAGE_URL}|g" $file

--- a/.docker/server_dockerfile
+++ b/.docker/server_dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.10 as api
+FROM python:3.10 AS api
 SHELL ["/bin/bash", "--login", "-c"]
 
 # Useful for installing deps from git, preventing big downloads and bandwith quotas

--- a/.docker/server_dockerfile
+++ b/.docker/server_dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.10
+FROM python:3.10 as api
 SHELL ["/bin/bash", "--login", "-c"]
 
 # Useful for installing deps from git, preventing big downloads and bandwith quotas

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ./logs:/logs
     restart: unless-stopped
     environment:
+      - VUE_APP_GIT_VERSION
       - VUE_APP_API_URL
       - VUE_APP_LOGO_URL
       - VUE_APP_HOMEPAGE_URL


### PR DESCRIPTION
This PR follows up #906 by using the version in the docker build, where available. It also provides the ability to manually set the tag version (useful in cases where the docker build is running inside git worktrees, or submodules).