### PR TITLE
Fix and refactor FTS field generation

### DIFF
--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -57,6 +57,7 @@
     },
     "immutable_id": {
       "title": "Immutable ID",
+      "format": "uuid",
       "type": "string"
     },
     "last_modified": {
@@ -320,6 +321,7 @@
         },
         "immutable_id": {
           "title": "Immutable ID",
+          "format": "uuid",
           "type": "string"
         },
         "last_modified": {
@@ -411,6 +413,7 @@
         },
         "immutable_id": {
           "title": "Immutable ID",
+          "format": "uuid",
           "type": "string"
         },
         "last_modified": {
@@ -484,6 +487,7 @@
         },
         "immutable_id": {
           "title": "Immutable ID",
+          "format": "uuid",
           "type": "string"
         },
         "last_modified": {

--- a/pydatalab/schemas/equipment.json
+++ b/pydatalab/schemas/equipment.json
@@ -57,6 +57,7 @@
     },
     "immutable_id": {
       "title": "Immutable ID",
+      "format": "uuid",
       "type": "string"
     },
     "last_modified": {
@@ -275,6 +276,7 @@
         },
         "immutable_id": {
           "title": "Immutable ID",
+          "format": "uuid",
           "type": "string"
         },
         "last_modified": {
@@ -366,6 +368,7 @@
         },
         "immutable_id": {
           "title": "Immutable ID",
+          "format": "uuid",
           "type": "string"
         },
         "last_modified": {
@@ -439,6 +442,7 @@
         },
         "immutable_id": {
           "title": "Immutable ID",
+          "format": "uuid",
           "type": "string"
         },
         "last_modified": {

--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -57,6 +57,7 @@
     },
     "immutable_id": {
       "title": "Immutable ID",
+      "format": "uuid",
       "type": "string"
     },
     "last_modified": {
@@ -279,6 +280,7 @@
         },
         "immutable_id": {
           "title": "Immutable ID",
+          "format": "uuid",
           "type": "string"
         },
         "last_modified": {
@@ -370,6 +372,7 @@
         },
         "immutable_id": {
           "title": "Immutable ID",
+          "format": "uuid",
           "type": "string"
         },
         "last_modified": {
@@ -443,6 +446,7 @@
         },
         "immutable_id": {
           "title": "Immutable ID",
+          "format": "uuid",
           "type": "string"
         },
         "last_modified": {

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -57,6 +57,7 @@
     },
     "immutable_id": {
       "title": "Immutable ID",
+      "format": "uuid",
       "type": "string"
     },
     "last_modified": {
@@ -333,6 +334,7 @@
         },
         "immutable_id": {
           "title": "Immutable ID",
+          "format": "uuid",
           "type": "string"
         },
         "last_modified": {
@@ -424,6 +426,7 @@
         },
         "immutable_id": {
           "title": "Immutable ID",
+          "format": "uuid",
           "type": "string"
         },
         "last_modified": {
@@ -497,6 +500,7 @@
         },
         "immutable_id": {
           "title": "Immutable ID",
+          "format": "uuid",
           "type": "string"
         },
         "last_modified": {

--- a/pydatalab/src/pydatalab/models/entries.py
+++ b/pydatalab/src/pydatalab/models/entries.py
@@ -25,6 +25,7 @@ class Entry(BaseModel, abc.ABC):
         None,
         title="Immutable ID",
         alias="_id",
+        format="uuid",
     )
     """The immutable database ID of the entry."""
 

--- a/pydatalab/src/pydatalab/mongo.py
+++ b/pydatalab/src/pydatalab/mongo.py
@@ -27,7 +27,7 @@ ITEMS_FTS_FIELDS: set[str] = set().union(
     *(
         {
             f
-            for f, p in model.schema()["properties"].items()
+            for f, p in model.schema(by_alias=False)["properties"].items()
             if (p.get("type") == "string" and p.get("format") not in ("date-time", "uuid"))
         }
         for model in ITEM_MODELS.values()

--- a/pydatalab/tests/server/test_items.py
+++ b/pydatalab/tests/server/test_items.py
@@ -18,3 +18,11 @@ def test_single_item_endpoints(client, inserted_default_items):
         assert response.json["status"] == "success"
         assert response.json["item_id"] == item.item_id
         assert response.json["item_data"]["item_id"] == item.item_id
+
+
+def test_fts_fields():
+    """Test non-exhaustively that certain fields make it into the fts index."""
+    from pydatalab.mongo import ITEMS_FTS_FIELDS
+
+    fields = ("item_id", "name", "description", "refcode", "synthesis_description", "supplier")
+    assert all(field in ITEMS_FTS_FIELDS for field in fields)


### PR DESCRIPTION
Closes #997, and is related to #993

This PR improves how we choose which fields to use in the FTS.

Previously, some IDs were being included, which will no longer happen.

Also, some field names were being added by aliases that are not present in the database, so were excluded (mostly starting materials fields).