### PR TITLE
Remove datatable-sort-badge when only one column is sorted

### DIFF
--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -480,11 +480,9 @@ export default {
   methods: {
     onSort(event) {
       const sortedColumns = event.multiSortMeta || [];
-      console.log(sortedColumns);
 
       this.$nextTick(() => {
         const tableHeaders = document.querySelectorAll(".p-datatable-sortable-column");
-        console.log(tableHeaders);
 
         tableHeaders.forEach((header) => {
           if (sortedColumns.length === 1) {

--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -26,6 +26,7 @@
       @row-select="null"
       @select-all-change="onSelectAllChange"
       @page="onPageChange"
+      @sort="onSort"
     >
       <!-- v-model:expandedRows="expandedRows" -->
 
@@ -477,6 +478,23 @@ export default {
     });
   },
   methods: {
+    onSort(event) {
+      const sortedColumns = event.multiSortMeta || [];
+      console.log(sortedColumns);
+
+      this.$nextTick(() => {
+        const tableHeaders = document.querySelectorAll(".p-datatable-sortable-column");
+        console.log(tableHeaders);
+
+        tableHeaders.forEach((header) => {
+          if (sortedColumns.length === 1) {
+            header.classList.add("hide-single-sort-badge");
+          } else {
+            header.classList.remove("hide-single-sort-badge");
+          }
+        });
+      });
+    },
     updateFilters(newFilters) {
       this.filters = newFilters;
     },

--- a/webapp/src/primevue-theme-preset.js
+++ b/webapp/src/primevue-theme-preset.js
@@ -71,6 +71,9 @@ const DatalabPreset = definePreset(Aura, {
         .no-operator .p-datatable-filter-operator {
           display: none !important;
         }
+        .p-datatable-sortable-column.hide-single-sort-badge .p-datatable-sort-badge {
+          display: none;
+        }
       `,
 });
 


### PR DESCRIPTION
Closes #1108 

The numbers always appear when you're in `sort-mode="multiple"` and prime-vue only removes them when you're in `sort-mode="single"`. This allows the user to know that they can sort several columns at once.

I guess we can find a way of removing the "1" when only one column is sorted, but I couldn't find anything in the prime-vue docs, or even using the custom theme we have in datalab (the two columns have exactly the same css classes), so I had to add another custom css class.

It's a first attempt to see what it could be.