### PR TITLE
Chatblock deployment fix: make sure LLM API keys are passed from .env to environ

### DIFF
--- a/pydatalab/src/pydatalab/apps/chat/blocks.py
+++ b/pydatalab/src/pydatalab/apps/chat/blocks.py
@@ -169,7 +169,7 @@ Start with a friendly introduction and give me a one sentence summary of what th
 
             if model_name.startswith("claude"):
                 self.chat_client = ChatAnthropic(
-                    anthropic_api_key=os.environ["ANTHROPIC_API_KEY"],
+                    anthropic_api_key=os.environ.get("ANTHROPIC_API_KEY"),
                     model=model_name,
                 )
             elif model_name.startswith("gpt"):

--- a/pydatalab/src/pydatalab/main.py
+++ b/pydatalab/src/pydatalab/main.py
@@ -67,14 +67,23 @@ def _check_feature_flags(app):
             CONFIG.IDENTIFIER_PREFIX,
         )
 
-    def _check_secret_and_warn(secret, error) -> bool:
+    def _check_secret_and_warn(secret: str, error: str, environ: bool = False) -> bool:
         """Checks if a secret has been set, and if so, return True.
 
         Otherwise, warn and return False.
+
+        Parameters:
+            secret: The secret to check.
+            error: The error message to log if the secret is missing.
+            environ: Whether the secret should also be checked as an environment variable.
         """
         if not app.config.get(secret):
             LOGGER.warning("%s: please set `%s`", error, secret)
             return False
+        if environ and not os.environ.get(secret):
+            LOGGER.warning("%s: please set as an environment variable too `%s`", error, secret)
+            return False
+
         return True
 
     if _check_secret_and_warn(
@@ -93,11 +102,11 @@ def _check_feature_flags(app):
     ):
         FEATURE_FLAGS.auth_mechanisms.orcid = True
     if _check_secret_and_warn(
-        "OPENAI_API_KEY", "No OpenAI API key provided, OpenAI-based ChatBlock will not work"
+        "OPENAI_API_KEY", "No OpenAI API key provided, OpenAI-based ChatBlock will not work", environ=True
     ):
         FEATURE_FLAGS.ai_integrations.openai = True
     if _check_secret_and_warn(
-        "ANTHROPIC_API_KEY", "No Anthropic API key provided, Claude-based ChatBlock will not work"
+        "ANTHROPIC_API_KEY", "No Anthropic API key provided, Claude-based ChatBlock will not work", environ=True,
     ):
         FEATURE_FLAGS.ai_integrations.anthropic = True
 

--- a/pydatalab/src/pydatalab/main.py
+++ b/pydatalab/src/pydatalab/main.py
@@ -158,6 +158,11 @@ def create_app(
     if app.config.get("OAUTHLIB_INSECURE_TRANSPORT"):
         os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = app.config["OAUTHLIB_INSECURE_TRANSPORT"]
 
+    # Set LLM API keys as env vars if present in the flask config
+    for key in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+        if app.config.get(key):
+            os.environ[key] = app.config[key]
+
     LOGGER.info("Launching datalab version %s", __version__)
     LOGGER.info("Starting app with Flask app.config: %s", app.config)
 

--- a/pydatalab/src/pydatalab/main.py
+++ b/pydatalab/src/pydatalab/main.py
@@ -102,11 +102,15 @@ def _check_feature_flags(app):
     ):
         FEATURE_FLAGS.auth_mechanisms.orcid = True
     if _check_secret_and_warn(
-        "OPENAI_API_KEY", "No OpenAI API key provided, OpenAI-based ChatBlock will not work", environ=True
+        "OPENAI_API_KEY",
+        "No OpenAI API key provided, OpenAI-based ChatBlock will not work",
+        environ=True,
     ):
         FEATURE_FLAGS.ai_integrations.openai = True
     if _check_secret_and_warn(
-        "ANTHROPIC_API_KEY", "No Anthropic API key provided, Claude-based ChatBlock will not work", environ=True,
+        "ANTHROPIC_API_KEY",
+        "No Anthropic API key provided, Claude-based ChatBlock will not work",
+        environ=True,
     ):
         FEATURE_FLAGS.ai_integrations.anthropic = True
 


### PR DESCRIPTION
Previously, LLM API keys were automatically set as env vars by pipenv as part of the build process. In this PR, the procedure is passed onto flask itself.