### PR TITLE
Refactor app block loading to prevent optional dependencies from breaking dev builds

### DIFF
--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "pydantic[email, dotenv] < 2.0",
     "pint ~= 0.24",
     "pandas[excel] ~= 2.2",
+    "pymongo ~= 4.7, < 4.11",
 ]
 
 [project.urls]
@@ -46,7 +47,6 @@ version_scheme = "post-release"
 
 [project.optional-dependencies]
 server = [
-    "pymongo ~= 4.7, < 4.11",
     "Flask ~= 3.0",
     "Flask-Login ~= 0.6",
     "Flask-Cors ~= 5.0",

--- a/pydatalab/src/pydatalab/apps/__init__.py
+++ b/pydatalab/src/pydatalab/apps/__init__.py
@@ -1,2 +1,125 @@
-# This import is required to prevent circular imports for application-specific blocks
-from pydatalab.blocks.base import DataBlock  # noqa
+"""This module provides a convenience wrapper for loading all
+'app' blocks, which may or may not be available.
+
+"""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # This import is required to prevent circular imports for application-specific blocks
+    from pydatalab.blocks.base import DataBlock  # noqa
+
+from pydatalab.blocks import COMMON_BLOCKS
+
+
+def _check_error(e):
+    if "circular" in str(e):
+        raise ImportError(e) from e
+
+
+def load_app_blocks():
+    app_blocks: list[type["DataBlock"]] = []
+
+    try:
+        # A dummy block that is used to check that bad blocks do not break the import
+        from pydatalab.apps._canary import CanaryBlock
+
+        app_blocks.append(CanaryBlock)
+    except ImportError as e:
+        _check_error(e)
+
+    try:
+        from pydatalab.apps.chat import ChatBlock
+
+        app_blocks.append(ChatBlock)
+    except ImportError as e:
+        _check_error(e)
+
+    try:
+        from pydatalab.apps.echem import CycleBlock
+
+        app_blocks.append(CycleBlock)
+    except ImportError as e:
+        _check_error(e)
+
+    try:
+        from pydatalab.apps.eis import EISBlock
+
+        app_blocks.append(EISBlock)
+    except ImportError as e:
+        _check_error(e)
+
+    try:
+        from pydatalab.apps.ftir import FTIRBlock
+
+        app_blocks.append(FTIRBlock)
+    except ImportError as e:
+        _check_error(e)
+
+    try:
+        from pydatalab.apps.nmr import NMRBlock
+
+        app_blocks.append(NMRBlock)
+    except ImportError as e:
+        _check_error(e)
+
+    try:
+        from pydatalab.apps.raman import RamanBlock
+
+        app_blocks.append(RamanBlock)
+    except ImportError as e:
+        _check_error(e)
+
+    try:
+        from pydatalab.apps.tga import MassSpecBlock
+
+        app_blocks.append(MassSpecBlock)
+    except ImportError as e:
+        _check_error(e)
+
+    try:
+        from pydatalab.apps.uvvis import UVVisBlock
+
+        app_blocks.append(UVVisBlock)
+    except ImportError as e:
+        _check_error(e)
+
+    try:
+        from pydatalab.apps.xrd import XRDBlock
+
+        app_blocks.append(XRDBlock)
+    except ImportError as e:
+        _check_error(e)
+
+    return app_blocks
+
+
+BLOCKS = COMMON_BLOCKS + load_app_blocks()
+BLOCK_TYPES: dict[str, type["DataBlock"]] = {block.blocktype: block for block in BLOCKS}
+
+
+def load_block_plugins():
+    """Search through any registered entrypoints at 'pydatalab.apps.plugins'
+    and load them as DataBlock subclasses.
+    """
+    from importlib.metadata import entry_points
+
+    from pydatalab.blocks.base import DataBlock
+
+    block_plugins: dict[str, type[DataBlock]] = {}
+    for entry_point in entry_points(group="pydatalab.apps.plugins"):
+        block = entry_point.load()
+
+        if not issubclass(block, DataBlock):
+            raise ValueError(f"Plugin {block} must be a subclass of DataBlock")
+
+        block_plugins[block.blocktype] = block
+
+        if block.blocktype not in BLOCK_TYPES:
+            BLOCK_TYPES[block.blocktype] = block
+            BLOCKS.append(block)
+
+    return block_plugins
+
+
+load_block_plugins()

--- a/pydatalab/src/pydatalab/apps/_canary/__init__.py
+++ b/pydatalab/src/pydatalab/apps/_canary/__init__.py
@@ -1,0 +1,6 @@
+from pydatalab.blocks.base import DataBlock
+
+raise ImportError("This canary block is only used for internal testing of dynamic block loading.")
+
+
+class CanaryBlock(DataBlock): ...

--- a/pydatalab/src/pydatalab/blocks/__init__.py
+++ b/pydatalab/src/pydatalab/blocks/__init__.py
@@ -1,73 +1,12 @@
-from pydatalab.apps.chat.blocks import ChatBlock
-from pydatalab.apps.echem import CycleBlock
-from pydatalab.apps.eis import EISBlock
-from pydatalab.apps.ftir import FTIRBlock
-from pydatalab.apps.nmr import NMRBlock
-from pydatalab.apps.raman import RamanBlock
-from pydatalab.apps.tga import MassSpecBlock
-from pydatalab.apps.uvvis import UVVisBlock
-from pydatalab.apps.xrd import XRDBlock
+# Base block import has to go first to avoid circular deps
 from pydatalab.blocks.base import DataBlock
 from pydatalab.blocks.common import CommentBlock, MediaBlock, NotSupportedBlock, TabularDataBlock
 
-BLOCKS: list[type["DataBlock"]] = [
+COMMON_BLOCKS: list[type[DataBlock]] = [
     CommentBlock,
     MediaBlock,
-    XRDBlock,
-    CycleBlock,
-    RamanBlock,
-    NMRBlock,
     NotSupportedBlock,
-    MassSpecBlock,
-    ChatBlock,
-    EISBlock,
     TabularDataBlock,
-    FTIRBlock,
-    UVVisBlock,
 ]
 
-BLOCK_TYPES: dict[str, type["DataBlock"]] = {block.blocktype: block for block in BLOCKS}
-
-
-def load_block_plugins():
-    """Search through any registered entrypoints at 'pydatalab.apps.plugins'
-    and load them as DataBlock subclasses.
-    """
-    from importlib.metadata import entry_points
-
-    block_plugins: dict[str, type[DataBlock]] = {}
-    for entry_point in entry_points(group="pydatalab.apps.plugins"):
-        block = entry_point.load()
-
-        if not issubclass(block, DataBlock):
-            raise ValueError(f"Plugin {block} must be a subclass of DataBlock")
-
-        block_plugins[block.blocktype] = block
-
-        if block.blocktype not in BLOCK_TYPES:
-            BLOCK_TYPES[block.blocktype] = block
-            BLOCKS.append(block)
-
-    return block_plugins
-
-
-load_block_plugins()
-
-__all__ = (
-    "CommentBlock",
-    "MediaBlock",
-    "XRDBlock",
-    "ChatBlock",
-    "EISBlock",
-    "CycleBlock",
-    "NotSupportedBlock",
-    "NMRBlock",
-    "RamanBlock",
-    "MassSpecBlock",
-    "TabularDataBlock",
-    "FTIRBlock",
-    "BLOCK_TYPES",
-    "BLOCKS",
-    "load_block_plugins",
-    "UVVisBlock",
-)
+__all__ = ("COMMON_BLOCKS", "DataBlock")

--- a/pydatalab/src/pydatalab/blocks/base.py
+++ b/pydatalab/src/pydatalab/blocks/base.py
@@ -3,8 +3,6 @@ import warnings
 from collections.abc import Callable, Sequence
 from typing import Any
 
-from bson import ObjectId
-
 from pydatalab.logger import LOGGER
 
 __all__ = ("generate_random_id", "DataBlock")
@@ -124,6 +122,7 @@ class DataBlock:
     def to_db(self):
         """returns a dictionary with the data for this
         block, ready to be input into mongodb"""
+        from bson import ObjectId
 
         LOGGER.debug("Casting block %s to database object.", self.__class__.__name__)
 

--- a/pydatalab/src/pydatalab/blocks/common.py
+++ b/pydatalab/src/pydatalab/blocks/common.py
@@ -2,11 +2,11 @@ import base64
 import io
 import warnings
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-import pandas as pd
-from PIL import Image
+if TYPE_CHECKING:
+    import pandas as pd
 
-from pydatalab.file_utils import get_file_info_by_id
 from pydatalab.logger import LOGGER
 
 from .base import DataBlock
@@ -49,6 +49,10 @@ class MediaBlock(DataBlock):
         return (self.encode_tiff,)
 
     def encode_tiff(self):
+        from PIL import Image
+
+        from pydatalab.file_utils import get_file_info_by_id
+
         if "file_id" not in self.data:
             LOGGER.warning("ImageBlock.encode_tiff(): No file set in the DataBlock")
             return
@@ -81,16 +85,17 @@ class TabularDataBlock(DataBlock):
     def plot_functions(self):
         return (self.plot_df,)
 
-    def _load(self) -> pd.DataFrame:
+    def _load(self) -> "pd.DataFrame":
         if "file_id" not in self.data:
             return
+        from pydatalab.file_utils import get_file_info_by_id
 
         file_info = get_file_info_by_id(self.data["file_id"], update_if_live=True)
 
         return self.load(file_info["location"])
 
     @classmethod
-    def load(cls, location: Path | str) -> pd.DataFrame:
+    def load(cls, location: Path | str) -> "pd.DataFrame":
         """Throw several pandas readers at the target file.
 
         If an excel-like format, try to read it with `pandas.read_excel()`.
@@ -101,6 +106,8 @@ class TabularDataBlock(DataBlock):
             pd.DataFrame: The loaded dataframe.
 
         """
+        import pandas as pd
+
         if not isinstance(location, Path):
             location = Path(location)
 

--- a/pydatalab/src/pydatalab/routes/v0_1/blocks.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/blocks.py
@@ -1,7 +1,7 @@
 import pymongo.errors
 from flask import Blueprint, jsonify, request
 
-from pydatalab.blocks import BLOCK_TYPES
+from pydatalab.apps import BLOCK_TYPES
 from pydatalab.blocks.base import DataBlock
 from pydatalab.logger import LOGGER
 from pydatalab.mongo import flask_mongo
@@ -27,7 +27,13 @@ def add_data_block():
     insert_index = request_json["index"]
 
     if block_type not in BLOCK_TYPES:
-        return jsonify(status="error", message="Invalid block type"), 400
+        return (
+            jsonify(
+                status="error",
+                message=f"Invalid block type {block_type!r}, must be one of {BLOCK_TYPES.keys()}",
+            ),
+            400,
+        )
 
     block = BLOCK_TYPES[block_type](item_id=item_id)
 

--- a/pydatalab/src/pydatalab/routes/v0_1/info.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/info.py
@@ -8,7 +8,7 @@ from flask import Blueprint, jsonify, request
 from pydantic import AnyUrl, BaseModel, Field, validator
 
 from pydatalab import __version__
-from pydatalab.blocks import BLOCK_TYPES
+from pydatalab.apps import BLOCK_TYPES
 from pydatalab.config import CONFIG, FEATURE_FLAGS, FeatureFlags
 from pydatalab.models import Collection, Person
 from pydatalab.models.items import Item

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -8,7 +8,7 @@ from pydantic import ValidationError
 from pymongo.command_cursor import CommandCursor
 from pymongo.errors import DuplicateKeyError
 
-from pydatalab.blocks import BLOCK_TYPES
+from pydatalab.apps import BLOCK_TYPES
 from pydatalab.config import CONFIG
 from pydatalab.logger import LOGGER
 from pydatalab.models import ITEM_MODELS

--- a/pydatalab/tests/apps/test_plugins.py
+++ b/pydatalab/tests/apps/test_plugins.py
@@ -1,5 +1,5 @@
 # Load block types first to avoid circular dependency issues
-from pydatalab.blocks import BLOCK_TYPES, BLOCKS, load_block_plugins
+from pydatalab.apps import BLOCK_TYPES, BLOCKS, load_block_plugins
 
 
 def test_load_plugins():
@@ -11,3 +11,14 @@ def test_load_plugins():
     assert isinstance(BLOCK_TYPES["insitu-nmr"], type)
     assert BLOCK_TYPES["insitu-nmr"] == InsituBlock
     assert InsituBlock in BLOCKS
+
+
+def test_load_app_blocks():
+    from pydatalab.apps import load_app_blocks
+    from pydatalab.apps.echem import CycleBlock
+    from pydatalab.apps.xrd import XRDBlock
+
+    app_blocks = load_app_blocks()
+
+    assert CycleBlock in app_blocks
+    assert XRDBlock in app_blocks

--- a/pydatalab/uv.lock
+++ b/pydatalab/uv.lock
@@ -577,6 +577,7 @@ dependencies = [
     { name = "periodictable" },
     { name = "pint" },
     { name = "pydantic", extra = ["dotenv", "email"] },
+    { name = "pymongo" },
 ]
 
 [package.optional-dependencies]
@@ -598,7 +599,6 @@ all = [
     { name = "pillow" },
     { name = "pybaselines" },
     { name = "pyjwt" },
-    { name = "pymongo" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "rosettasciio" },
@@ -640,7 +640,6 @@ server = [
     { name = "paramiko" },
     { name = "pillow" },
     { name = "pyjwt" },
-    { name = "pymongo" },
     { name = "python-dotenv" },
     { name = "werkzeug" },
 ]
@@ -686,7 +685,7 @@ requires-dist = [
     { name = "pybaselines", marker = "extra == 'apps'", specifier = "~=1.1" },
     { name = "pydantic", extras = ["dotenv", "email"], specifier = "<2.0" },
     { name = "pyjwt", marker = "extra == 'server'", specifier = "~=2.9" },
-    { name = "pymongo", marker = "extra == 'server'", specifier = "~=4.7,<4.11" },
+    { name = "pymongo", specifier = "~=4.7,<4.11" },
     { name = "python-dateutil", marker = "extra == 'apps'", specifier = "~=2.9" },
     { name = "python-dotenv", marker = "extra == 'server'", specifier = "~=1.0" },
     { name = "rosettasciio", marker = "extra == 'apps'", specifier = "~=0.3,<0.4" },


### PR DESCRIPTION
Closes #1178 by moving all block loading into the apps module.

This still feels like a bit of a temporary solution, ideally this could be refactored away at some point with better hierarchy between apps and blocks, but for now this is the way of doing it with minimal server import changes (otherwise we'd have to move the base data block and change every block and plugin to use a new location of base data block). The overall problem stems from the fact that the base block is implemented in `pydatalab.blocks.base` and we want to import it, and many child classes of it, from the top-level `pydatalab.blocks`. This PR simply moves the loading stage into `pydatalab.apps`.

Also makes pymongo a core dep.

Relatedly we should also worry about https://github.com/datalab-org/datalab/issues/1159 -- providing a proper error when an unknown block is encountered

NB/ as this changes the internal datalab API, we should reserve this for the next minor release (also hopefully soon).