### PR TITLE
Prepare 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This release includes significant new functionality and UI redesign, as well as
 several bug and quality-of-life fixes, performance improvements and
 backwards-compatible API enhancements.
 
+
+!!! warning
+This release also bumps the supported MongoDB version all the way from v3 to v8. 
+Whilst older MongoDB versions should still continue to work, version 8 will now be tested and used in the docker builds, so we recommend you upgrade.
+For existing databases this requires you to first dump the database using `mongodump` with the old MongoDB version, then upgrade to the new version and restore the database with `mongorestore`. 
+If you unsure about this process then please ask us for help!
+
 ### Highlights
 
 - Extra functionality for all data tables: column selection, persistent user

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ several bug and quality-of-life fixes, performance improvements and
 backwards-compatible API enhancements.
 
 > [!WARNING]
-> This release also bumps the supported MongoDB version all the way from v3 to v8. 
+> This release also bumps the supported MongoDB version all the way from v3 to v8.
 > Whilst older MongoDB versions should still continue to work, version 8 will now be tested and used in the docker builds, so we recommend you upgrade.
-> For existing databases this requires you to first dump the database using `mongodump` with the old MongoDB version, then upgrade to the new version and restore the database with `mongorestore`. 
+> For existing databases this requires you to first dump the database using `mongodump` with the old MongoDB version, then upgrade to the new version and restore the database with `mongorestore`.
 > If you unsure about this process then please ask us for help!
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@ This release includes significant new functionality and UI redesign, as well as
 several bug and quality-of-life fixes, performance improvements and
 backwards-compatible API enhancements.
 
-
-!!! warning MongoDB version 8
-    This release also bumps the supported MongoDB version all the way from v3 to v8. 
-    Whilst older MongoDB versions should still continue to work, version 8 will now be tested and used in the docker builds, so we recommend you upgrade.
-    For existing databases this requires you to first dump the database using `mongodump` with the old MongoDB version, then upgrade to the new version and restore the database with `mongorestore`. 
-    If you unsure about this process then please ask us for help!
+> [!WARNING]
+> This release also bumps the supported MongoDB version all the way from v3 to v8. 
+> Whilst older MongoDB versions should still continue to work, version 8 will now be tested and used in the docker builds, so we recommend you upgrade.
+> For existing databases this requires you to first dump the database using `mongodump` with the old MongoDB version, then upgrade to the new version and restore the database with `mongorestore`. 
+> If you unsure about this process then please ask us for help!
 
 ### Highlights
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ several bug and quality-of-life fixes, performance improvements and
 backwards-compatible API enhancements.
 
 
-!!! warning
-This release also bumps the supported MongoDB version all the way from v3 to v8. 
-Whilst older MongoDB versions should still continue to work, version 8 will now be tested and used in the docker builds, so we recommend you upgrade.
-For existing databases this requires you to first dump the database using `mongodump` with the old MongoDB version, then upgrade to the new version and restore the database with `mongorestore`. 
-If you unsure about this process then please ask us for help!
+!!! warning MongoDB version 8
+    This release also bumps the supported MongoDB version all the way from v3 to v8. 
+    Whilst older MongoDB versions should still continue to work, version 8 will now be tested and used in the docker builds, so we recommend you upgrade.
+    For existing databases this requires you to first dump the database using `mongodump` with the old MongoDB version, then upgrade to the new version and restore the database with `mongorestore`. 
+    If you unsure about this process then please ask us for help!
 
 ### Highlights
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,7 @@ several bug and quality-of-life fixes, performance improvements and
 backwards-compatible API enhancements.
 
 > [!WARNING]
-> This release also bumps the supported MongoDB version all the way from v3 to v8.
-> Whilst older MongoDB versions should still continue to work, version 8 will now be tested and used in the docker builds, so we recommend you upgrade.
-> For existing databases this requires you to first dump the database using `mongodump` with the old MongoDB version, then upgrade to the new version and restore the database with `mongorestore`.
-> If you unsure about this process then please ask us for help!
+> This release also bumps the supported MongoDB version all the way from v3 to v8. Whilst older MongoDB versions should still continue to work, version 8 will now be tested and used in the docker builds, so we recommend you upgrade. For existing databases this requires you to first dump the database using `mongodump` with the old MongoDB version, then upgrade to the new version and restore the database with `mongorestore`. If you unsure about this process then please ask us for help!
 
 ### Highlights
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.6.0 (May 2025)
+## v0.6.0 (June 2025)
 
 This release includes significant new functionality and UI redesign, as well as
 several bug and quality-of-life fixes, performance improvements and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog
 
+## v0.6.0 (May 2025)
+
+This release includes significant new functionality and UI redesign, as well as
+several bug and quality-of-life fixes, performance improvements and
+backwards-compatible API enhancements.
+
+### Highlights
+
+- Extra functionality for all data tables: column selection, persistent user
+  preferences and improved filtering.
+- Improved inventory management: native UI for hazard labels, CAS numbers and external barcodes,
+  complementing the first release of the
+  [`datalab-cheminventory-plugin`](https://github.com/datalab-industries/datalab-cheminventory-plugin)
+  for two-way sync with [cheminventory.net](https://cheminventory.net).
+- Starting materials can now also have synthesis information recorded for them.
+- New blocks for UV-Vis data and *in situ* NMR data (developed in separate core
+  plugin at
+  [`datalab-app-plugin-insitu`](https://github.com/datalab-org/datalab-app-plugin-insitu)),
+  as well as new file formats supported in the XRD (Rigaku's .rasx, variants of .xy), NMR (JCAMP-DX) blocks
+  and media block (PDF documents).
+- Improved item search throughout the API, removing the need to search on
+  whitespace or puncutation delimited words (e.g., ID matches will now begin after
+  just 3 characters, rather than needing to type a full ID).
+
+
+## v0.5.2 (March 2025)
+
+This patch release makes several visual/interactivity improvements around
+loading states in the UI, and adds two new blocks: FTIR and a tabular data
+block for plotting data from within generic CSV/Excel files.
+
+## What's Changed
+* Fix docs link in mkdocs by @ml-evs in https://github.com/datalab-org/datalab/pull/1044
+* Improve loading state for data-intensive blocks by @BenjaminCharmes in https://github.com/datalab-org/datalab/pull/1049
+* Add support for reading excel-like spreadsheets in tabular data block by @ml-evs in https://github.com/datalab-org/datalab/pull/1052
+* Add Login Splash Screen by @BenjaminCharmes in https://github.com/datalab-org/datalab/pull/907
+* Added FTIR block and associated tests by @be-smith in https://github.com/datalab-org/datalab/pull/1061
+* Update CITATION.cff by @ml-evs in https://github.com/datalab-org/datalab/pull/1069
+
+## New Contributors
+* @be-smith made their first contribution in https://github.com/datalab-org/datalab/pull/1061
+
+**Full Changelog**: https://github.com/datalab-org/datalab/compare/v0.5.1...v0.5.2
+
+## v0.5.1 (January 2025)
+
+This patch release simply pins the `uv` version used in builds to avoid future breakages.
+
+## What's Changed
+
+* Bump the github-actions group across 1 directory with 2 updates by @dependabot in https://github.com/datalab-org/datalab/pull/1031
+* Update uv to 0.5.x now that dynamic versioning is supported by @ml-evs in https://github.com/datalab-org/datalab/pull/1032
+* Pin uv by @ml-evs in https://github.com/datalab-org/datalab/pull/1039
+
+
+**Full Changelog**: https://github.com/datalab-org/datalab/compare/v0.5.0...v0.5.1
+
 ## v0.5.0 (December 2024)
 
 This release is long overdue following the 8 pre-releases. The 0.5.x series now provides a stable base for us to begin some major overhauling of how we handle custom schemas and data blocks, both of which will form the basis of 0.6.x in the new year.

--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@ with several instances deployed for members in the
 [*datalab* federation](https://github.com/datalab-org/datalab-federation).
 
 > [!NOTE]
-> You may be looking for the identically named project
-> [DataLab](https://datalab-platform.com) for signal
-> processing, which also has plugins, clients and other shared concepts!
+> You may be looking for the identically named project [DataLab](https://datalab-platform.com) for signal processing, which also has plugins, clients and other shared concepts!
 
 <div align="center">
 <video width="400" controls src="https://github.com/datalab-org/datalab/assets/7916000/0065cdd6-a5f0-4391-b192-0137fe208acc">

--- a/pydatalab/mkdocs.yml
+++ b/pydatalab/mkdocs.yml
@@ -49,6 +49,7 @@ markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.highlight
+  - callouts
   - pymdownx.superfences:
       # Allows mermaid code blocks to be rendered via mermaid.js
       custom_fences:

--- a/pydatalab/mkdocs.yml
+++ b/pydatalab/mkdocs.yml
@@ -49,7 +49,7 @@ markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.highlight
-  - callouts
+  - github-callouts
   - pymdownx.superfences:
       # Allows mermaid code blocks to be rendered via mermaid.js
       custom_fences:

--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -126,6 +126,7 @@ dev-dependencies = [
     "mkdocs-material ~= 9.5",
     "mkdocstrings[python] ~= 0.29",
     "mkdocs-awesome-pages-plugin ~= 2.9",
+    "markdown-callouts ~= 0.4",
 ]
 
 [tool.uv.sources]

--- a/pydatalab/uv.lock
+++ b/pydatalab/uv.lock
@@ -549,6 +549,7 @@ server = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "markdown-callouts" },
     { name = "mkdocs" },
     { name = "mkdocs-awesome-pages-plugin" },
     { name = "mkdocs-material" },
@@ -602,6 +603,7 @@ provides-extras = ["server", "apps", "app-plugins-git", "chat", "deploy", "all"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "markdown-callouts", specifier = "~=0.4" },
     { name = "mkdocs", specifier = "~=1.6" },
     { name = "mkdocs-awesome-pages-plugin", specifier = "~=2.9" },
     { name = "mkdocs-material", specifier = "~=9.5" },
@@ -1298,6 +1300,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/28/3af612670f82f4c056911fbbbb42760255801b3068c48de792d354ff4472/markdown-3.7.tar.gz", hash = "sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2", size = 357086 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/08/83871f3c50fc983b88547c196d11cf8c3340e37c32d2e9d6152abe2c61f7/Markdown-3.7-py3-none-any.whl", hash = "sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803", size = 106349 },
+]
+
+[[package]]
+name = "markdown-callouts"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/73/ae5aa379f6f7fea9d0bf4cba888f9a31d451d90f80033ae60ae3045770d5/markdown_callouts-0.4.0.tar.gz", hash = "sha256:7ed2c90486967058a73a547781121983839522d67041ae52c4979616f1b2b746", size = 9768 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/b5/7b0a0a52c82bfccd830af2a8cc8add1c5bc932e0204922434954a631dd51/markdown_callouts-0.4.0-py3-none-any.whl", hash = "sha256:ed0da38f29158d93116a0d0c6ecaf9df90b37e0d989b5337d678ee6e6d6550b7", size = 7108 },
 ]
 
 [[package]]


### PR DESCRIPTION
Update changelog with 0.6.0 changes, and make a few docs tweaks.

Closes #1241 and #1196.