### PR TITLE
Fix bug where blocks would not be loaded automatically

### DIFF
--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -694,7 +694,7 @@ export async function requestNewAPIKey() {
   }
 }
 
-export function getBlocksInfos() {
+export async function getBlocksInfos() {
   return fetch_get(`${API_URL}/info/blocks`)
     .then(function (response_json) {
       store.commit("setBlocksInfos", response_json.data);


### PR DESCRIPTION
Closes #926.

This one is my bad; in #808 I refactored the edit page to also be able to load from refcodes, so the code went from a single method with a promise handler to do the rest of the loading, to an if/else choosing between two async methods, with the rest of the loading happening outside of the promise, i.e., immediately (before the data had loaded).

This PR fixes that and refactors block loading into its own method. It also hides some components until the block info and item data is fully loaded.

Long story short, we need a test for this edit page behaviour (I will endeavour to make one)!