### PR TITLE
Add `uv-lock` to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,13 @@ repos:
       - id: check-symlinks
       - id: mixed-line-ending
 
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.4.24
+    hooks:
+      - id: uv-lock
+        args: [ --directory=pydatalab ]
+        always_run: true
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.3
     hooks:


### PR DESCRIPTION
This will be helpful for e.g., dependabot PRs that update `pyproject.toml`, but don't know how to update the `uv.lock`, as we can just ask pre-commit CI to fix them, with the CI still running with locked deps every time.