### PR TITLE
Fix oversharing regex search

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -314,7 +314,7 @@ def search_items():
         match_obj = {
             "$or": [{field: {"$regex": query, "$options": "i"}} for field in ITEMS_FTS_FIELDS]
         }
-        match_obj.update(get_default_permissions(user_only=False))
+        match_obj = {"$and": [get_default_permissions(user_only=False), match_obj]}
         pipeline.append({"$match": match_obj})
 
     else:


### PR DESCRIPTION
Closes #1130, fairly urgently. This had not been deployed anywhere but is a bit nasty in terms of allowing users to search for other user's samples.

This could be avoided in the future by wrapping all database access in a class that injects permissions at the top level, though this is only worth doing once the new permissions system is in.

I'll merge this myself once the tests pass.