### PR TITLE
Tweak for edit page to allow upload file modal to load correctly

### DIFF
--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -57,7 +57,7 @@
   </nav>
 
   <!-- Item-type header information goes here -->
-  <div v-if="itemDataLoaded" class="editor-body">
+  <div class="editor-body">
     <component :is="itemTypeEntry?.itemInformationComponent" :item_id="item_id" />
 
     <FileList :item_id="item_id" :file_ids="file_ids" :stored_files="stored_files" />
@@ -163,7 +163,7 @@ export default {
       return this.itemTypeEntry?.navbarColor || "DarkGrey";
     },
     item_data() {
-      return this.$store.state.all_item_data[this.item_id] || null;
+      return this.$store.state.all_item_data[this.item_id] || {};
     },
     blocks() {
       return this.item_data.blocks_obj;


### PR DESCRIPTION
Related to #935, for some reason that I can't quite discern, adding an `isItemLoaded` guard to displaying the file list prevents uppy from being loaded properly. I've removed that guard and tweaked the unloaded value of `item_data` to be `{}` so that key access simply fail and return `undefined`, rather than erroring out.