### PR TITLE
Update CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,17 +1,13 @@
 # YAML 1.2
 # Metadata for citation of this software according to the CFF format (https://citation-file-format.github.io/)
 cff-version: 1.2.0
-message: If you use this software, please cite the versioned archive.
+message: If you use this software in a publication, please cite the source code archive on Zenodo.
 title: datalab
-abstract: Datalab is a place to store experimental data and the connections between them.
-authors:
-- given-names: Matthew L.
-  family-names: Evans
-  orcid: https://orcid.org/0000-0002-1182-9098
-- given-names: Joshua D.
-  family-names: Bocarsly
-  orcid: https://orcid.org/0000-0002-7523-152X
-repository-code: https://github.com/the-grey-group/datalab
-url: https://github.com/the-grey-group/datalab
+abstract: datalab is a place to store experimental data and the connections between them.
+repository-code: https://github.com/datalab-org/datalab
+url: https://github.com/datalab-org/datalab
 type: software
 license: MIT
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.14719467


### PR DESCRIPTION
This PR adds the Zenodo DOI to our `CITATION.cff` file, and fixes the GitHub links. I *think* that by removing the author list, Zenodo will automatically pick up the GH contributors and any connected ORCID accounts they have (maybe @jdbocarsly make sure your ORCID is linked to GitHub). I'll see how this looks in the next release's Zenodo archive and maybe revert to the original if this is not the case. We can edit author metadata at any point directly in Zenodo anyway.