### PR TITLE
Update uv to 0.5.x now that dynamic versioning is supported

### DIFF
--- a/.docker/server_dockerfile
+++ b/.docker/server_dockerfile
@@ -12,7 +12,7 @@ RUN apt update && apt install -y gnupg curl tree mdbtools && apt clean
 WORKDIR /opt
 RUN wget https://fastdl.mongodb.org/tools/db/mongodb-database-tools-ubuntu2204-x86_64-100.9.0.deb && apt install ./mongodb-database-tools-*-100.9.0.deb
 
-COPY --from=ghcr.io/astral-sh/uv:0.4.21 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.5 /uv /usr/local/bin/uv
 ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
     UV_PYTHON_DOWNLOADS=never \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.4.21"
+          version: "0.5.x"
           enable-cache: true
 
       - name: Install dependencies
@@ -78,7 +78,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.4.21"
+          version: "0.5.x"
           enable-cache: true
 
       - name: Install locked versions of dependencies

--- a/pydatalab/uv.lock
+++ b/pydatalab/uv.lock
@@ -533,7 +533,6 @@ array = [
 
 [[package]]
 name = "datalab-server"
-version = "0.5.0.post2+g1abe64e0.d20250115"
 source = { editable = "." }
 dependencies = [
     { name = "bokeh" },
@@ -2772,7 +2771,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/58/edec25190b6403caf4426dd418234f2358a106634b7d6aa4aec6939b104f/watchdog-5.0.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:0f9332243355643d567697c3e3fa07330a1d1abf981611654a1f2bf2175612b7", size = 79334 },
     { url = "https://files.pythonhosted.org/packages/97/69/cfb2d17ba8aabc73be2e2d03c8c319b1f32053a02c4b571852983aa24ff2/watchdog-5.0.3-py3-none-win32.whl", hash = "sha256:c66f80ee5b602a9c7ab66e3c9f36026590a0902db3aea414d59a2f55188c1f49", size = 79320 },
     { url = "https://files.pythonhosted.org/packages/91/b4/2b5b59358dadfa2c8676322f955b6c22cde4937602f40490e2f7403e548e/watchdog-5.0.3-py3-none-win_amd64.whl", hash = "sha256:f00b4cf737f568be9665563347a910f8bdc76f88c2970121c86243c8cfdf90e9", size = 79325 },
-    { url = "https://files.pythonhosted.org/packages/38/b8/0aa69337651b3005f161f7f494e59188a1d8d94171666900d26d29d10f69/watchdog-5.0.3-py3-none-win_ia64.whl", hash = "sha256:49f4d36cb315c25ea0d946e018c01bb028048023b9e103d3d3943f58e109dd45", size = 79324 },
 ]
 
 [[package]]


### PR DESCRIPTION
This was causing some issues with later versions in the 0.4.x stream of `uv`.

Developers can update their own `uv` installations with `uv self update`.