### PR TITLE
Add scheduled `uv lock -U` to replace dependabot

### DIFF
--- a/.github/workflows/dependable-bot.yml
+++ b/.github/workflows/dependable-bot.yml
@@ -1,0 +1,45 @@
+name: Automatic `uv` dependency upgrades
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+
+  uv-update-pins:
+    name: Run linters and other pre-commit hooks
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "0.4.x"
+          enable-cache: true
+
+      - name: Sync latest compatible dependencies and commit
+        working-directory: ./pydatalab
+        run: |
+          uv lock -U 2> output.txt
+
+      - name: Create PR with changes
+        uses: peter-evans/create-pull-request@v7
+        with:
+          base: main
+          sign-commits: true
+          branch: ci/update-uv-lock-main-deps
+          delete-branch: true
+          commit-message: "ci: update uv lock file"
+          title: "Update uv.lock with latest dependencies"
+          body-path: ./pydatalab/output.txt


### PR DESCRIPTION
dependabot is not being very useful right now. Instead, I propose a simple wf that runs `uv lock -U` each week and makes a PR with any changes, similar to a grouped dependabot update PR that should always lead to latest compatible versions.

We could then adapt this in the future with updates for newer (potentially breaking) versions of other deps.

If this works, we can disable dependabot for Python for all but security updates (which I don't believe `uv` has explicit support for), and leave it on only for `npm`.