### PR TITLE
Explicitly don't use a polyfill for `vm`

### DIFF
--- a/webapp/vue.config.js
+++ b/webapp/vue.config.js
@@ -8,6 +8,7 @@ module.exports = {
       stream: require.resolve("stream-browserify"),
       process: require.resolve("process/browser"),
       buffer: require.resolve("buffer/"),
+      vm: false,
     };
     config.externals = {
       ...config.externals,


### PR DESCRIPTION
In our build, we are getting a warning about the fact that we don't have a polyfill for one of cypress's subdependencies, which uses the node.js `vm` function:

``` 
warning  in ./node_modules/asn1.js/lib/asn1/api.js

Module not found: Error: Can't resolve 'vm' in '/Users/josh/datalabvue/webapp/node_modules/asn1.js/lib/asn1'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
	- add a fallback 'resolve.fallback: { "vm": require.resolve("vm-browserify") }'
	- install 'vm-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
	resolve.fallback: { "vm": false }
```

I don't believe we really need the polyfill since since we haven't had one in for a while and the tests don't seem broken, so this PR just makes that explicit in `vue.config.js`