### PR TITLE
Fix docs link in mkdocs

### DIFF
--- a/pydatalab/mkdocs.yml
+++ b/pydatalab/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: datalab
 site_description: Documentation for datalab
-site_url: https://the-datalab.readthedocs.io
+site_url: https://docs.datalab-org.io
 
 theme:
   name: material


### PR DESCRIPTION
This should redirect anyway but we may as well use the real link.