### PR TITLE
Allow runtime compose args to be set from environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ services:
       context: .
       dockerfile: .docker/server_dockerfile
       args:
-        - WEB_CONCURRENCY=4
-        - SETUPTOOLS_SCM_PRETEND_VERSION
+        WEB_CONCURRENCY: ${WEB_CONCURRENCY:-4}
+        SETUPTOOLS_SCM_PRETEND_VERSION: ${SETUPTOOLS_SCM_PRETEND_VERSION}
     depends_on:
       - database
     restart: unless-stopped


### PR DESCRIPTION
Previously it was impossible to set e.g., `WEB_CONCURRENCY` at anything but the default value, as the it would be overridden by the compose file value.