### PR TITLE
Add block types and titles to summary API response

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -163,6 +163,7 @@ def get_samples_summary(
 
     _project = {
         "_id": 0,
+        "blocks": {"blocktype": 1, "title": 1},
         "creators": {
             "display_name": 1,
             "contact_email": 1,


### PR DESCRIPTION
Closes #1000 by adding `blocktypes` in the sample summary responses, wanted to sneak this in before the release!