### PR TITLE
Add guard for block info loading to edit page

### DIFF
--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -70,7 +70,7 @@
     </div>
 
     <!-- Display the blocks -->
-    <div v-if="blocksLoaded" class="container block-container">
+    <div v-if="blocksLoaded && blockInfoLoaded" class="container block-container">
       <transition-group name="block-list" tag="div">
         <div v-for="block_id in item_data.display_order" :key="block_id" class="block-list-item">
           <component :is="getBlockDisplayType(block_id)" :item_id="item_id" :block_id="block_id" />


### PR DESCRIPTION
I think one of the errors I see in development a lot has just come up during #1133 -- if a block tries to access its schema when loading (to e.g., get accepted file extensions), then this can sometimes fail if the store is not ready. This PR simply adds the existing guard for whether block schemas have been loaded before loading the block list itself. At some point we should refactor the store to do a lot of this stuff automatically.