### PR TITLE
Stagger fortnightly scheduled uv/yarn updates

### DIFF
--- a/.github/workflows/dependable-bot.yml
+++ b/.github/workflows/dependable-bot.yml
@@ -1,7 +1,7 @@
 name: Automatic `uv` dependency upgrades
 on:
   schedule:
-    - cron: "0 0 * * 3"
+    - cron: "0 0 1-7,15-21 * 3"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/yarn-upgrade-bot.yml
+++ b/.github/workflows/yarn-upgrade-bot.yml
@@ -1,7 +1,7 @@
 name: Automatic `yarn` dependency upgrades
 on:
   schedule:
-    - cron: "0 0 * * 3"
+    - cron: "0 0 8-14,21-31 * 3"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
I think it makes sense to stagger the Python/JS ecosystem updates, so if we have any issues in the week after merging one, we can be fairly sure it was the cause. This PR staggers the updates so that Python updates on Wednesdays in the 1st and 3rd week of a month, and JS in the 2nd and 4th. 