### PR TITLE
Delete large keys (e.g., bokeh_plot_data) when sending and before receiving updated block data

### DIFF
--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -485,8 +485,14 @@ export async function getCollectionData(collection_id) {
 }
 
 export async function updateBlockFromServer(item_id, block_id, block_data, saveToDatabase = true) {
-  console.log("updateBlockFromServer called with data:");
-  console.log(block_data);
+  // Send the current block state to the API and receive an updated version
+  // of the block in return
+  //
+  // - Will strip known "large data" keys, even if not formalised, e.g., bokeh_plot_data.
+  //
+  delete block_data.bokeh_plot_data;
+  delete block_data.processed_data;
+  delete block_data.metadata;
   store.commit("setBlockUpdating", block_id);
   return fetch_post(`${API_URL}/update-block/`, {
     item_id: item_id,

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -233,7 +233,10 @@ export default createStore({
     updateBlockData(state, payload) {
       // requires the following fields in payload:
       // item_id, block_id, block_data
-      console.log("updating block data with:", payload);
+      // This process should invalidate any existing bokeh plot, which may not be present if the plotting
+      // in the new block failed.
+      state.all_item_data[payload.item_id]["blocks_obj"][payload.block_id]["bokeh_plot_data"] =
+        null;
       Object.assign(
         state.all_item_data[payload.item_id]["blocks_obj"][payload.block_id],
         payload.block_data,


### PR DESCRIPTION
Closes #1206 by zeroing the store data for plots when receiving a new version (in case the new version does not contain a plot).

Likewise, drops bokeh plot data (and other large fields) when sending information back to the API about the block (should be significantly faster), as these are not used anywhere at the moment. In future, this should be standardized by properly nesting block fields rather than polluting the top-level namespace.