### PR TITLE
Pin uv

### DIFF
--- a/.docker/server_dockerfile
+++ b/.docker/server_dockerfile
@@ -12,7 +12,7 @@ RUN apt update && apt install -y gnupg curl tree mdbtools && apt clean
 WORKDIR /opt
 RUN wget https://fastdl.mongodb.org/tools/db/mongodb-database-tools-ubuntu2204-x86_64-100.9.0.deb && apt install ./mongodb-database-tools-*-100.9.0.deb
 
-COPY --from=ghcr.io/astral-sh/uv:0.5 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.5.19 /uv /usr/local/bin/uv
 ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
     UV_PYTHON_DOWNLOADS=never \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.5.19"
           enable-cache: true
 
       - name: Install dependencies
@@ -78,7 +78,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.x"
+          version: "0.5.19"
           enable-cache: true
 
       - name: Install locked versions of dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.19"
+          version: "0.5.22"
           enable-cache: true
 
       - name: Install dependencies
@@ -78,7 +78,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.19"
+          version: "0.5.22"
           enable-cache: true
 
       - name: Install locked versions of dependencies

--- a/.github/workflows/dependable-bot.yml
+++ b/.github/workflows/dependable-bot.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.5.19"
+          version: "0.5.22"
           enable-cache: true
 
       - name: Sync latest compatible dependencies and commit

--- a/.github/workflows/dependable-bot.yml
+++ b/.github/workflows/dependable-bot.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.4.x"
+          version: "0.5.19"
           enable-cache: true
 
       - name: Sync latest compatible dependencies and commit

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,6 +47,8 @@ You will need Python 3.10 or higher to run *datalab*; we recommend using a tool 
 ##### Installation with `uv` or `venv`
 
 We recommend using [`uv`](https://github.com/astral-sh/uv) (see the linked repository or https://docs.astral.sh/uv for installation instructions) for managing your *datalab* installation.
+This is still a fledgling tool that is supporting a wider subset of features each day; for now, we recommend using the version pinned in our `.docker/server_dockerfile` (currently 0.5.19), otherwise you may need to regenerate the `uv.lock` file locally (please do not commit this file).
+
 
 You could also use the standard library `venv` module, but this will not allow you to install pinned dependencies as easily, and is significantly slower than `uv`.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,7 +47,7 @@ You will need Python 3.10 or higher to run *datalab*; we recommend using a tool 
 ##### Installation with `uv` or `venv`
 
 We recommend using [`uv`](https://github.com/astral-sh/uv) (see the linked repository or https://docs.astral.sh/uv for installation instructions) for managing your *datalab* installation.
-This is still a fledgling tool that is supporting a wider subset of features each day; for now, we recommend using the version pinned in our `.docker/server_dockerfile` (currently 0.5.19), otherwise you may need to regenerate the `uv.lock` file locally (please do not commit this file).
+This is still a fledgling tool that is supporting a wider subset of features each day; for now, we recommend using the version pinned in our `.docker/server_dockerfile`, otherwise you may need to regenerate the `uv.lock` file locally (please do not commit this file).
 
 
 You could also use the standard library `venv` module, but this will not allow you to install pinned dependencies as easily, and is significantly slower than `uv`.


### PR DESCRIPTION
This PR pins uv to 0.5.19 until the 0.6 release, as this version has working dynamic metadata + self-referential dependencies, which 0.5.20/21 seem to break (https://github.com/astral-sh/uv/issues/10776).

EDIT: This is already fixed in 0.5.22, so let's pin to that instead for now.