### PR TITLE
Add docker build var to spoof API version

### DIFF
--- a/.docker/server_dockerfile
+++ b/.docker/server_dockerfile
@@ -29,6 +29,12 @@ WORKDIR /app
 # Install the local version of the package and mount the repository data to get version info
 COPY ./pydatalab/ ./
 RUN git config --global --add safe.directory /
+
+# Used to fake the version of the package in cases where datalab is only
+# available as a git submodule or worktree
+ARG SETUPTOOLS_SCM_PRETEND_VERSION
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}
+
 # Install editable mode so that the server runs from a sensible place where we can stuff .env files
 RUN --mount=type=bind,target=/.git,source=./.git uv pip install --python /opt/.venv/bin/python --no-deps --editable .
 

--- a/.docker/server_dockerfile
+++ b/.docker/server_dockerfile
@@ -19,6 +19,11 @@ ENV UV_LINK_MODE=copy \
     UV_PROJECT_ENVIRONMENT=/opt/.venv \
     UV_PYTHON=python3.10
 
+# Used to fake the version of the package in cases where datalab is only
+# available as a git submodule or worktree
+ARG SETUPTOOLS_SCM_PRETEND_VERSION
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}
+
 WORKDIR /app
 COPY ./pydatalab/pyproject.toml .
 COPY ./pydatalab/uv.lock .
@@ -29,11 +34,6 @@ WORKDIR /app
 # Install the local version of the package and mount the repository data to get version info
 COPY ./pydatalab/ ./
 RUN git config --global --add safe.directory /
-
-# Used to fake the version of the package in cases where datalab is only
-# available as a git submodule or worktree
-ARG SETUPTOOLS_SCM_PRETEND_VERSION
-ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}
 
 # Install editable mode so that the server runs from a sensible place where we can stuff .env files
 RUN --mount=type=bind,target=/.git,source=./.git uv pip install --python /opt/.venv/bin/python --no-deps --editable .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       dockerfile: .docker/server_dockerfile
       args:
         - WEB_CONCURRENCY=4
+        - SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}
     depends_on:
       - database
     restart: unless-stopped


### PR DESCRIPTION
Right now, if the version of datalab is being installed from a git submodule, or a worktree, it is impossible to set the API version. For the app, we can override  this with the `VUE_APP_GIT_VERSION`. For the API, we have to use the `SETUPTOOLS_SCM_PRETEND_SCM_VERSION`. This PR passes that value through the build system to make it available when `uv` installs.