### PR TITLE
[WIP] Improving formatting of valid chemical formulae

### DIFF
--- a/webapp/src/components/ChemicalFormula.vue
+++ b/webapp/src/components/ChemicalFormula.vue
@@ -1,11 +1,6 @@
 <template>
   <span>
     {{ chemFormulaFormat }}
-    <!--
-    <span v-for="(match, index) in chemFormulaFormat" :key="index">
-      {{ match[1] }}<sub v-if="match[2]">{{ match[2] }}</sub>
-    </span>
-    -->
   </span>
 </template>
 
@@ -19,13 +14,29 @@ export default {
   },
   computed: {
     chemFormulaFormat() {
+      // Need to capture several groups, if the overall format doesn't apply, then
+      // there should be no additional formatting whatsoever
+      //
+      // Some rules:
+      //
+      // * numbers between element symbols need to be subscripted, including "." and variables like "x"
+      //    - e.g., Na3P => Na<sub>3</sub>P, Na3+xP => Na<sub>3+x</sub>P
+      // * charges need to be handled separately and superscripted
+      //    - e.g., Na+Cl- => Na<sup>+</sup>Cl<sup>-</sup>
+      // * empirical labels for formula units like [pyr] must be left alone
+      // * dots, when not used within numbers, must be treated as an interpunct "dot product" style dot
+      //     - e.g., Cu2SO4.H2O => Cu<sub>2</sub>SO<sub>4</sub> · H<sub>2</sub>O
+      if (!this.formula) {
+        return this.formula;
+      }
+      // Optimistically subscript all numbers in formula if it matches
+      // regexp for element symbols, brackets and numbers only
+      const chemicalFormulaRegex = /[A-Z][a-z]{0,2}(?:\d*(?:\.\d+)?)?|[([{]|[)]}]/g;
+      if (this.formula.match(chemicalFormulaRegex)) {
+        // Do stuff
+      }
+
       return this.formula;
-      //if (!this.formula) {
-      //  return " ";
-      //}
-      //const re = /([A-Z][a-z]?)(\d+\.?\d*)?/g;
-      //var all_matches = [...this.formula.matchAll(re)];
-      //return all_matches;
     },
   },
 };


### PR DESCRIPTION
For now, this PR simply starts listing some rules on chemical formulae formatting that we can follow eventually, e.g.:

```
    chemFormulaFormat() {
      // Need to capture several groups, if the overall format doesn't apply, then
      // there should be no additional formatting whatsoever
      //
      // Some rules:
      //
      // * numbers between element symbols need to be subscripted, including "." and variables like "x"
      //    - e.g., Na3P => Na<sub>3</sub>P, Na3+xP => Na<sub>3+x</sub>P
      // * charges need to be handled separately and superscripted
      //    - e.g., Na+Cl- => Na<sup>+</sup>Cl<sup>-</sup>
      // * empirical labels for formula units like [pyr] must be left alone
      // * dots, when not used within numbers, must be treated as an interpunct "dot product" style dot
      //     - e.g., Cu2SO4.H2O => Cu<sub>2</sub>SO<sub>4</sub> · H<sub>2</sub>O

```

I think many of these can be handled selectively with some judicious regexes, and beyond formatting, the same rules could be used to validate e.g., empirical formulae in JS used for computing yields and the like.