### PR TITLE
Update collection deletion endpoint to also unlink items

### DIFF
--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -472,7 +472,7 @@ def test_cell_from_scratch(client):
 
 
 @pytest.mark.dependency(depends=["test_create_cell"])
-def test_create_collections(client, default_collection):
+def test_create_collections(client, default_collection, database):
     # Check no collections initially
     response = client.get("/collections")
     assert len(response.json["data"]) == 0, response.json
@@ -530,12 +530,16 @@ def test_create_collections(client, default_collection):
     assert response.json["item_data"]["collections"][0]["collection_id"] == "test_collection_2"
 
     # Test that collections can be deleted and relationships to items are removed
+    deleted_id = database.collections.find_one({"collection_id": new_collection.collection_id})[
+        "_id"
+    ]
     response = client.delete(f"/collections/{new_collection.collection_id}")
     assert response.status_code == 200, response.json
     assert response.json["status"] == "success"
     response = client.get(f"/collections/{new_collection.collection_id}")
     assert response.status_code == 404, response.json
     test_id = ids.pop()
+    assert database.items.find_one({"relationships.immutable_id": deleted_id}) is None
     response = client.get(f"/get-item-data/{test_id}")
     assert response.status_code == 200, response.json
     assert response.json["status"] == "success"


### PR DESCRIPTION
Closes #932.

This also provides a template for #543, which we should really use everywhere throughout the API for routes that make multiple database calls