### PR TITLE
Use `<router-link>` for "Home" button on edit page to preserve store

### DIFF
--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -9,7 +9,7 @@
       <FormattedItemName :item_id="item_id" :item-type="itemType" />
     </span>
     <div class="navbar-nav">
-      <a class="nav-item nav-link" href="/">Home</a>
+      <router-link class="nav-item nav-link" to="/">Home</router-link>
       <div class="nav-item dropdown">
         <a
           id="navbarDropdown"


### PR DESCRIPTION
This will preserve the store when going back and forth betweens samples via the home button.

I think more generally, we can now think of more aggressively caching table data to speed-up load times, i.e., on table load, first just check the store and use that value if its not empty. Potentially an async load could then be triggered in the background (related to https://github.com/datalab-org/datalab/pull/1013#pullrequestreview-2468184726).