### PR TITLE
Fix Datatable sorting for Collections and Creators

### DIFF
--- a/webapp/src/components/SampleTable.vue
+++ b/webapp/src/components/SampleTable.vue
@@ -34,8 +34,8 @@ export default {
         { field: "name", header: "Sample name" },
         { field: "chemform", header: "Formula", body: "ChemicalFormula" },
         { field: "date", header: "Date" },
-        { field: "collections", header: "Collections", body: "CollectionList", filter: true },
-        { field: "creators", header: "Creators", body: "Creators", filter: true },
+        { field: "collectionsList", header: "Collections", body: "CollectionList", filter: true },
+        { field: "creatorsList", header: "Creators", body: "Creators", filter: true },
         {
           field: "blocks",
           header: "",
@@ -49,11 +49,15 @@ export default {
   },
   computed: {
     samples() {
-      return this.$store.state.sample_list.map((sample) => ({
-        ...sample,
-        collectionsList: sample.collections.join(", "),
-        creatorsList: sample.creators.map((creator) => creator.display_name).join(", "),
-      }));
+      return this.$store.state.sample_list.map((sample) => {
+        return {
+          ...sample,
+          collectionsList: sample.collections
+            .map((collection) => collection.collection_id)
+            .join(", "),
+          creatorsList: sample.creators.map((creator) => creator.display_name).join(", "),
+        };
+      });
     },
   },
   mounted() {


### PR DESCRIPTION
Closes #1047 

This PR fixes the sorting issue for both `Collections` and `Creators` in the PrimeVue DataTable by ensuring that a list of strings is passed as props instead of arrays of objects.