### PR TITLE
Dynamic table tweaks: filter by item type enum & resizable columns

### DIFF
--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -17,6 +17,8 @@
       filter-display="menu"
       :global-filter-fields="globalFilterFields"
       removable-sort
+      column-resize-mode="fit"
+      resizable-columns
       sort-mode="multiple"
       @filter="onFilter"
       @row-click="goToEditPage"

--- a/webapp/src/primevue-theme-preset.js
+++ b/webapp/src/primevue-theme-preset.js
@@ -68,6 +68,9 @@ const DatalabPreset = definePreset(Aura, {
         .p-datatable-filter-add-rule-button {
           display: none !important;
         }
+        .no-operator .p-datatable-filter-operator {
+          display: none !important;
+        }
       `,
 });
 


### PR DESCRIPTION
This PR attempts to turn on resizable columns and set the starting size with `"fit"`, addressing #889,

It also then tries to use a custom enum filtering for item types. For now, I just pull the values that the user has in the table, but ideally in the future it would query the server for the API schemas to see which types are available globally.

This doesn't quite work yet, the filtering does not seem to be applied correctly for types. Could oyu maybe take a look @BenjaminCharmes?