### PR TITLE
Tweak git version spoofing in docker config, and test it 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
         run: |
           cp webapp/.env.test_e2e .env
           echo "PYDATALAB_TESTING=true" >> pydatalab/.env
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION=0.11.11rc8" >> pydatalab/.env
 
       - name: Load previously built Docker images
         uses: docker/bake-action@v5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       dockerfile: .docker/server_dockerfile
       args:
         - WEB_CONCURRENCY=4
-        - SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}
+        - SETUPTOOLS_SCM_PRETEND_VERSION
     depends_on:
       - database
     restart: unless-stopped


### PR DESCRIPTION
- Remove annoying warning by removing default value for spoof version in docker-compose
- Add version spoof to CI to check that it does not introduce build failure