### PR TITLE
Hotfix for file-overwriting from uppy

### DIFF
--- a/webapp/src/file_upload.js
+++ b/webapp/src/file_upload.js
@@ -57,9 +57,8 @@ export default function setupUppy(item_id, trigger_selector, reactive_file_list)
     for (const file_id in reactive_file_list) {
       // console.log(`evaluating ${reactive_file_list[file_id].name} vs ${file.name}`)
       if (reactive_file_list[file_id].name == file.name) {
-        matching_file_id = file_id;
         alert(
-          "A file with this name already exists in the sample. If you upload this, it will update the current file.",
+          "A file with this name already exists in the sample. If you upload this, it will be duplicated on the current item.",
         );
       }
     }


### PR DESCRIPTION
Do not consider filenames when uploading a file via uppy, just show the alert

Closes #939 