### PR TITLE
[WIP] Add yields section to synthesis tables and models

### DIFF
--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -130,6 +130,14 @@
         "$ref": "#/definitions/Constituent"
       }
     },
+    "synthesis_products": {
+      "title": "Synthesis Products",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Constituent"
+      }
+    },
     "synthesis_description": {
       "title": "Synthesis Description",
       "type": "string"

--- a/pydatalab/src/pydatalab/models/samples.py
+++ b/pydatalab/src/pydatalab/models/samples.py
@@ -17,8 +17,22 @@ class Sample(Item):
     synthesis_constituents: List[Constituent] = Field([])
     """A list of references to constituent materials giving the amount and relevant inlined details of consituent items."""
 
+    synthesis_products: List[Constituent] = Field([])
+    """A list of references to constituent materials giving the amount and relevant inlined details of relevant sythesis products."""
+
     synthesis_description: Optional[str]
     """Free-text details of the procedure applied to synthesise the sample"""
+
+    @root_validator
+    def add_self_product(cls, values):
+        if not values.get("synthesis_products"):
+            values["synthesis_products"].append(
+                Constituent(
+                    quantity=None, item={"type": values["type"], "item_id": values["item_id"]}
+                )
+            )
+
+        return values
 
     @root_validator
     def add_missing_synthesis_relationships(cls, values):

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -882,7 +882,7 @@ def get_item_data(
     )
 
     # Must be exported to JSON first to apply the custom pydantic JSON encoders
-    return_dict = json.loads(doc.json(exclude_unset=True))
+    return_dict = json.loads(doc.json())
 
     if item_id is None:
         item_id = return_dict["item_id"]

--- a/webapp/src/components/CompactConstituentTable.vue
+++ b/webapp/src/components/CompactConstituentTable.vue
@@ -113,8 +113,8 @@ export default {
   },
   props: {
     modelValue: {
-      type: String,
-      default: "",
+      type: Array,
+      default: () => [],
     },
     typesToQuery: {
       type: Array,
@@ -132,7 +132,7 @@ export default {
   },
   computed: {
     newSelectIsShown() {
-      return this.constituents.length == 0 || this.addNewConstituentIsActive;
+      return this.addNewConstituentIsActive;
     },
     constituents: {
       get() {

--- a/webapp/src/components/SynthesisInformation.vue
+++ b/webapp/src/components/SynthesisInformation.vue
@@ -1,20 +1,39 @@
 <template>
   <div id="synthesis-information">
-    <label class="mr-2 pb-2">Synthesis Information</label>
-    <div class="card component-card">
-      <div class="card-body pt-2 pb-0 mb-0 pl-5">
-        <CompactConstituentTable
-          id="synthesis-table"
-          v-model="constituents"
-          :types-to-query="['samples', 'starting_materials']"
-        />
+    <label for="synthesis-information" class="mr-2">Synthesis information</label>
+    <div class="card">
+      <span id="synthesis-reactants-label" class="subheading mt-2 pb-2 ml-2">
+        <label for="synthesis-reactants-table">Reactants, reagents, inputs</label>
+      </span>
+      <div class="component-card">
+        <div class="card-body pt-2 pb-0 mb-0 pl-5">
+          <CompactConstituentTable
+            id="synthesis-reactants-table"
+            v-model="constituents"
+            :types-to-query="['samples', 'starting_materials']"
+          />
+        </div>
       </div>
+      <span id="synthesis-products-label" class="subheading mt-2 pb-2 ml-2"
+        ><label for="synthesis-products-table">Products</label></span
+      >
+      <div class="component-card">
+        <div class="card-body pt-2 pb-0 mb-0 pl-5">
+          <CompactConstituentTable
+            id="synthesis-products-table"
+            v-model="products"
+            :types-to-query="['samples', 'starting_materials']"
+          />
+        </div>
+      </div>
+      <span id="synthesis-procedure-label" class="subheading mt-2 pb-2 ml-2"
+        ><label>Procedure</label></span
+      >
+      <TinyMceInline
+        v-model="SynthesisDescription"
+        aria-labelledby="synthesis-procedure-label"
+      ></TinyMceInline>
     </div>
-    <span id="synthesis-procedure-label" class="subheading ml-2">Procedure</span>
-    <TinyMceInline
-      v-model="SynthesisDescription"
-      aria-labelledby="synthesis-procedure-label"
-    ></TinyMceInline>
   </div>
 </template>
 
@@ -31,15 +50,9 @@ export default {
   props: {
     item_id: { type: String, required: true },
   },
-  data() {
-    return {
-      selectedNewConstituent: null,
-      selectedChangedConstituent: null,
-      selectShown: [],
-    };
-  },
   computed: {
     constituents: createComputedSetterForItemField("synthesis_constituents"),
+    products: createComputedSetterForItemField("synthesis_products"),
     SynthesisDescription: createComputedSetterForItemField("synthesis_description"),
   },
   watch: {
@@ -51,35 +64,11 @@ export default {
       },
       deep: true,
     },
-  },
-  mounted() {
-    this.selectShown = new Array(this.constituents.length).fill(false);
-  },
-  methods: {
-    addConstituent(selectedItem) {
-      this.constituents.push({
-        item: selectedItem,
-        quantity: null,
-        unit: "g",
-      });
-      this.selectedNewConstituent = null;
-      this.selectShown.push(false);
-    },
-    turnOnRowSelect(index) {
-      this.selectShown[index] = true;
-      this.selectedChangedConstituent = this.constituents[index].item;
-      this.$nextTick(function () {
-        // unfortunately this seems to be the "official" way to focus on the select element:
-        this.$refs[`select${index}`].$refs.selectComponent.$refs.search.focus();
-      });
-    },
-    swapConstituent(selectedItem, index) {
-      this.constituents[index].item = selectedItem;
-      this.selectShown[index] = false;
-    },
-    removeConstituent(index) {
-      this.constituents.splice(index, 1);
-      this.selectShown.splice(index, 1);
+    products: {
+      handler() {
+        this.$store.commit("setItemSaved", { item_id: this.item_id, isSaved: false });
+      },
+      deep: true,
     },
   },
 };
@@ -91,6 +80,5 @@ export default {
   font-size: small;
   font-weight: 600;
   text-transform: uppercase;
-  margin-bottom: 0px;
 }
 </style>


### PR DESCRIPTION
Initial work on adding products/yields to synthesis information. Probably blocked by #1101 at the moment. 

This PR adds a `synthesis_products` field that is by default added with a self-loop to the current sample.

Things to consider:

- [ ] Should we ban self-loops elsewhere in this description?
- [ ] Should the model be extended to specify both yield % and amount + unit, or should yield always be computed dynamically? (or equivalently, should yield % be an allowed value for amount + unit itself if computed externally)