### PR TITLE
Split vue docker build into two stages

### DIFF
--- a/.docker/app_dockerfile
+++ b/.docker/app_dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:20-bullseye AS app
+FROM node:20-bullseye AS build
 SHELL ["/bin/bash", "--login", "-c"]
 
 WORKDIR /app
@@ -11,7 +11,6 @@ COPY webapp/package.json webapp/yarn.lock ./
 # Using a custom node_modules location to avoid mounting it outside of docker
 RUN --mount=type=cache,target=/root/.cache/yarn yarn install --frozen-lockfile --modules-folder /node_modules
 
-ENV PATH=$PATH:/node_modules/.bin
 ENV NODE_ENV=production
 
 # These get replaced by the entrypoint script for production builds.
@@ -26,7 +25,16 @@ ARG VUE_APP_QR_CODE_RESOLVER_URL=magic-qr-code-resolver-url
 COPY webapp ./
 RUN --mount=type=bind,target=/.git,src=./.git VUE_APP_GIT_VERSION=$(node scripts/get-version.js) /node_modules/.bin/vue-cli-service build
 
+FROM node:20-bullseye AS production
+
+ENV PATH=$PATH:/node_modules/.bin
 COPY ./.docker/app_entrypoint.sh /app/
+
+COPY webapp/package.json webapp/yarn.lock ./
+
+COPY --from=build /app/dist /app/dist
+RUN --mount=type=cache,target=/root/.cache/yarn yarn install --frozen-lockfile --modules-folder /node_modules --production
+
 CMD [ "/bin/bash", "-c", "/app/app_entrypoint.sh" ]
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 CMD curl --fail http://localhost:8081 || exit 1


### PR DESCRIPTION
After talking to my esteemed colleague Claude, I now realise that `yarn install` includes dev dependencies by default. By splitting our docker build into two stages, one that uses all deps to make the build, and the next that only installs runtime deps, combined with #957 I can shave ~ 1 GB off the final image size.