### PR TITLE
Add upper pin to pymongo

### DIFF
--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -45,7 +45,7 @@ version_scheme = "post-release"
 
 [project.optional-dependencies]
 server = [
-    "pymongo ~= 4.7",
+    "pymongo ~= 4.7, < 4.11",
     "Flask ~= 3.0",
     "Flask-Login ~= 0.6",
     "Flask-Cors ~= 5.0",

--- a/pydatalab/uv.lock
+++ b/pydatalab/uv.lock
@@ -680,7 +680,7 @@ requires-dist = [
     { name = "pybaselines", marker = "extra == 'apps'", specifier = "~=1.1" },
     { name = "pydantic", extras = ["dotenv", "email"], specifier = "<2.0" },
     { name = "pyjwt", marker = "extra == 'server'", specifier = "~=2.9" },
-    { name = "pymongo", marker = "extra == 'server'", specifier = "~=4.7" },
+    { name = "pymongo", marker = "extra == 'server'", specifier = "~=4.7,<4.11" },
     { name = "python-dateutil", marker = "extra == 'apps'", specifier = "~=2.9" },
     { name = "python-dotenv", marker = "extra == 'server'", specifier = "~=1.0" },
     { name = "rosettasciio", marker = "extra == 'apps'", specifier = "~=0.3,<0.4" },


### PR DESCRIPTION
pymongo 4.11 only supports MongoDB 4+, and we are quite behind in our MongoDB updates (see #814). This PR is a temporary fix.