### PR TITLE
Add suggested 'ready-for-review' workaround to checks not running from actions-created PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI tests
 on:
   pull_request:
+    types: [ready_for_review, opened, synchronize, reopened]
 
   push:
     branches:

--- a/.github/workflows/dependable-bot.yml
+++ b/.github/workflows/dependable-bot.yml
@@ -49,3 +49,4 @@ jobs:
           title: "Update uv.lock with latest dependencies"
           body-path: ./pydatalab/output.txt
           labels: dependency_updates,Python
+          draft: always-true


### PR DESCRIPTION
Long story short: checks won't run on PRs created by actions, like #945 (see long history at https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-1411863193 for why)

The suggested workaround is to always make the PRs as drafts, then have the tests trigger when someone clicks `ready-for-review`. If this works, it seems fairly elegant to me. This PR implements that, and I will merge it straight away to test.