### PR TITLE
Better handle case where block in database is not implemented by app/API

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -36,16 +36,16 @@
     "mermaid": "^10.1.0",
     "primeicons": "^7.0.0",
     "primevue": "^4.0.0",
+    "qrcode-vue3": "^1.6.8",
     "serve": "^14.2.1",
     "stream-browserify": "^3.0.0",
     "tinymce": "^5.10.9",
     "vue": "^3.2.4",
+    "vue-qrcode-reader": "^5.5.7",
     "vue-router": "^4.0.0-0",
     "vue-select": "^4.0.0-beta.6",
     "vue3-easy-data-table": "^1.5.45",
-    "vuex": "^4.0.0-0",
-    "qrcode-vue3": "^1.6.8",
-    "vue-qrcode-reader": "^5.5.7"
+    "vuex": "^4.0.0-0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.8",

--- a/webapp/src/components/datablocks/DataBlockBase.vue
+++ b/webapp/src/components/datablocks/DataBlockBase.vue
@@ -9,7 +9,9 @@
       />
       <input v-model="BlockTitle" class="form-control-plaintext block-title" type="text" />
       <span class="blocktype-label ml-auto mr-3">{{ blockType }}</span>
-      <span class="block-header-icon"><StyledBlockInfo :block-info="blockInfo" /></span>
+      <span v-if="blockInfo" class="block-header-icon"
+        ><StyledBlockInfo :block-info="blockInfo"
+      /></span>
       <font-awesome-icon
         :icon="['fa', 'sync']"
         class="block-header-icon"
@@ -170,7 +172,7 @@ export default {
       return this.$store.state.updatingDelayed[this.block_id];
     },
     blockInfo() {
-      return this.$store.state.blocksInfos[this.blockType];
+      return this.$store.state.blocksInfos?.[this.blockType];
     },
     BlockTitle: createComputedSetterForBlockField("title"),
     BlockDescription: createComputedSetterForBlockField("freeform_comment"),

--- a/webapp/src/components/datablocks/NotImplementedBlock.vue
+++ b/webapp/src/components/datablocks/NotImplementedBlock.vue
@@ -1,6 +1,9 @@
 <template>
   <DataBlockBase>
-    <div class="alert alert-danger">This block type has not been implemented!</div>
+    <div class="alert alert-danger">
+      This block type is not implemented/installed for this <i>datalab</i> instance. Please contact
+      your <i>datalab</i> administrator.
+    </div>
   </DataBlockBase>
 </template>
 

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -185,6 +185,9 @@ export default {
       return this.$store.state.files;
     },
     blocksInfos() {
+      if (Object.keys(this.$store.state.blocksInfos).length == 0) {
+        getBlocksInfos();
+      }
       return this.$store.state.blocksInfos;
     },
     itemApiUrl() {
@@ -202,7 +205,6 @@ export default {
     },
   },
   created() {
-    getBlocksInfos();
     this.getSampleData();
     this.interval = setInterval(() => this.setLastModified(), 30000);
   },
@@ -248,19 +250,6 @@ export default {
       var element = document.getElementById(id);
       element.scrollIntoView({
         behavior: "smooth",
-      });
-    },
-    change_a_block(event, block_id) {
-      let item_id = this.item_id;
-      let new_data = {
-        block_id: 7,
-        a_new_field: "foo bar",
-      };
-      console.log(new_data);
-      this.$store.commit("updateBlockData", {
-        item_id,
-        block_id,
-        block_data: new_data,
       });
     },
     getBlockDisplayType(block_id) {

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -3945,9 +3945,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001517, caniuse-lite@^1.0.30001520, caniuse-lite@^1.0.30001640:
-  version "1.0.30001641"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001641.tgz#3572862cd18befae3f637f2a1101cc033c6782ac"
-  integrity sha512-Phv5thgl67bHYo1TtMY/MurjkHhV4EDaCosezRXgZ8jzA/Ub+wjxAvbGvjoFENStinwi5kCyOYV3mi5tOGykwA==
+  version "1.0.30001668"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001668.tgz"
+  integrity sha512-nWLrdxqCdblixUO+27JtGJJE/txpJlyUy5YN1u53wLZkP0emYCo5zgS6QYft7VUYR42LGgi/S5hdLZTrnyIddw==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.4.0"


### PR DESCRIPTION
Should remove the annoying warning when doing block development.

Also prevents reloading the block info endpoint for every edit page.