### PR TITLE
Add timezone consistency across deployments & UI

### DIFF
--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -95,7 +95,7 @@ line-length = 100
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W", "Q"]
+select = ["E", "F", "I", "W", "Q", "DTZ"]
 ignore = ["E501", "E402"]
 fixable = ["A", "B", "C", "D", "E", "F", "I"]
 unfixable = []

--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -61,7 +61,7 @@
     },
     "last_modified": {
       "title": "Last Modified",
-      "type": "date",
+      "type": "string",
       "format": "date-time"
     },
     "relationships": {
@@ -91,7 +91,7 @@
     },
     "date": {
       "title": "Date",
-      "type": "date",
+      "type": "string",
       "format": "date-time"
     },
     "name": {
@@ -324,7 +324,7 @@
         },
         "last_modified": {
           "title": "Last Modified",
-          "type": "date",
+          "type": "string",
           "format": "date-time"
         },
         "relationships": {
@@ -415,7 +415,7 @@
         },
         "last_modified": {
           "title": "Last Modified",
-          "type": "date",
+          "type": "string",
           "format": "date-time"
         },
         "relationships": {
@@ -488,7 +488,7 @@
         },
         "last_modified": {
           "title": "Last Modified",
-          "type": "date",
+          "type": "string",
           "format": "date-time"
         },
         "relationships": {
@@ -506,7 +506,7 @@
         "last_modified_remote": {
           "title": "Last Modified Remote",
           "description": "The last date/time at which the remote file was modified.",
-          "type": "date",
+          "type": "string",
           "format": "date-time"
         },
         "item_ids": {

--- a/pydatalab/schemas/equipment.json
+++ b/pydatalab/schemas/equipment.json
@@ -61,7 +61,7 @@
     },
     "last_modified": {
       "title": "Last Modified",
-      "type": "date",
+      "type": "string",
       "format": "date-time"
     },
     "relationships": {
@@ -91,7 +91,7 @@
     },
     "date": {
       "title": "Date",
-      "type": "date",
+      "type": "string",
       "format": "date-time"
     },
     "name": {
@@ -279,7 +279,7 @@
         },
         "last_modified": {
           "title": "Last Modified",
-          "type": "date",
+          "type": "string",
           "format": "date-time"
         },
         "relationships": {
@@ -370,7 +370,7 @@
         },
         "last_modified": {
           "title": "Last Modified",
-          "type": "date",
+          "type": "string",
           "format": "date-time"
         },
         "relationships": {
@@ -443,7 +443,7 @@
         },
         "last_modified": {
           "title": "Last Modified",
-          "type": "date",
+          "type": "string",
           "format": "date-time"
         },
         "relationships": {
@@ -461,7 +461,7 @@
         "last_modified_remote": {
           "title": "Last Modified Remote",
           "description": "The last date/time at which the remote file was modified.",
-          "type": "date",
+          "type": "string",
           "format": "date-time"
         },
         "item_ids": {

--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -61,7 +61,7 @@
     },
     "last_modified": {
       "title": "Last Modified",
-      "type": "date",
+      "type": "string",
       "format": "date-time"
     },
     "relationships": {
@@ -91,7 +91,7 @@
     },
     "date": {
       "title": "Date",
-      "type": "date",
+      "type": "string",
       "format": "date-time"
     },
     "name": {
@@ -283,7 +283,7 @@
         },
         "last_modified": {
           "title": "Last Modified",
-          "type": "date",
+          "type": "string",
           "format": "date-time"
         },
         "relationships": {
@@ -374,7 +374,7 @@
         },
         "last_modified": {
           "title": "Last Modified",
-          "type": "date",
+          "type": "string",
           "format": "date-time"
         },
         "relationships": {
@@ -447,7 +447,7 @@
         },
         "last_modified": {
           "title": "Last Modified",
-          "type": "date",
+          "type": "string",
           "format": "date-time"
         },
         "relationships": {
@@ -465,7 +465,7 @@
         "last_modified_remote": {
           "title": "Last Modified Remote",
           "description": "The last date/time at which the remote file was modified.",
-          "type": "date",
+          "type": "string",
           "format": "date-time"
         },
         "item_ids": {

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -61,7 +61,7 @@
     },
     "last_modified": {
       "title": "Last Modified",
-      "type": "date",
+      "type": "string",
       "format": "date-time"
     },
     "relationships": {
@@ -92,7 +92,7 @@
     "date": {
       "title": "Date Acquired",
       "description": "The date the item was acquired",
-      "type": "date",
+      "type": "string",
       "format": "date-time"
     },
     "name": {
@@ -123,7 +123,7 @@
     "date_opened": {
       "title": "Date Opened",
       "description": "The date the container was opened",
-      "type": "date",
+      "type": "string",
       "format": "date-time"
     },
     "CAS": {
@@ -337,7 +337,7 @@
         },
         "last_modified": {
           "title": "Last Modified",
-          "type": "date",
+          "type": "string",
           "format": "date-time"
         },
         "relationships": {
@@ -428,7 +428,7 @@
         },
         "last_modified": {
           "title": "Last Modified",
-          "type": "date",
+          "type": "string",
           "format": "date-time"
         },
         "relationships": {
@@ -501,7 +501,7 @@
         },
         "last_modified": {
           "title": "Last Modified",
-          "type": "date",
+          "type": "string",
           "format": "date-time"
         },
         "relationships": {
@@ -519,7 +519,7 @@
         "last_modified_remote": {
           "title": "Last Modified Remote",
           "description": "The last date/time at which the remote file was modified.",
-          "type": "date",
+          "type": "string",
           "format": "date-time"
         },
         "item_ids": {

--- a/pydatalab/scripts/migrate_files_to_files_ObjectId_v2.py
+++ b/pydatalab/scripts/migrate_files_to_files_ObjectId_v2.py
@@ -53,7 +53,7 @@ for sample in all_samples:
             "size": None,
             "sample_ids": [sample_id],
             "blocks": [],
-            "last_modified": datetime.datetime.now().isoformat(),
+            "last_modified": datetime.datetime.now().isoformat(),  # noqa
             "metadata": {},
             "representation": None,
             "source_server_name": None,  # not used for source=uploaded

--- a/pydatalab/src/pydatalab/backups.py
+++ b/pydatalab/src/pydatalab/backups.py
@@ -133,9 +133,7 @@ def create_backup(strategy: BackupStrategy) -> bool:
 
     """
 
-    snapshot_name = (
-        f"datalab-snapshot-{datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}.tar.gz"
-    )
+    snapshot_name = f"datalab-snapshot-{datetime.datetime.now(tz=datetime.timezone.utc).strftime('%Y-%m-%d-%H-%M-%S')}.tar.gz"
 
     if strategy.hostname is None:
         snapshot_path = strategy.location / snapshot_name

--- a/pydatalab/src/pydatalab/models/files.py
+++ b/pydatalab/src/pydatalab/models/files.py
@@ -1,4 +1,3 @@
-import datetime
 from typing import Any, Dict, List, Optional
 
 from pydantic import Field
@@ -37,7 +36,7 @@ class File(Entry, HasOwner, HasRevisionControl):
         description="The source of the file, e.g. 'remote' or 'uploaded'."
     )
 
-    time_added: datetime.datetime = Field(description="The timestamp for the original file upload.")
+    time_added: IsoformatDateTime = Field(description="The timestamp for the original file upload.")
 
     metadata: Optional[Dict[Any, Any]] = Field(description="Any additional metadata.")
 

--- a/pydatalab/src/pydatalab/models/utils.py
+++ b/pydatalab/src/pydatalab/models/utils.py
@@ -153,17 +153,17 @@ class IsoformatDateTime(datetime.datetime):
         yield cls.validate
 
     @classmethod
-    def validate(cls, v):
+    def validate(cls, v) -> datetime.datetime | None:
+        """Cast isoformat strings to datetimes and enforce UTC if tzinfo is missing."""
         if isinstance(v, str):
             if v in ["0", " "]:
                 return None
-            return datetime.datetime.fromisoformat(v)
+            v = datetime.datetime.fromisoformat(v)
+
+        if v.tzinfo is None:
+            v = v.replace(tzinfo=datetime.timezone.utc)
 
         return v
-
-    @classmethod
-    def __modify_schema__(cls, field_schema):
-        field_schema.update(type="date")
 
 
 JSON_ENCODERS = {

--- a/pydatalab/src/pydatalab/routes/v0_1/auth.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/auth.py
@@ -285,7 +285,7 @@ def generate_and_share_magic_link():
     # The key `exp` is a standard part of JWT; pyjwt treats this as an expiration time
     # and will correctly encode the datetime
     token = jwt.encode(
-        {"exp": datetime.datetime.utcnow() + LINK_EXPIRATION, "email": email},
+        {"exp": datetime.datetime.now(datetime.timezone.utc) + LINK_EXPIRATION, "email": email},
         CONFIG.SECRET_KEY,
         algorithm="HS256",
     )
@@ -356,7 +356,9 @@ def email_logged_in():
         algorithms=["HS256"],
     )
 
-    if datetime.datetime.fromtimestamp(data["exp"]) < datetime.datetime.utcnow():
+    if datetime.datetime.fromtimestamp(
+        data["exp"], tz=datetime.timezone.utc
+    ) < datetime.datetime.now(tz=datetime.timezone.utc):
         raise ValueError("Token expired, please request a new one.")
 
     email = data["email"]

--- a/pydatalab/src/pydatalab/routes/v0_1/collections.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/collections.py
@@ -134,7 +134,9 @@ def create_collection():
             409,  # 409: Conflict
         )
 
-    data["last_modified"] = data.get("last_modified", datetime.datetime.now().isoformat())
+    data["last_modified"] = data.get(
+        "last_modified", datetime.datetime.now(datetime.timezone.utc).isoformat()
+    )
 
     try:
         data_model = Collection(**data)
@@ -235,7 +237,7 @@ def save_collection(collection_id):
         if k in updated_data:
             del updated_data[k]
 
-    updated_data["last_modified"] = datetime.datetime.now().isoformat()
+    updated_data["last_modified"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
     collection = flask_mongo.db.collections.find_one(
         {"collection_id": collection_id, **get_default_permissions(user_only=True)}

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -480,7 +480,7 @@ def _create_sample(
             409,  # 409: Conflict
         )
 
-    new_sample["date"] = new_sample.get("date", datetime.datetime.now())
+    new_sample["date"] = new_sample.get("date", datetime.datetime.now(tz=datetime.timezone.utc))
     try:
         data_model: Item = model(**new_sample)
 
@@ -811,7 +811,7 @@ def save_item():
         if k in updated_data:
             del updated_data[k]
 
-    updated_data["last_modified"] = datetime.datetime.now().isoformat()
+    updated_data["last_modified"] = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
 
     for block_id, block_data in updated_data.get("blocks_obj", {}).items():
         blocktype = block_data["blocktype"]

--- a/pydatalab/tests/server/test_equipment.py
+++ b/pydatalab/tests/server/test_equipment.py
@@ -25,7 +25,7 @@ def test_new_equipment(client, default_equipment_dict):
     for key, value in response.json["sample_list_entry"].items():
         if key in default_equipment_dict:
             if isinstance(v := default_equipment_dict[key], datetime.datetime):
-                v = v.isoformat()
+                v = v.replace(tzinfo=datetime.timezone.utc).isoformat()
             assert value == v
 
 
@@ -41,7 +41,7 @@ def test_get_item_data(client, default_equipment_dict):
 
     for key in default_equipment_dict.keys():
         if isinstance(v := default_equipment_dict[key], datetime.datetime):
-            v = v.isoformat()
+            v = v.replace(tzinfo=datetime.timezone.utc).isoformat()
         assert response.json["item_data"][key] == v
 
 
@@ -72,7 +72,7 @@ def test_new_equipment_with_automatically_generated_id(client):
 
     for key in new_equipment_data.keys():
         if isinstance(v := new_equipment_data[key], datetime.datetime):
-            v = v.isoformat()
+            v = v.replace(tzinfo=datetime.timezone.utc).isoformat()
         assert response.json["item_data"][key] == v
 
 

--- a/pydatalab/tests/server/test_remote_filesystems.py
+++ b/pydatalab/tests/server/test_remote_filesystems.py
@@ -106,7 +106,7 @@ def test_get_directory_structure_remote(real_mongo_client, random_string):
     dummy_dir_structure = {
         "contents": [],
         "name": "test",
-        "last_updated": datetime.datetime.now(),
+        "last_updated": datetime.datetime.now(tz=datetime.timezone.utc),
         "type": "toplevel",
     }
     real_mongo_client.get_database().remoteFilesystems.insert_one(dummy_dir_structure)

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -25,7 +25,7 @@ def test_new_sample(client, default_sample_dict):
         if key == "creator_ids":
             continue
         if isinstance(v := default_sample_dict[key], datetime.datetime):
-            v = v.isoformat()
+            v = v.replace(tzinfo=datetime.timezone.utc).isoformat()
         assert response.json["sample_list_entry"][key] == v
 
 
@@ -38,7 +38,7 @@ def test_get_item_data(client, default_sample_dict):
         if key == "creator_ids":
             continue
         if isinstance(v := default_sample_dict[key], datetime.datetime):
-            v = v.isoformat()
+            v = v.replace(tzinfo=datetime.timezone.utc).isoformat()
         assert response.json["item_data"][key] == v
 
 
@@ -83,7 +83,7 @@ def test_new_sample_with_automatically_generated_id(client, user_id):
 
     for key in new_sample_data.keys():
         if isinstance(v := new_sample_data[key], datetime.datetime):
-            v = v.isoformat()
+            v = v.replace(tzinfo=datetime.timezone.utc).isoformat()
         if key == "creator_ids":
             continue
         assert response.json["item_data"][key] == v

--- a/pydatalab/tests/server/test_starting_materials.py
+++ b/pydatalab/tests/server/test_starting_materials.py
@@ -27,7 +27,7 @@ def test_new_starting_material(client, default_starting_material_dict):
             continue
         if key in default_starting_material_dict:
             if isinstance(v := default_starting_material_dict[key], datetime.datetime):
-                v = v.isoformat()
+                v = v.replace(tzinfo=datetime.timezone.utc).isoformat()
             assert value == v
 
 
@@ -45,7 +45,7 @@ def test_get_item_data(admin_client, default_starting_material_dict):
             continue
 
         if isinstance(v := default_starting_material_dict[key], datetime.datetime):
-            v = v.isoformat()
+            v = v.replace(tzinfo=datetime.timezone.utc).isoformat()
         assert response.json["item_data"][key] == v
 
 
@@ -81,7 +81,7 @@ def test_new_starting_material_with_automatically_generated_id(client):
         if key == "creator_ids":
             continue
         if isinstance(v := new_starting_material_data[key], datetime.datetime):
-            v = v.isoformat()
+            v = v.replace(tzinfo=datetime.timezone.utc).isoformat()
         assert response.json["item_data"][key] == v
 
 

--- a/pydatalab/tests/test_models.py
+++ b/pydatalab/tests/test_models.py
@@ -83,7 +83,7 @@ def test_relationship_with_custom_type():
 
 
 def test_file():
-    current_datetime = datetime.datetime.now()
+    current_datetime = datetime.datetime.now(datetime.timezone.utc)
     file_dict1 = {
         "_id": "6437c96341ffc8169a957e2d",
         "size": 10003,
@@ -121,14 +121,16 @@ def test_file():
     # minimal file
     File2 = File(**file_dict2)
     assert File2.type == "files"
-    assert File2.time_added == datetime.datetime.fromisoformat("2019-05-18T15:18:10")
+    assert File2.time_added == datetime.datetime.fromisoformat("2019-05-18T15:18:10").replace(
+        tzinfo=datetime.timezone.utc
+    )
 
     # make sure you can make a sample with the files internal
     sample = Sample(
         creator_ids=[ObjectId("0123456789ab0123456789ab"), ObjectId("1023456789ab0123456789ab")],
         creators=None,
         date="2020-01-01 00:00",
-        last_modified=datetime.datetime(2020, 1, 1, 0, 0),
+        last_modified=datetime.datetime(2020, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),
         item_id="1234",
         files=[file_dict1, file_dict2],
     )
@@ -154,19 +156,26 @@ def test_custom_and_inherited_items():
     assert item_dict["type"] == "items_custom"
     assert item_dict["creator_ids"][0] == ObjectId("0123456789ab0123456789ab")
     assert item_dict["creator_ids"][1] == ObjectId("1023456789ab0123456789ab")
-    assert item_dict["date"] == datetime.datetime.fromisoformat("2020-01-01 00:00")
+    assert item_dict["date"] == datetime.datetime.fromisoformat("2020-01-01 00:00").replace(
+        tzinfo=datetime.timezone.utc
+    )
 
     item_json = json.loads(item.json())
     assert item_json["type"] == "items_custom"
     assert item_json["creator_ids"][0] == str(ObjectId("0123456789ab0123456789ab"))
     assert item_json["creator_ids"][1] == str(ObjectId("1023456789ab0123456789ab"))
-    assert item_json["date"] == datetime.datetime.fromisoformat("2020-01-01 00:00").isoformat()
+    assert (
+        item_json["date"]
+        == datetime.datetime.fromisoformat("2020-01-01 00:00")
+        .replace(tzinfo=datetime.timezone.utc)
+        .isoformat()
+    )
 
     sample = Sample(
         creator_ids=[ObjectId("0123456789ab0123456789ab"), ObjectId("1023456789ab0123456789ab")],
         creators=None,
         date="2020-01-01 00:00",
-        last_modified=datetime.datetime(2020, 1, 1, 0, 0),
+        last_modified=datetime.datetime(2020, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),
         item_id="1234",
     )
 
@@ -174,17 +183,28 @@ def test_custom_and_inherited_items():
     assert sample_dict["type"] == "samples"
     assert sample_dict["creator_ids"][0] == ObjectId("0123456789ab0123456789ab")
     assert sample_dict["creator_ids"][1] == ObjectId("1023456789ab0123456789ab")
-    assert sample_dict["date"] == datetime.datetime.fromisoformat("2020-01-01 00:00")
-    assert sample_dict["last_modified"] == datetime.datetime.fromisoformat("2020-01-01 00:00")
+    assert sample_dict["date"] == datetime.datetime.fromisoformat("2020-01-01 00:00").replace(
+        tzinfo=datetime.timezone.utc
+    )
+    assert sample_dict["last_modified"] == datetime.datetime.fromisoformat(
+        "2020-01-01 00:00"
+    ).replace(tzinfo=datetime.timezone.utc)
 
     sample_json = json.loads(sample.json())
     assert sample_json["type"] == "samples"
     assert sample_json["creator_ids"][0] == str(ObjectId("0123456789ab0123456789ab"))
     assert sample_json["creator_ids"][1] == str(ObjectId("1023456789ab0123456789ab"))
-    assert sample_json["date"] == datetime.datetime.fromisoformat("2020-01-01 00:00").isoformat()
+    assert (
+        sample_json["date"]
+        == datetime.datetime.fromisoformat("2020-01-01 00:00")
+        .replace(tzinfo=datetime.timezone.utc)
+        .isoformat()
+    )
     assert (
         sample_json["last_modified"]
-        == datetime.datetime.fromisoformat("2020-01-01 00:00").isoformat()
+        == datetime.datetime.fromisoformat("2020-01-01 00:00")
+        .replace(tzinfo=datetime.timezone.utc)
+        .isoformat()
     )
 
 

--- a/webapp/cypress/e2e/equipment.cy.js
+++ b/webapp/cypress/e2e/equipment.cy.js
@@ -67,7 +67,7 @@ describe("Equipment table page", () => {
         expect(body).to.have.property("item_id", "test_e3");
         expect(body.item_data).to.have.property("item_id", "test_e3");
         expect(body.item_data).to.have.property("name", "my inst");
-        expect(body.item_data).to.have.property("date", "1990-01-07T00:00:00");
+        expect(body.item_data).to.have.property("date", "1990-01-07T00:00:00+00:00");
       });
   });
 

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -38,7 +38,7 @@
         <StyledInput
           id="startmat-date-acquired"
           v-model="DateAcquired"
-          type="date"
+          type="datetime-local"
           :readonly="!isEditable"
         />
       </div>

--- a/webapp/src/resources.js
+++ b/webapp/src/resources.js
@@ -39,6 +39,9 @@ export const GRAVATAR_STYLE = "identicon";
 const editable_inventory = process.env.VUE_APP_EDITABLE_INVENTORY || "false";
 export const EDITABLE_INVENTORY = editable_inventory.toLowerCase() == "true";
 
+// Eventually this should be pulled from the schema
+export const DATETIME_FIELDS = new Set(["date"]);
+
 export const UPPY_MAX_TOTAL_FILE_SIZE =
   Number(process.env.VUE_APP_UPPY_MAX_TOTAL_FILE_SIZE) != null
     ? process.env.VUE_APP_UPPY_MAX_TOTAL_FILE_SIZE

--- a/webapp/src/views/CollectionPage.vue
+++ b/webapp/src/views/CollectionPage.vue
@@ -144,9 +144,7 @@ export default {
       if (item_date == null) {
         this.lastModified = "Unknown";
       } else {
-        // API dates are in UTC but missing Z suffix
-        const save_date = new Date(item_date + "Z");
-        this.lastModified = formatDistanceToNow(save_date, { addSuffix: true });
+        this.lastModified = formatDistanceToNow(new Date(item_date), { addSuffix: true });
       }
     },
   },

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -310,9 +310,7 @@ export default {
       if (item_date == null) {
         this.lastModified = "Unknown";
       } else {
-        // API dates are in UTC but missing Z suffix
-        const save_date = new Date(item_date + "Z");
-        this.lastModified = formatDistanceToNow(save_date, { addSuffix: true });
+        this.lastModified = formatDistanceToNow(new Date(item_date), { addSuffix: true });
       }
     },
   },


### PR DESCRIPTION
This PR enforces UTC for all datetimes stored by datalab, via:

- updating the underlying model so that any missing timezone from a user/script is interpreted as UTC. This is done at the validator level, so some inconsistencies might arise in old data that has not previously been stored with a timezone, but the API at least will always validate and fix it this now. I explicitly added the timezones into remote fs checking so that we don't have to worry about mongo version compatibility.
- The app code can now assume that a missing timezone really does mean UTC, and all future timestamps should have the `00:00` UTC offset suffix.
- App code now has to have a custom computed setter/getter for datetime objects, so that we can cast the format from HTML `<input format='datetime-local'>` into the full isoformat stamp.
- all internal datetimes now use UTC explicitly, with enabling of the ruff DTZ/flake8-datetimez linting rules

Closes #440 

Assorted fixes:

- [x] the `IsoformatDateTime` wrapper was also setting a bad JSON Schema type, for some reason -- this is removed
- [x] The `File` model wasn't using the extended datetime format for `time_added`. 

Relatedly (from HN today...): https://ssoready.com/blog/engineering/truths-programmers-timezones/
