### PR TITLE
Revert overly smart schedule for upgrade PRs

### DIFF
--- a/.github/workflows/dependable-bot.yml
+++ b/.github/workflows/dependable-bot.yml
@@ -1,7 +1,7 @@
 name: Automatic `uv` dependency upgrades
 on:
   schedule:
-    - cron: "0 0 1-7,15-21 * 3"
+    - cron: "4 3 * * 3"  # Wednesday's in the early morning
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/dependable-bot.yml
+++ b/.github/workflows/dependable-bot.yml
@@ -1,7 +1,7 @@
 name: Automatic `uv` dependency upgrades
 on:
   schedule:
-    - cron: "4 3 * * 3"  # Wednesday's in the early morning
+    - cron: "4 3 * * 3"  # Wednesdays in the early morning
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/yarn-upgrade-bot.yml
+++ b/.github/workflows/yarn-upgrade-bot.yml
@@ -1,7 +1,7 @@
 name: Automatic `yarn` dependency upgrades
 on:
   schedule:
-    - cron: "0 0 8-14,21-31 * 3"
+    - cron: "5 3 * * 3"  # Wednesday's in the early morning
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/yarn-upgrade-bot.yml
+++ b/.github/workflows/yarn-upgrade-bot.yml
@@ -1,7 +1,7 @@
 name: Automatic `yarn` dependency upgrades
 on:
   schedule:
-    - cron: "5 3 * * 3"  # Wednesday's in the early morning
+    - cron: "5 3 * * 3"  # Wednesdays in the early morning
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
GitHub Actions schedules convert `day (month)` && `day (week)` clauses in cron jobs as `OR`, so we were just running every day of the week. This PR goes back to the simple case where both upgrade PRs run on a Wednesday. We can always just close the PR one week if we don't want to deal with it.