### PR TITLE
Enable flake8-logging-rules (G) in ruff

### DIFF
--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -96,14 +96,16 @@ line-length = 100
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W", "Q", "DTZ", "S"]
+select = ["E", "F", "I", "W", "Q", "DTZ", "S", "G"]
 ignore = ["E501", "E402"]
 per-file-ignores = {"tests/*" = ["S101"]}
 
-fixable = ["A", "B", "C", "D", "E", "F", "I", "S"]
+fixable = ["A", "B", "C", "D", "E", "F", "I", "S", "G"]
 unfixable = []
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+logger-objects = ["pydatalab.logger.LOGGER"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["pydatalab"]


### PR DESCRIPTION
Related to #971, this PR enables the `flake8-logging-rules` set in Ruff. The main change is preventing eagerly formatted strings in cases where the logger does not need to output anything, e.g., `LOGGER.debug(f"Hard to compute thing: {hard_to_compute_thing}")` which will run even if the logger is not in debug mode.