### PR TITLE
Add regex-based alternative to full-text search

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -16,7 +16,7 @@ from pydatalab.models.items import Item
 from pydatalab.models.people import Person
 from pydatalab.models.relationships import RelationshipType
 from pydatalab.models.utils import generate_unique_refcode
-from pydatalab.mongo import flask_mongo
+from pydatalab.mongo import ITEMS_FTS_FIELDS, flask_mongo
 from pydatalab.permissions import PUBLIC_USER_ID, active_users_or_get_only, get_default_permissions
 
 ITEMS = Blueprint("items", __name__)
@@ -302,30 +302,41 @@ def search_items():
         # should figure out how to parse as list automatically
         types = types.split(",")
 
-    match_obj = {
-        "$text": {"$search": query},
-        **get_default_permissions(user_only=False),
-    }
-    if types is not None:
-        match_obj["type"] = {"$in": types}
+    pipeline = []
 
-    cursor = flask_mongo.db.items.aggregate(
-        [
-            {"$match": match_obj},
-            {"$sort": {"score": {"$meta": "textScore"}}},
-            {"$limit": nresults},
-            {
-                "$project": {
-                    "_id": 0,
-                    "type": 1,
-                    "item_id": 1,
-                    "name": 1,
-                    "chemform": 1,
-                    "refcode": 1,
-                }
-            },
-        ]
+    if isinstance(query, str) and query.startswith("%"):
+        query = query.lstrip("%")
+        match_obj = {
+            "$or": [{field: {"$regex": query, "$options": "i"}} for field in ITEMS_FTS_FIELDS]
+        }
+        match_obj.update(get_default_permissions(user_only=False))
+        pipeline.append({"$match": match_obj})
+
+    else:
+        match_obj = {
+            "$match": {
+                "$text": {"$search": query},
+                **get_default_permissions(user_only=False),
+            }
+        }
+        pipeline.append(match_obj)
+        pipeline.append({"$sort": {"score": {"$meta": "textScore"}}})
+
+    pipeline.append({"$limit": nresults})
+    pipeline.append(
+        {
+            "$project": {
+                "_id": 0,
+                "type": 1,
+                "item_id": 1,
+                "name": 1,
+                "chemform": 1,
+                "refcode": 1,
+            }
+        }
     )
+
+    cursor = flask_mongo.db.items.aggregate(pipeline)
 
     return jsonify({"status": "success", "items": list(cursor)}), 200
 
@@ -341,7 +352,7 @@ def _create_sample(
             dict(
                 status="error",
                 messages=f"""Request to create item with generate_id_automatically = true is incompatible with the provided item data,
-                which has an item_id included (provided id: {sample_dict['item_id']}")""",
+                which has an item_id included (provided id: {sample_dict["item_id"]}")""",
             ),
             400,
         )

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -304,6 +304,9 @@ def search_items():
 
     pipeline = []
 
+    if isinstance(query, str):
+        query = query.strip("'")
+
     if isinstance(query, str) and query.startswith("%"):
         query = query.lstrip("%")
         match_obj = {

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -192,6 +192,16 @@ def test_full_text_search(client, real_mongo_client, example_items):
     assert len(response.json["items"]) == 5
     assert response.json["items"][0]["item_id"] == "material"
 
+    # Test regex search
+    response = client.get("/search-items/?query='%mat'")
+
+    assert response.status_code == 200
+    assert response.json["status"] == "success"
+    assert len(response.json["items"]) == 2
+    item_ids = {item["item_id"] for item in response.json["items"]}
+    assert "material" in item_ids
+    assert "12345" in item_ids
+
 
 @pytest.mark.dependency(depends=["test_delete_sample"])
 def test_new_sample_with_relationships(client, complicated_sample):

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -193,11 +193,10 @@ def test_full_text_search(client, real_mongo_client, example_items):
     assert response.json["items"][0]["item_id"] == "material"
 
     # Test regex search
-    response = client.get("/search-items/?query='%mat'")
+    response = client.get("/search-items/?query=%mater")
 
     assert response.status_code == 200
     assert response.json["status"] == "success"
-    assert len(response.json["items"]) == 2
     item_ids = {item["item_id"] for item in response.json["items"]}
     assert "material" in item_ids
     assert "12345" in item_ids


### PR DESCRIPTION
After noodling around in #993, I think the conclusion is that its not worth maintaining a potentially large separate custom index for FTS that works with only a few characters. Instead, as a bit of a prototype, this PR adds a simple regex-based search that can triggered in the item select by prefixing the query with "%". This seems to work fairly well at our typical database sizes, but might need some optimisations. For now it also only uses the fields that are currently part of the free-text index, but this could be expanded (and we can add real indices over these fields if performance is bad).

Closes #679? 