### PR TITLE
Do not update 'files' reference when saving item

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -995,6 +995,7 @@ def save_item():
     for k in (
         "_id",
         "file_ObjectIds",
+        "files",
         "creators",
         "creator_ids",
         "item_id",


### PR DESCRIPTION
I accidentally depended on an item having `files` saved in the db, where actually it should only be a field constructed for the API response. This crept through as calling `save-item` from the app included this field, and as it fits the pydantic model, it was being saved in the database.

We still need a better way of distinguishing such fields between the database and API, by adding special validators to the base entry types and annotating them as such in our models, but this just patches this problem for now.