### PR TITLE
Treat warnings in pytest as errors, fixing things along the way

### DIFF
--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -124,3 +124,8 @@ dev-dependencies = [
 
 [tool.pytest.ini_options]
 addopts = "--cov-report=term --cov-report=xml --cov ./src/pydatalab"
+filterwarnings = [
+    "error",
+    "ignore:.*np.bool8*:DeprecationWarning",
+
+]

--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -66,7 +66,7 @@ apps = [
     # NMR
     "nmrglue ~= 0.10",
     # Electrochemistry
-    "navani @ git+https://github.com/the-grey-group/navani.git@v0.1.7",
+    "navani @ git+https://github.com/the-grey-group/navani.git@v0.1.8",
     "galvani ~= 0.4, < 0.5",
     "NewareNDA >= 2024",
     # Raman
@@ -75,7 +75,7 @@ apps = [
     # TGA
     "python-dateutil ~= 2.9",
     # Insitu
-    "datalab-app-plugin-insitu @ git+https://github.com/datalab-org/datalab-app-plugin-insitu.git@v0.1.1",
+    "datalab-app-plugin-insitu @ git+https://github.com/datalab-org/datalab-app-plugin-insitu.git@v0.1.2",
 ]
 chat = [
     # Hard upper pin on langchain is 0.3 as pydantic is not supported

--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -98,11 +98,12 @@ line-length = 100
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W", "Q", "DTZ"]
+select = ["E", "F", "I", "W", "Q", "DTZ", "S"]
 ignore = ["E501", "E402"]
-fixable = ["A", "B", "C", "D", "E", "F", "I"]
+per-file-ignores = {"tests/*" = ["S101"]}
+
+fixable = ["A", "B", "C", "D", "E", "F", "I", "S"]
 unfixable = []
-per-file-ignores = {}
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
@@ -127,5 +128,10 @@ addopts = "--cov-report=term --cov-report=xml --cov ./src/pydatalab"
 filterwarnings = [
     "error",
     "ignore:.*np.bool8*:DeprecationWarning",
-
+    "ignore::pytest.PytestUnraisableExceptionWarning",
+    "ignore:.*Polyfit may be poorly conditioned*:numpy.RankWarning",
+    "ignore:.*invalid value encountered in sqrt*:RuntimeWarning",
+    "ignore:.*kernel_size exceeds volume extent*:UserWarning",
+    "ignore:.*divide by zero encountered in log10*:RuntimeWarning",
+    "ignore:.*invalid value encountered in log10*:RuntimeWarning",
 ]

--- a/pydatalab/src/pydatalab/apps/chat/blocks.py
+++ b/pydatalab/src/pydatalab/apps/chat/blocks.py
@@ -260,7 +260,7 @@ Start with a friendly introduction and give me a one sentence summary of what th
             # replace file_id with the actual filename
             file_id = block.pop("file_id", None)
             if file_id:
-                block["file"] = item_filenames.get(file_id, None)
+                block["file"] = item_filenames.get(file_id)
 
         top_level_keys_to_remove = [
             "display_order",

--- a/pydatalab/src/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/src/pydatalab/apps/echem/blocks.py
@@ -114,10 +114,10 @@ class CycleBlock(DataBlock):
         cycle_summary_df = None
         if not reload:
             if parsed_file_loc.exists():
-                raw_df = pd.read_pickle(parsed_file_loc)
+                raw_df = pd.read_pickle(parsed_file_loc)  # noqa: S301
 
             if cycle_summary_file_loc.exists():
-                cycle_summary_df = pd.read_pickle(cycle_summary_file_loc)
+                cycle_summary_df = pd.read_pickle(cycle_summary_file_loc)  # noqa: S301
 
         if raw_df is None:
             try:
@@ -137,8 +137,8 @@ class CycleBlock(DataBlock):
             if cycle_summary_df is None:
                 cycle_summary_df = ec.cycle_summary(raw_df)
                 cycle_summary_df.to_pickle(cycle_summary_file_loc)
-        except Exception:
-            pass
+        except Exception as exc:
+            LOGGER.warning("Cycle summary generation failed with error: %s", exc)
 
         raw_df = raw_df.filter(required_keys)
         raw_df.rename(columns=keys_with_units, inplace=True)

--- a/pydatalab/src/pydatalab/apps/nmr/utils.py
+++ b/pydatalab/src/pydatalab/apps/nmr/utils.py
@@ -117,7 +117,8 @@ def read_topspin_txt(filename, sample_mass_mg=None, nscans=None):
     size = int(size_match.group(1))
 
     intensity = np.genfromtxt(filename, comments="#")
-    assert len(intensity) == size, "length of intensities does not match I"
+    if len(intensity) != size:
+        raise RuntimeError(f"length of intensities does not match I ({size}) vs ({len(intensity)})")
 
     data = {
         "ppm": np.linspace(left, right, size),

--- a/pydatalab/src/pydatalab/backups.py
+++ b/pydatalab/src/pydatalab/backups.py
@@ -53,11 +53,11 @@ def take_snapshot(snapshot_path: Path, encrypt: bool = False) -> None:
         LOGGER.debug("Taking dump of database %s", CONFIG.MONGO_URI)
 
         # Check that mongodump is available
-        subprocess.check_output(["mongodump", "--version"])
+        subprocess.check_output(["mongodump", "--version"])  # noqa: S603, S607
 
         with tempfile.TemporaryDirectory() as temp_dir:
             command = ["mongodump", CONFIG.MONGO_URI, "--out", str(Path(temp_dir).resolve())]
-            subprocess.check_output(command)
+            subprocess.check_output(command)  # noqa: S603
 
             for file in Path(temp_dir).iterdir():
                 tar.add(file, arcname=Path("mongodb"))
@@ -67,7 +67,7 @@ def take_snapshot(snapshot_path: Path, encrypt: bool = False) -> None:
         LOGGER.debug("Dumping server config.")
         with tempfile.TemporaryDirectory() as temp_dir:
             with open(tmp_config := Path(temp_dir) / "config.json", "w") as f:
-                data = CONFIG.json(indent=2, skip_defaults=True)
+                data = CONFIG.json(indent=2, exclude_unset=True)
                 f.write(data)
 
                 tar.add(
@@ -107,15 +107,15 @@ def restore_snapshot(snapshot_path: Path, decrypt: bool = False):
     with tarfile.open(snapshot_path, mode=mode) as tar:
         LOGGER.debug("Restoring files from %s", snapshot_path)
         files = [m for m in tar.getmembers() if m.name.startswith("files/")]
-        tar.extractall(path=CONFIG.FILE_DIRECTORY, members=files)
+        tar.extractall(path=CONFIG.FILE_DIRECTORY, members=files)  # noqa: S202
         LOGGER.debug("Files restored from %s", snapshot_path)
 
         LOGGER.debug("Restoring database from %s", snapshot_path)
         with tempfile.TemporaryDirectory() as temp_dir:
             database = [m for m in tar.getmembers() if m.name.startswith("mongodb/")]
-            tar.extractall(path=temp_dir, members=database)
+            tar.extractall(path=temp_dir, members=database)  # noqa: S202
             command = ["mongorestore", CONFIG.MONGO_URI, "--drop", str(Path(temp_dir) / "mongodb")]
-            subprocess.check_output(command)
+            subprocess.check_output(command)  # noqa: S603
         LOGGER.debug("Database restored from %s", snapshot_path)
 
     LOGGER.info("Snapshot restored from %s", snapshot_path)

--- a/pydatalab/src/pydatalab/blocks/base.py
+++ b/pydatalab/src/pydatalab/blocks/base.py
@@ -19,7 +19,7 @@ def generate_random_id():
     The ids here are HTML id friendly, using lowercase letters and numbers. The first character
     is always a letter.
     """
-    randlist = [random.choice("abcdefghijklmnopqrstuvwxyz")] + random.choices(
+    randlist = [random.choice("abcdefghijklmnopqrstuvwxyz")] + random.choices(  # noqa: S311
         "abcdefghijklmnopqrstuvwxyz0123456789", k=14
     )
     return "".join(randlist)

--- a/pydatalab/src/pydatalab/config.py
+++ b/pydatalab/src/pydatalab/config.py
@@ -243,19 +243,19 @@ its importance when deploying a datalab instance.""",
         {
             "daily-snapshots": BackupStrategy(
                 hostname=None,
-                location="/tmp/datalab-backups/daily-snapshots/",
+                location="/tmp/datalab-backups/daily-snapshots/",  # noqa: S108
                 frequency="5 4 * * *",  # 4:05 every day
                 retention=7,
             ),
             "weekly-snapshots": BackupStrategy(
                 hostname=None,
-                location="/tmp/datalab-backups/weekly-snapshots/",
+                location="/tmp/datalab-backups/weekly-snapshots/",  # noqa: S108
                 frequency="5 3 * * 1",  # 03:05 every Monday
                 retention=5,
             ),
             "quarterly-snapshots": BackupStrategy(
                 hostname=None,
-                location="/tmp/datalab-backups/quarterly-snapshots/",
+                location="/tmp/datalab-backups/quarterly-snapshots/",  # noqa: S108
                 frequency="5 2 1 1,4,7,10 *",  # first of January, April, July, October at 02:05
                 retention=4,
             ),

--- a/pydatalab/src/pydatalab/file_utils.py
+++ b/pydatalab/src/pydatalab/file_utils.py
@@ -73,7 +73,7 @@ def _sync_file_with_remote(remote_path: str, src: str) -> None:
         pathlib.Path(src).parent.mkdir(parents=False, exist_ok=True)
 
         LOGGER.debug("Syncing file with '%s'", scp_command)
-        proc = subprocess.Popen(
+        proc = subprocess.Popen(  # noqa: S602
             scp_command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
         _, stderr = proc.communicate()
@@ -102,7 +102,7 @@ def _call_remote_stat(path: str):
     path = path.replace(r"\ ", " ").replace(" ", r"\ ")
     hostname, file_path = path.split(":", 1)
     command = f"ssh {hostname} 'stat -c %Y {file_path}'"
-    process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # noqa: S602
     LOGGER.debug(f"Calling {command}")
     try:
         stdout, stderr = process.communicate(timeout=20)

--- a/pydatalab/src/pydatalab/logger.py
+++ b/pydatalab/src/pydatalab/logger.py
@@ -99,7 +99,11 @@ def logged_route(fn: Callable):
                 request.get_json().keys() if request.get_json() else "null",
             )
         except Exception:
-            pass
+            LOGGER.debug(
+                "Calling %s with request: %s, Unable to decode JSON payload",
+                fn.__name__,
+                request,
+            )
         try:
             result = fn(*args, **kwargs)
 

--- a/pydatalab/src/pydatalab/models/utils.py
+++ b/pydatalab/src/pydatalab/models/utils.py
@@ -183,7 +183,7 @@ class RefCodeFactory:
 
 
 def random_uppercase(length: int = 6):
-    return "".join(random.choices(string.ascii_uppercase, k=length))
+    return "".join(random.choices(string.ascii_uppercase, k=length))  # noqa: S311
 
 
 class RandomAlphabeticalRefcodeFactory(RefCodeFactory):

--- a/pydatalab/src/pydatalab/mongo.py
+++ b/pydatalab/src/pydatalab/mongo.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from typing import List, Optional
 
 # Must be imported in this way to allow for easy patching with mongomock
@@ -44,6 +45,7 @@ def insert_pydantic_model_fork_safe(model: BaseModel, collection: str) -> str:
     )
 
 
+@lru_cache(maxsize=1)
 def _get_active_mongo_client(timeoutMS: int = 1000) -> pymongo.MongoClient:
     """Returns a `MongoClient` for the configured `MONGO_URI`,
     raising a `RuntimeError` if not available.
@@ -71,6 +73,7 @@ def _get_active_mongo_client(timeoutMS: int = 1000) -> pymongo.MongoClient:
         raise RuntimeError from exc
 
 
+@lru_cache(maxsize=1)
 def get_database() -> pymongo.database.Database:
     """Returns the configured database."""
     return _get_active_mongo_client().get_database()

--- a/pydatalab/src/pydatalab/remote_filesystems.py
+++ b/pydatalab/src/pydatalab/remote_filesystems.py
@@ -199,7 +199,7 @@ def _get_latest_directory_structure(
 
         """
         command = tree_command + [str(directory_path), "--timefmt", tree_timefmt]
-        process = subprocess.Popen(
+        process = subprocess.Popen(  # noqa: S603
             command,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -224,7 +224,7 @@ def _get_latest_directory_structure(
 
         """
         command = f"ssh {hostname} 'PATH=$PATH:~/ {' '.join(tree_command)} \"{directory_path}\" --timefmt {tree_timefmt}'"
-        process = subprocess.Popen(
+        process = subprocess.Popen(  # noqa: S602,S607
             command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
         LOGGER.debug(f"Calling {command}")

--- a/pydatalab/src/pydatalab/routes/v0_1/auth.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/auth.py
@@ -501,7 +501,7 @@ def get_authenticated_user_info():
 def generate_user_api_key():
     """Returns metadata associated with the currently authenticated user."""
     if current_user.is_authenticated:
-        new_key = "".join(random.choices(ascii_letters, k=KEY_LENGTH))
+        new_key = "".join(random.choices(ascii_letters, k=KEY_LENGTH))  # noqa: S311
         flask_mongo.db.api_keys.update_one(
             {"_id": ObjectId(current_user.id)},
             {"$set": {"hash": sha512(new_key.encode("utf-8")).hexdigest()}},

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -351,7 +351,7 @@ def _create_sample(
     copy_from_item_id: Optional[str] = None,
     generate_id_automatically: bool = False,
 ) -> tuple[dict, int]:
-    sample_dict["item_id"] = sample_dict.get("item_id", None)
+    sample_dict["item_id"] = sample_dict.get("item_id")
     if generate_id_automatically and sample_dict["item_id"]:
         return (
             dict(
@@ -625,7 +625,7 @@ def update_item_permissions(refcode: str):
     request_json = request.get_json()
     creator_ids: list[ObjectId] = []
 
-    if not len(refcode.split(":")) == 2:
+    if len(refcode.split(":")) != 2:
         refcode = f"{CONFIG.IDENTIFIER_PREFIX}:{refcode}"
 
     current_item = flask_mongo.db.items.find_one(
@@ -666,7 +666,7 @@ def update_item_permissions(refcode: str):
 
     # Validate all creator IDs are present in the database
     found_ids = [d for d in flask_mongo.db.users.find({"_id": {"$in": creator_ids}}, {"_id": 1})]  # type: ignore
-    if not len(found_ids) == len(creator_ids):
+    if len(found_ids) != len(creator_ids):
         return (
             jsonify(
                 {
@@ -704,7 +704,7 @@ def update_item_permissions(refcode: str):
         {"$set": {"creator_ids": creator_ids}},
     )
 
-    if not result.modified_count == 1:
+    if result.modified_count != 1:
         return jsonify(
             {
                 "status": "error",
@@ -765,7 +765,7 @@ def get_item_data(
     if item_id:
         match = {"item_id": item_id}
     elif refcode:
-        if not len(refcode.split(":")) == 2:
+        if len(refcode.split(":")) != 2:
             refcode = f"{CONFIG.IDENTIFIER_PREFIX}:{refcode}"
 
         match = {"refcode": refcode}
@@ -803,7 +803,7 @@ def get_item_data(
     if not doc or (
         not current_user.is_authenticated
         and not CONFIG.TESTING
-        and not doc["type"] == "starting_materials"
+        and doc["type"] != "starting_materials"
     ):
         return (
             jsonify(

--- a/pydatalab/tasks.py
+++ b/pydatalab/tasks.py
@@ -202,7 +202,9 @@ def _check_id(id=None, base_url=None, api_key=None):
     import requests
 
     log = setup_log("check_item_validity")
-    response = requests.get(f"{base_url}/get-item-data/{id}", headers={"DATALAB-API-KEY": api_key})
+    response = requests.get(
+        f"{base_url}/get-item-data/{id}", headers={"DATALAB-API-KEY": api_key}, timeout=30
+    )
     if response.status_code != 200:
         log.error(f"ꙮ {id!r}: {response.content!r}")
 
@@ -236,13 +238,13 @@ def check_item_validity(_, base_url: str | None = None, starting_materials: bool
 
     log = setup_log("check_item_validity")
 
-    user_response = requests.get(f"{base_url}/get-current-user/", headers=headers)
+    user_response = requests.get(f"{base_url}/get-current-user/", headers=headers, timeout=30)
     if not user_response.status_code == 200:
         raise SystemExit(f"Could not get current user: {user_response.content!r}")
 
     all_samples_ids = [
         d["item_id"]
-        for d in requests.get(f"{base_url}/samples/", headers=headers).json()["samples"]
+        for d in requests.get(f"{base_url}/samples/", headers=headers, timeout=30).json()["samples"]
     ]
 
     log.info(f"Found {len(all_samples_ids)} items")
@@ -255,9 +257,9 @@ def check_item_validity(_, base_url: str | None = None, starting_materials: bool
     if starting_materials:
         all_starting_material_ids = [
             d["item_id"]
-            for d in requests.get(f"{base_url}/starting-materials/", headers=headers).json()[
-                "items"
-            ]
+            for d in requests.get(
+                f"{base_url}/starting-materials/", headers=headers, timeout=30
+            ).json()["items"]
         ]
         multiprocessing.Pool(max(min(len(all_starting_material_ids), 8), 1)).map(
             functools.partial(_check_id, api_key=api_key, base_url=base_url),
@@ -296,13 +298,14 @@ def check_remotes(_, base_url: str | None = None, invalidate_cache: bool = False
 
     log = setup_log("check_remotes")
 
-    user_response = requests.get(f"{base_url}/get-current-user/", headers=headers)
+    user_response = requests.get(f"{base_url}/get-current-user/", headers=headers, timeout=30)
     if not user_response.status_code == 200:
         raise SystemExit(f"Could not get current user: {user_response.content!r}")
 
     directory_response = requests.get(
         f"{base_url}/list-remote-directories?invalidate_cache={'1' if invalidate_cache else '0'}",
         headers=headers,
+        timeout=30,
     )
 
     if directory_response.status_code != 200:

--- a/pydatalab/tests/server/conftest.py
+++ b/pydatalab/tests/server/conftest.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Union
 from unittest.mock import patch
 
 import mongomock
@@ -34,7 +33,7 @@ def monkeypatch_session():
 
 
 @pytest.fixture(scope="module")
-def real_mongo_client() -> Union[pymongo.MongoClient, None]:
+def real_mongo_client() -> pymongo.MongoClient | None:
     """Returns a connected MongoClient if available, otherwise `None`."""
     client = pymongo.MongoClient(
         MONGO_URI, connect=True, connectTimeoutMS=100, serverSelectionTimeoutMS=100
@@ -44,7 +43,8 @@ def real_mongo_client() -> Union[pymongo.MongoClient, None]:
     except pymongo.errors.ServerSelectionTimeoutError:
         return None
 
-    return client
+    yield client
+    client.close()
 
 
 @pytest.fixture(scope="module")
@@ -183,7 +183,7 @@ def deactivated_client(app, deactivated_user_api_key):
 def generate_api_key():
     import random
 
-    return "".join(random.choices("abcdef0123456789", k=24))
+    return "".join(random.choices("abcdef0123456789", k=24))  # noqa: S311
 
 
 @pytest.fixture(scope="function")

--- a/pydatalab/tests/server/test_equipment.py
+++ b/pydatalab/tests/server/test_equipment.py
@@ -39,7 +39,7 @@ def test_get_item_data(client, default_equipment_dict):
     assert len(response.json["item_data"]["creators"]) == 0
     assert len(response.json["item_data"]["creator_ids"]) == 0
 
-    for key in default_equipment_dict.keys():
+    for key in default_equipment_dict:
         if isinstance(v := default_equipment_dict[key], datetime.datetime):
             v = v.replace(tzinfo=datetime.timezone.utc).isoformat()
         assert response.json["item_data"][key] == v
@@ -70,7 +70,7 @@ def test_new_equipment_with_automatically_generated_id(client):
     assert response.json["status"] == "success"
     assert response.json["item_data"]["refcode"].split(":")[1] == created_item_id
 
-    for key in new_equipment_data.keys():
+    for key in new_equipment_data:
         if isinstance(v := new_equipment_data[key], datetime.datetime):
             v = v.replace(tzinfo=datetime.timezone.utc).isoformat()
         assert response.json["item_data"][key] == v
@@ -105,7 +105,7 @@ def test_save_good_equipment(client, default_equipment_dict):
     response = client.get("/get-item-data/test_e1")
     assert response.status_code == 200
     assert response.json["status"] == "success"
-    for key in default_equipment_dict.keys():
+    for key in default_equipment_dict:
         if key in updated_equipment and key in response.json:
             assert response.json[key] == updated_equipment[key]
 

--- a/pydatalab/tests/server/test_files.py
+++ b/pydatalab/tests/server/test_files.py
@@ -80,6 +80,7 @@ def test_get_file_and_delete(client, default_filepath, default_sample):
     assert file_response.json is None
     assert file_response.status_code == 200
     assert len(file_response.data) == 2465718
+    file_response.close()
 
     delete_response = client.post(
         "/delete-file-from-sample/",

--- a/pydatalab/tests/server/test_remote_filesystems.py
+++ b/pydatalab/tests/server/test_remote_filesystems.py
@@ -14,7 +14,7 @@ from pydatalab.remote_filesystems import (
 """The Unix `tree` utility is required for many of these tests,
 this variable checks whether it is installed locally."""
 TREE_AVAILABLE = False
-_ = sp.call("tree -v", shell=True)
+_ = sp.call("tree -v", shell=True)  # noqa: S602,S607
 if _ == 0:
     TREE_AVAILABLE = True
 

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -21,7 +21,7 @@ def test_new_sample(client, default_sample_dict):
     # Test that 201: Created is emitted
     assert response.status_code == 201, response.json
     assert response.json["status"] == "success"
-    for key in default_sample_dict.keys():
+    for key in default_sample_dict:
         if key == "creator_ids":
             continue
         if isinstance(v := default_sample_dict[key], datetime.datetime):
@@ -34,7 +34,7 @@ def test_get_item_data(client, default_sample_dict):
     response = client.get("/get-item-data/12345")
     assert response.status_code == 200
     assert response.json["status"] == "success"
-    for key in default_sample_dict.keys():
+    for key in default_sample_dict:
         if key == "creator_ids":
             continue
         if isinstance(v := default_sample_dict[key], datetime.datetime):
@@ -81,7 +81,7 @@ def test_new_sample_with_automatically_generated_id(client, user_id):
     assert response.json["status"] == "success"
     assert response.json["item_data"]["refcode"].split(":")[1] == created_item_id
 
-    for key in new_sample_data.keys():
+    for key in new_sample_data:
         if isinstance(v := new_sample_data[key], datetime.datetime):
             v = v.replace(tzinfo=datetime.timezone.utc).isoformat()
         if key == "creator_ids":
@@ -103,7 +103,7 @@ def test_save_good_sample(client, default_sample_dict):
     response = client.get("/get-item-data/12345")
     assert response.status_code == 200
     assert response.json["status"] == "success"
-    for key in default_sample_dict.keys():
+    for key in default_sample_dict:
         if key in updated_sample and key in response.json:
             assert response.json[key] == updated_sample[key]
 

--- a/pydatalab/tests/server/test_starting_materials.py
+++ b/pydatalab/tests/server/test_starting_materials.py
@@ -40,7 +40,7 @@ def test_get_item_data(admin_client, default_starting_material_dict):
     # all starting materials should have no creators currently (they are shared among a deployment):
     assert len(response.json["item_data"]["creators"]) == 0
     assert len(response.json["item_data"]["creator_ids"]) == 0
-    for key in default_starting_material_dict.keys():
+    for key in default_starting_material_dict:
         if key == "creator_ids":
             continue
 
@@ -77,7 +77,7 @@ def test_new_starting_material_with_automatically_generated_id(client):
     assert response.json["status"] == "success"
     assert response.json["item_data"]["refcode"].split(":")[1] == created_item_id
 
-    for key in new_starting_material_data.keys():
+    for key in new_starting_material_data:
         if key == "creator_ids":
             continue
         if isinstance(v := new_starting_material_data[key], datetime.datetime):
@@ -114,7 +114,7 @@ def test_save_good_starting_material(admin_client, default_starting_material_dic
     response = admin_client.get("/get-item-data/test_sm")
     assert response.status_code == 200
     assert response.json["status"] == "success"
-    for key in default_starting_material_dict.keys():
+    for key in default_starting_material_dict:
         if key in updated_starting_material and key in response.json:
             assert response.json[key] == updated_starting_material[key]
 

--- a/pydatalab/tests/test_config.py
+++ b/pydatalab/tests/test_config.py
@@ -21,8 +21,8 @@ def test_update_settings():
     }
     config.update(new_settings)
 
-    assert config.MONGO_URI == new_settings["mongo_uri"]
-    assert config.NEW_KEY == new_settings["new_key"]
+    assert new_settings["mongo_uri"] == config.MONGO_URI
+    assert new_settings["new_key"] == config.NEW_KEY
     assert config.SECRET_KEY
     assert Path(config.FILE_DIRECTORY).name == "files"
 
@@ -80,5 +80,5 @@ def test_mail_settings_combinations(tmpdir):
     env_file.write_text("MAIL_PASSWORD=password\nMAIL_DEFAULT_SENDER=test2@example.com")
 
     app = create_app(env_file=env_file)
-    assert app.config["MAIL_PASSWORD"] == "password"
+    assert app.config["MAIL_PASSWORD"] == "password"  # noqa: S105
     assert app.config["MAIL_DEFAULT_SENDER"] == "test2@example.com"

--- a/pydatalab/uv.lock
+++ b/pydatalab/uv.lock
@@ -543,8 +543,8 @@ array = [
 
 [[package]]
 name = "datalab-app-plugin-insitu"
-version = "0.1.1"
-source = { git = "https://github.com/datalab-org/datalab-app-plugin-insitu.git?rev=v0.1.1#52d116201fc663c5eb7a34878dcf5f1a5ba53af9" }
+version = "0.1.2"
+source = { git = "https://github.com/datalab-org/datalab-app-plugin-insitu.git?rev=v0.1.2#ce47ea2dfefa2be177b76bbf5b339abb47e98a67" }
 dependencies = [
     { name = "lmfit" },
     { name = "matplotlib" },
@@ -653,7 +653,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bokeh", specifier = "~=2.4,<3.0" },
-    { name = "datalab-app-plugin-insitu", marker = "extra == 'apps'", git = "https://github.com/datalab-org/datalab-app-plugin-insitu.git?rev=v0.1.1" },
+    { name = "datalab-app-plugin-insitu", marker = "extra == 'apps'", git = "https://github.com/datalab-org/datalab-app-plugin-insitu.git?rev=v0.1.2" },
     { name = "datalab-server", extras = ["apps", "chat", "server"], marker = "extra == 'all'" },
     { name = "flask", marker = "extra == 'server'", specifier = "~=3.0" },
     { name = "flask-compress", marker = "extra == 'server'", specifier = "~=1.15" },
@@ -669,7 +669,7 @@ requires-dist = [
     { name = "langchain-anthropic", marker = "extra == 'chat'", specifier = "~=0.1" },
     { name = "langchain-openai", marker = "extra == 'chat'", specifier = "~=0.1" },
     { name = "matplotlib", specifier = "~=3.8" },
-    { name = "navani", marker = "extra == 'apps'", git = "https://github.com/the-grey-group/navani.git?rev=v0.1.7" },
+    { name = "navani", marker = "extra == 'apps'", git = "https://github.com/the-grey-group/navani.git?rev=v0.1.8" },
     { name = "newarenda", marker = "extra == 'apps'", specifier = ">=2024" },
     { name = "nmrglue", marker = "extra == 'apps'", specifier = "~=0.10" },
     { name = "pandas", extras = ["excel"], specifier = "~=2.2" },
@@ -1672,8 +1672,8 @@ wheels = [
 
 [[package]]
 name = "navani"
-version = "0.1.5"
-source = { git = "https://github.com/the-grey-group/navani.git?rev=v0.1.7#d171781b483f0a17a0ada7a043c8f1e243499245" }
+version = "0.1.8"
+source = { git = "https://github.com/the-grey-group/navani.git#922ffe190ae76a1e00ec0396f00f62fd571b8a53" }
 dependencies = [
     { name = "galvani" },
     { name = "matplotlib" },


### PR DESCRIPTION
Closes #1115

This (ongoing) work uncovered some bugs:

- [x] galvani not releasing file descriptors for MPR files -> fixed in navani v0.1.8
- [x] in situ plugin pinning to navani too aggressively -> fixed in plugin v0.1.2
- [x] better closing of db connections (minor performance gain probably), think i'll remove flask-pymongo soon
- [x] skipping lots of warnings about nasty things we have to do (e.g., calling subprocesses)
- [x] skipping some numerical warnings for e.g., baseline corrections in XRD