### PR TITLE
Initial implementation of manual ngram-based search in MongoDB

### DIFF
--- a/pydatalab/src/pydatalab/main.py
+++ b/pydatalab/src/pydatalab/main.py
@@ -206,6 +206,7 @@ def create_app(
         extension.init_app(app)
 
     pydatalab.mongo.create_default_indices()
+    pydatalab.mongo.create_ngram_item_index()
 
     if CONFIG.FILE_DIRECTORY is not None:
         pathlib.Path(CONFIG.FILE_DIRECTORY).mkdir(parents=False, exist_ok=True)

--- a/pydatalab/src/pydatalab/mongo.py
+++ b/pydatalab/src/pydatalab/mongo.py
@@ -216,7 +216,7 @@ def create_ngram_item_index(
     global_ngram_count: dict[str, int] = collections.defaultdict(int)
     for item in db.items.find({}):
         item_count += 1
-        ngrams: dict[str, int] = _generate_item_ngrams(item, ITEM_FTS_FIELDS)
+        ngrams: dict[str, int] = _generate_item_ngrams(item, ITEMS_FTS_FIELDS)
         ngram_index[item["_id"]] = set(ngrams)
         type_index[item["_id"]] = item["type"]
         for g in ngrams:

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -16,7 +16,7 @@ from pydatalab.models.items import Item
 from pydatalab.models.people import Person
 from pydatalab.models.relationships import RelationshipType
 from pydatalab.models.utils import generate_unique_refcode
-from pydatalab.mongo import ITEM_FTS_FIELDS, _generate_item_ngrams, flask_mongo
+from pydatalab.mongo import ITEMS_FTS_FIELDS, _generate_item_ngrams, flask_mongo
 from pydatalab.permissions import PUBLIC_USER_ID, active_users_or_get_only, get_default_permissions
 
 ITEMS = Blueprint("items", __name__)
@@ -577,7 +577,7 @@ def _create_sample(
 
     # Update ngram index, if configured
     ngrams = _generate_item_ngrams(
-        flask_mongo.db.items.find_one(result.inserted_id), ITEM_FTS_FIELDS
+        flask_mongo.db.items.find_one(result.inserted_id), ITEMS_FTS_FIELDS
     )
     flask_mongo.db.items_fts.update_one(
         {"_id": result.inserted_id},
@@ -1061,7 +1061,7 @@ def save_item():
         )
 
     # Update ngram index, if configured
-    ngrams = _generate_item_ngrams(updated_doc, ITEM_FTS_FIELDS)
+    ngrams = _generate_item_ngrams(updated_doc, ITEMS_FTS_FIELDS)
     flask_mongo.db.items_fts.update_one(
         {"_id": updated_doc["_id"]},
         {"$set": {"type": updated_doc["type"], "_fts_ngrams": list(ngrams)}},

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -6,6 +6,7 @@ from bson import ObjectId
 from flask import Blueprint, jsonify, redirect, request
 from flask_login import current_user
 from pydantic import ValidationError
+from pymongo import ReturnDocument
 from pymongo.command_cursor import CommandCursor
 
 from pydatalab.blocks import BLOCK_TYPES
@@ -1049,6 +1050,7 @@ def save_item():
     updated_doc = flask_mongo.db.items.find_one_and_update(
         {"item_id": item_id},
         {"$set": item},
+        return_document=ReturnDocument.AFTER,
     )
 
     if updated_doc is None:

--- a/pydatalab/tests/server/test_fts.py
+++ b/pydatalab/tests/server/test_fts.py
@@ -1,0 +1,51 @@
+"""This module tests fundamental routines around
+the n-gram FTS.
+
+"""
+
+from pydatalab.mongo import _generate_item_ngrams, _generate_ngrams
+
+
+def test_ngram_single_field():
+    field = "ABCDEF"
+    ngrams = _generate_ngrams(field, 3)
+    expected = ["abc", "bcd", "cde", "def"]
+    assert list(ngrams) == expected
+    assert all([ngrams[e] == 1 for e in expected])
+
+    field = "ABC"
+    ngrams = _generate_ngrams(field, 3)
+    assert ngrams == {"abc": 1}
+
+    field = "some: punctuation"
+    ngrams = _generate_ngrams(field, 3)
+    expected = ["som", "ome", "pun", "unc", "nct", "ctu", "tua", "uat", "ati", "tio", "ion"]
+    assert list(ngrams) == expected
+
+    field = "What about a full sentence? or: even, two?"
+    ngrams = _generate_ngrams(field, 3)
+    expected = [
+        "wha",
+        "hat",
+        "abo",
+        "bou",
+        "out",
+        "ful",
+        "ull",
+        "sen",
+        "ent",
+        "nte",
+        "ten",
+        "enc",
+        "nce",
+        "eve",
+        "ven",
+        "two",
+    ]
+    assert list(ngrams) == expected
+    assert all([ngrams[e] == 1 for e in expected])
+
+
+def test_ngram_item(default):
+    item = {"refcode": "ABCDEF"}
+    assert _generate_item_ngrams(item, 3) == {"abc": 1, "bcd": 1, "cde": 1, "def": 1}

--- a/pydatalab/tests/server/test_ngram_fts.py
+++ b/pydatalab/tests/server/test_ngram_fts.py
@@ -3,7 +3,7 @@ the n-gram FTS.
 
 """
 
-from pydatalab.mongo import _generate_item_ngrams, _generate_ngrams
+from pydatalab.mongo import _generate_item_ngrams, _generate_ngrams, create_ngram_item_index
 
 
 def test_ngram_single_field():
@@ -49,3 +49,57 @@ def test_ngram_single_field():
 def test_ngram_item():
     item = {"refcode": "ABCDEF"}
     assert _generate_item_ngrams(item, {"refcode"}, n=3) == {"abc": 1, "bcd": 1, "cde": 1, "def": 1}
+
+
+def test_ngram_fts_route(client, default_sample_dict, real_mongo_client, database):
+    default_sample_dict["item_id"] = "ABCDEF"
+    response = client.post("/new-sample/", json=default_sample_dict)
+    assert response.status_code == 201
+
+    # Check that creating the ngram index with existing items works
+    create_ngram_item_index(real_mongo_client, background=False, filter_top_ngrams=None)
+
+    doc = database.items_fts.find_one({})
+    ngrams = set(doc["_fts_ngrams"])
+    for ng in ["abc", "bcd", "cde", "def", "sam", "ple"]:
+        assert ng in ngrams
+    assert doc["type"] == "samples"
+
+    query_strings = ("ABC", "ABCDEF", "abcd", "cdef")
+
+    for q in query_strings:
+        response = client.get(f"/search-items-ngram/?query={q}&types=samples")
+        assert response.status_code == 200
+        assert response.json["status"] == "success"
+        assert len(response.json["items"]) == 1
+        assert response.json["items"][0]["item_id"] == "ABCDEF"
+
+    # Check that new items are added to the ngram index
+    default_sample_dict["item_id"] = "ABCDEF2"
+    response = client.post("/new-sample/", json=default_sample_dict)
+    assert response.status_code == 201
+
+    for q in query_strings:
+        response = client.get(f"/search-items-ngram/?query={q}&types=samples")
+        assert response.status_code == 200
+        assert response.json["status"] == "success"
+        assert len(response.json["items"]) == 2
+        assert response.json["items"][0]["item_id"] == "ABCDEF"
+        assert response.json["items"][1]["item_id"] == "ABCDEF2"
+
+    # Check that updates are reflected in the ngram index
+    # This test also makes sure that the string 'test' is not picked up from the refcode,
+    # which has an explicit carve out
+    default_sample_dict["description"] = "test string with punctuation"
+    update_req = {"item_id": "ABCDEF2", "data": default_sample_dict}
+    response = client.post("/save-item/", json=update_req)
+    assert response.status_code == 200
+
+    query_strings = ("test", "punctuation")
+
+    for q in query_strings:
+        response = client.get(f"/search-items-ngram/?query={q}&types=samples")
+        assert response.status_code == 200
+        assert response.json["status"] == "success"
+        assert len(response.json["items"]) == 1
+        assert response.json["items"][0]["item_id"] == "ABCDEF2"

--- a/pydatalab/tests/server/test_ngram_fts.py
+++ b/pydatalab/tests/server/test_ngram_fts.py
@@ -46,6 +46,6 @@ def test_ngram_single_field():
     assert all([ngrams[e] == 1 for e in expected])
 
 
-def test_ngram_item(default):
+def test_ngram_item():
     item = {"refcode": "ABCDEF"}
-    assert _generate_item_ngrams(item, 3) == {"abc": 1, "bcd": 1, "cde": 1, "def": 1}
+    assert _generate_item_ngrams(item, {"refcode"}, n=3) == {"abc": 1, "bcd": 1, "cde": 1, "def": 1}

--- a/webapp/src/components/ItemSelect.vue
+++ b/webapp/src/components/ItemSelect.vue
@@ -43,7 +43,9 @@
 <script>
 import vSelect from "vue-select";
 import FormattedItemName from "@/components/FormattedItemName.vue";
-import { searchItems } from "@/server_fetch_utils.js";
+//! TO REMOVE
+import { searchItems, searchItemsNgram } from "@/server_fetch_utils.js";
+//! TO REMOVE
 import { debounceTime } from "@/resources.js";
 
 export default {
@@ -68,6 +70,12 @@ export default {
       type: String,
       default: "type to search...",
     },
+    //! TO REMOVE
+    ngram: {
+      type: Boolean,
+      default: false,
+    },
+    //! TO REMOVE
   },
   emits: ["update:modelValue"],
   data() {
@@ -97,7 +105,12 @@ export default {
       clearTimeout(this.debounceTimeout); // reset the timer
       // start the timer
       this.debounceTimeout = setTimeout(async () => {
-        await searchItems(query, 100, this.typesToQuery)
+        //! TO REMOVE
+        const searchFunction = this.ngram ? searchItemsNgram : searchItems;
+
+        await searchFunction(query, 100, this.typesToQuery)
+          //! TO REMOVE
+
           .then((items) => {
             this.items = items;
           })

--- a/webapp/src/components/Navbar.vue
+++ b/webapp/src/components/Navbar.vue
@@ -31,6 +31,9 @@
     <router-link to="/item-graph"
       ><font-awesome-icon icon="project-diagram" />&nbsp;Graph View</router-link
     >
+    <!--! TO REMOVE -->
+    | <router-link to="/ngram">Ngram Search</router-link>
+    <!--! TO REMOVE -->
   </div>
   <div v-if="!isLoggedIn" class="container">
     <div class="alert alert-info col-md-6 col-lg-4 text-center mx-auto">

--- a/webapp/src/router/index.js
+++ b/webapp/src/router/index.js
@@ -19,7 +19,18 @@ import Login3 from "../views/Login3.vue";
 //  return user !== null;
 //};
 
+//! TO REMOVE
+import NgramSearch from "../views/NgramSearch.vue";
+//! TO REMOVE
+
 const routes = [
+  //! TO REMOVE
+  {
+    path: "/ngram",
+    name: "ngram",
+    component: NgramSearch,
+  },
+  //! TO REMOVE
   {
     path: "/about",
     name: "About",

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -314,6 +314,21 @@ export function searchItems(query, nresults = 100, types = null) {
   });
 }
 
+//! TO REMOVE
+export function searchItemsNgram(query, nresults = 100, types = null) {
+  // construct a url with parameters:
+  var url = new URL(`${API_URL}/search-items-ngram/`);
+  var params = { query: query, nresults: nresults, types: types };
+  Object.keys(params).forEach((key) => url.searchParams.append(key, params[key]));
+  console.log(`using to construct url for searchItemsNgram: ${url}`);
+  console.log(url);
+  console.log(params);
+  return fetch_get(url).then(function (response_json) {
+    return response_json.items;
+  });
+}
+//! TO REMOVE
+
 export function searchCollections(query, nresults = 100) {
   // construct a url with parameters:
   var url = new URL(`${API_URL}/search-collections`);

--- a/webapp/src/views/NgramSearch.vue
+++ b/webapp/src/views/NgramSearch.vue
@@ -1,0 +1,44 @@
+<template>
+  <Navbar />
+
+  <div class="container mt-4">
+    <div class="row">
+      <div class="col-md-6">
+        <h3>Current Search</h3>
+        <ItemSelect
+          v-model="searchValue"
+          :ngram="false"
+          placeholder="Search with current implementation..."
+        />
+      </div>
+
+      <div class="col-md-6">
+        <h3>Ngram Search</h3>
+        <ItemSelect
+          v-model="searchValue"
+          :ngram="true"
+          placeholder="Search with ngram implementation..."
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Navbar from "@/components/Navbar";
+import ItemSelect from "@/components/ItemSelect.vue";
+
+export default {
+  components: {
+    Navbar,
+    ItemSelect,
+  },
+  data() {
+    return {
+      searchValue: "",
+    };
+  },
+};
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
Closes #679 -- MongoDB text indexes tokenize using whitespace and punctuation only. This PR investigates whether we can build a manual ngram index, so when searching for refcode `ABCDEF`, you get results if you only ask for `ABC`, `BCD` etc. 

This is done by making a separate collection called `item_fts` that is used only for this kind of search, by storing `immutable_id`, `type` and `ngrams` for all items, with an index over `ngrams`. Lookup is then done by ngrammifying the query string and doing array lookup and ordering by the number of matches.

Will have to fiddle around to see:
- what the optimal value of `N` is, and whether we need to do all N+1-grams up to a fixed range
- how expensive this is for realistic deployment sizes
- whether it might be better to try an edit-distance based approach for some fields