### PR TITLE
Replace browser-native dialogs with custom datalab dialog service

### DIFF
--- a/webapp/cypress/support/commands.js
+++ b/webapp/cypress/support/commands.js
@@ -85,10 +85,8 @@ Cypress.Commands.add("deleteItems", (type, items_id) => {
   cy.get('[data-testid="selected-dropdown"]').click();
   cy.get('[data-testid="delete-selected-button"]').click();
 
-  cy.on("window:confirm", (text) => {
-    expect(text).to.contains(items_id);
-    return true;
-  });
+  cy.findByText("Confirm Deletion").should("exist");
+  cy.get('[data-testid="dialog-modal-confirm-button"]').click();
 
   items_id.forEach((item_id) => {
     cy.get(`[data-testid=${type}-table]`)

--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -1,6 +1,17 @@
 <template>
   <router-view />
+  <DialogContainer />
 </template>
+
+<script>
+import DialogContainer from "@/components/DialogContainer.vue";
+
+export default {
+  components: {
+    DialogContainer,
+  },
+};
+</script>
 
 <style>
 body {

--- a/webapp/src/components/BatchCreateItemModal.vue
+++ b/webapp/src/components/BatchCreateItemModal.vue
@@ -339,6 +339,7 @@
 
 <script>
 import Modal from "@/components/Modal.vue";
+import { DialogService } from "@/services/DialogService.js";
 import ItemSelect from "@/components/ItemSelect.vue";
 import { createNewSamples } from "@/server_fetch_utils.js";
 import { validateEntryID } from "@/field_utils.js";
@@ -592,8 +593,10 @@ export default {
           this.beforeSubmit = false;
         })
         .catch((error) => {
-          window.alert("Error with creating new items: " + error);
-          console.log("Error with creating new items: " + error);
+          DialogService.error({
+            title: "Error creating item batch",
+            message: "An error occured while creating the batch:" + error.message,
+          });
         });
     },
     openEditPagesInNewTabs() {

--- a/webapp/src/components/CollectionSelect.vue
+++ b/webapp/src/components/CollectionSelect.vue
@@ -37,6 +37,8 @@
 </template>
 
 <script>
+import { DialogService } from "@/services/DialogService";
+
 import vSelect from "vue-select";
 import FormattedCollectionName from "@/components/FormattedCollectionName.vue";
 import {
@@ -158,9 +160,11 @@ export default {
           }
         } catch (error) {
           console.error("Error:", error);
-          alert(
-            "An error occurred while creating the collection. Please check that your desired collection ID is valid.",
-          );
+          DialogService.error({
+            title: "Collection Creation Failed",
+            message:
+              "An error occurred while creating the collection. Please check that your desired collection ID is valid.",
+          });
         }
       }
     },

--- a/webapp/src/components/CreateCollectionModal.vue
+++ b/webapp/src/components/CreateCollectionModal.vue
@@ -44,6 +44,8 @@
 </template>
 
 <script>
+import { DialogService } from "@/services/DialogService";
+
 import Modal from "@/components/Modal.vue";
 import ItemSelect from "@/components/ItemSelect.vue";
 import { createNewCollection } from "@/server_fetch_utils.js";
@@ -100,7 +102,10 @@ export default {
             console.log("error parsing error message", e);
           } finally {
             if (!id_error) {
-              alert("Error with creating new sample: " + error);
+              DialogService.error({
+                title: "Collection Creation Failed",
+                message: "Error with creating new collection: " + error,
+              });
             }
           }
         });

--- a/webapp/src/components/CreateEquipmentModal.vue
+++ b/webapp/src/components/CreateEquipmentModal.vue
@@ -95,6 +95,8 @@
 </template>
 
 <script>
+import { DialogService } from "@/services/DialogService";
+
 import Modal from "@/components/Modal.vue";
 import ItemSelect from "@/components/ItemSelect.vue";
 import { createNewItem } from "@/server_fetch_utils.js";
@@ -189,7 +191,10 @@ export default {
             console.log("error parsing error message", e);
           } finally {
             if (!is_item_id_error) {
-              alert("Error with creating new equipment: " + error);
+              DialogService.error({
+                title: "Creation Error",
+                message: "Error with creating new equipment: " + error,
+              });
             }
           }
         });

--- a/webapp/src/components/CreateItemModal.vue
+++ b/webapp/src/components/CreateItemModal.vue
@@ -104,6 +104,8 @@
 </template>
 
 <script>
+import { DialogService } from "@/services/DialogService";
+
 import Modal from "@/components/Modal.vue";
 import ItemSelect from "@/components/ItemSelect.vue";
 import { createNewItem } from "@/server_fetch_utils.js";
@@ -208,7 +210,10 @@ export default {
             console.log("error parsing error message", e);
           } finally {
             if (!is_item_id_error) {
-              alert("Error with creating new item: " + error);
+              DialogService.error({
+                title: "Creation Error",
+                message: "Error with creating new item: " + error,
+              });
             }
           }
         });

--- a/webapp/src/components/DialogContainer.vue
+++ b/webapp/src/components/DialogContainer.vue
@@ -1,0 +1,51 @@
+<template>
+  <DialogModal
+    v-if="currentDialog"
+    v-model:isVisible="isVisible"
+    :title="currentDialog.title"
+    :message="currentDialog.message"
+    :type="currentDialog.type"
+    :confirm-button-text="currentDialog.confirmButtonText"
+    :cancel-button-text="currentDialog.cancelButtonText"
+    :show-cancel-button="currentDialog.showCancelButton"
+    :show-close-button="currentDialog.showCloseButton"
+    :close-on-overlay-click="currentDialog.closeOnOverlayClick"
+    @confirm="handleConfirm"
+    @cancel="handleCancel"
+  />
+</template>
+
+<script>
+import { DialogService } from "@/services/DialogService";
+import DialogModal from "./DialogModal.vue";
+
+export default {
+  name: "DialogContainer",
+  components: {
+    DialogModal,
+  },
+  data() {
+    return {
+      isVisible: false,
+    };
+  },
+  computed: {
+    currentDialog() {
+      return DialogService.getState().currentDialog;
+    },
+  },
+  watch: {
+    currentDialog(newValue) {
+      this.isVisible = !!newValue;
+    },
+  },
+  methods: {
+    handleConfirm() {
+      DialogService.closeCurrentDialog(true);
+    },
+    handleCancel() {
+      DialogService.closeCurrentDialog(false);
+    },
+  },
+};
+</script>

--- a/webapp/src/components/DialogModal.vue
+++ b/webapp/src/components/DialogModal.vue
@@ -32,10 +32,22 @@
             </div>
           </div>
           <div class="modal-footer">
-            <button v-if="showCancelButton" type="button" class="btn btn-secondary" @click="cancel">
+            <button
+              v-if="showCancelButton"
+              data-testid="dialog-modal-cancel-button"
+              type="button"
+              class="btn btn-secondary"
+              @click="cancel"
+            >
               {{ cancelButtonText }}
             </button>
-            <button type="button" class="btn" :class="confirmButtonClass" @click="confirm">
+            <button
+              type="button"
+              data-testid="dialog-modal-confirm-button"
+              class="btn"
+              :class="confirmButtonClass"
+              @click="confirm"
+            >
               {{ confirmButtonText }}
             </button>
           </div>

--- a/webapp/src/components/DialogModal.vue
+++ b/webapp/src/components/DialogModal.vue
@@ -1,43 +1,48 @@
 <template>
   <Teleport to="body">
-    <div v-if="isVisible" class="dialog-overlay" @click.self="handleOverlayClick">
-      <div class="dialog-modal">
-        <div class="dialog-header">
-          <h5 class="dialog-title">{{ title }}</h5>
-          <button v-if="showCloseButton" type="button" class="close" @click="cancel">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-        <div class="dialog-body">
-          <div v-if="type === 'error'" class="dialog-icon error-icon">
-            <font-awesome-icon icon="exclamation-circle" size="2x" />
+    <div v-if="isVisible" class="modal fade show d-block" @click.self="handleOverlayClick">
+      <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">{{ title }}</h5>
+            <button v-if="showCloseButton" type="button" class="close" @click="cancel">
+              <span aria-hidden="true">&times;</span>
+            </button>
           </div>
-          <div v-else-if="type === 'warning'" class="dialog-icon warning-icon">
-            <font-awesome-icon icon="exclamation-triangle" size="2x" />
-          </div>
-          <div v-else-if="type === 'info'" class="dialog-icon info-icon">
-            <font-awesome-icon icon="info-circle" size="2x" />
-          </div>
-          <div v-else-if="type === 'success'" class="dialog-icon success-icon">
-            <font-awesome-icon icon="check-circle" size="2x" />
-          </div>
+          <div class="modal-body">
+            <div class="d-flex align-items-center">
+              <div v-if="type === 'error'" class="mr-3 text-danger">
+                <font-awesome-icon icon="exclamation-circle" size="2x" />
+              </div>
+              <div v-else-if="type === 'warning'" class="mr-3 text-warning">
+                <font-awesome-icon icon="exclamation-triangle" size="2x" />
+              </div>
+              <div v-else-if="type === 'info'" class="mr-3 text-info">
+                <font-awesome-icon icon="info-circle" size="2x" />
+              </div>
+              <div v-else-if="type === 'success'" class="mr-3 text-success">
+                <font-awesome-icon icon="check-circle" size="2x" />
+              </div>
 
-          <div class="dialog-content">
-            <!-- eslint-disable-next-line vue/no-v-html -->
-            <p v-if="message" v-html="message"></p>
-            <slot></slot>
+              <div class="flex-grow-1 d-flex align-items-center">
+                <!-- eslint-disable-next-line vue/no-v-html -->
+                <p v-if="message" class="mb-0" v-html="message"></p>
+                <slot></slot>
+              </div>
+            </div>
           </div>
-        </div>
-        <div class="dialog-footer">
-          <button v-if="showCancelButton" type="button" class="btn btn-secondary" @click="cancel">
-            {{ cancelButtonText }}
-          </button>
-          <button type="button" class="btn" :class="confirmButtonClass" @click="confirm">
-            {{ confirmButtonText }}
-          </button>
+          <div class="modal-footer">
+            <button v-if="showCancelButton" type="button" class="btn btn-secondary" @click="cancel">
+              {{ cancelButtonText }}
+            </button>
+            <button type="button" class="btn" :class="confirmButtonClass" @click="confirm">
+              {{ confirmButtonText }}
+            </button>
+          </div>
         </div>
       </div>
     </div>
+    <div v-if="isVisible" class="modal-backdrop fade show"></div>
   </Teleport>
 </template>
 
@@ -113,92 +118,3 @@ export default {
   },
 };
 </script>
-
-<style scoped>
-.dialog-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1050;
-}
-
-.dialog-modal {
-  background-color: white;
-  border-radius: 0.3rem;
-  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
-  max-width: 500px;
-  width: 90%;
-  max-height: 90vh;
-  overflow-y: auto;
-  animation: dialog-fade-in 0.3s;
-}
-
-.dialog-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem;
-  border-bottom: 1px solid #dee2e6;
-}
-
-.dialog-title {
-  margin: 0;
-  line-height: 1.5;
-}
-
-.dialog-body {
-  padding: 1rem;
-  display: flex;
-  align-items: flex-start;
-}
-
-.dialog-icon {
-  margin-right: 1rem;
-  min-width: 2em;
-}
-
-.dialog-content {
-  flex-grow: 1;
-}
-
-.error-icon {
-  color: #dc3545;
-}
-
-.warning-icon {
-  color: #ffc107;
-}
-
-.info-icon {
-  color: #17a2b8;
-}
-
-.success-icon {
-  color: #28a745;
-}
-
-.dialog-footer {
-  padding: 1rem;
-  border-top: 1px solid #dee2e6;
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.5rem;
-}
-
-@keyframes dialog-fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(-20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-</style>

--- a/webapp/src/components/DialogModal.vue
+++ b/webapp/src/components/DialogModal.vue
@@ -1,0 +1,204 @@
+<template>
+  <Teleport to="body">
+    <div v-if="isVisible" class="dialog-overlay" @click.self="handleOverlayClick">
+      <div class="dialog-modal">
+        <div class="dialog-header">
+          <h5 class="dialog-title">{{ title }}</h5>
+          <button v-if="showCloseButton" type="button" class="close" @click="cancel">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="dialog-body">
+          <div v-if="type === 'error'" class="dialog-icon error-icon">
+            <font-awesome-icon icon="exclamation-circle" size="2x" />
+          </div>
+          <div v-else-if="type === 'warning'" class="dialog-icon warning-icon">
+            <font-awesome-icon icon="exclamation-triangle" size="2x" />
+          </div>
+          <div v-else-if="type === 'info'" class="dialog-icon info-icon">
+            <font-awesome-icon icon="info-circle" size="2x" />
+          </div>
+          <div v-else-if="type === 'success'" class="dialog-icon success-icon">
+            <font-awesome-icon icon="check-circle" size="2x" />
+          </div>
+
+          <div class="dialog-content">
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <p v-if="message" v-html="message"></p>
+            <slot></slot>
+          </div>
+        </div>
+        <div class="dialog-footer">
+          <button v-if="showCancelButton" type="button" class="btn btn-secondary" @click="cancel">
+            {{ cancelButtonText }}
+          </button>
+          <button type="button" class="btn" :class="confirmButtonClass" @click="confirm">
+            {{ confirmButtonText }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script>
+export default {
+  name: "DialogModal",
+  props: {
+    title: {
+      type: String,
+      default: "Dialog",
+    },
+    message: {
+      type: String,
+      default: "",
+    },
+    type: {
+      type: String,
+      default: "info",
+      validator: (value) => ["info", "warning", "error", "success", "confirm"].includes(value),
+    },
+    confirmButtonText: {
+      type: String,
+      default: "OK",
+    },
+    cancelButtonText: {
+      type: String,
+      default: "Cancel",
+    },
+    showCancelButton: {
+      type: Boolean,
+      default: false,
+    },
+    showCloseButton: {
+      type: Boolean,
+      default: true,
+    },
+    closeOnOverlayClick: {
+      type: Boolean,
+      default: false,
+    },
+    isVisible: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ["confirm", "cancel", "update:isVisible"],
+  computed: {
+    confirmButtonClass() {
+      const classes = {
+        info: "btn-info",
+        warning: "btn-warning",
+        error: "btn-danger",
+        success: "btn-success",
+        confirm: "btn-primary",
+      };
+      return classes[this.type] || "btn-primary";
+    },
+  },
+  methods: {
+    confirm() {
+      this.$emit("confirm");
+      this.$emit("update:isVisible", false);
+    },
+    cancel() {
+      this.$emit("cancel");
+      this.$emit("update:isVisible", false);
+    },
+    handleOverlayClick() {
+      if (this.closeOnOverlayClick) {
+        this.cancel();
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1050;
+}
+
+.dialog-modal {
+  background-color: white;
+  border-radius: 0.3rem;
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+  max-width: 500px;
+  width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+  animation: dialog-fade-in 0.3s;
+}
+
+.dialog-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  border-bottom: 1px solid #dee2e6;
+}
+
+.dialog-title {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.dialog-body {
+  padding: 1rem;
+  display: flex;
+  align-items: flex-start;
+}
+
+.dialog-icon {
+  margin-right: 1rem;
+  min-width: 2em;
+}
+
+.dialog-content {
+  flex-grow: 1;
+}
+
+.error-icon {
+  color: #dc3545;
+}
+
+.warning-icon {
+  color: #ffc107;
+}
+
+.info-icon {
+  color: #17a2b8;
+}
+
+.success-icon {
+  color: #28a745;
+}
+
+.dialog-footer {
+  padding: 1rem;
+  border-top: 1px solid #dee2e6;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+@keyframes dialog-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/webapp/src/components/DynamicDataTableButtons.vue
+++ b/webapp/src/components/DynamicDataTableButtons.vue
@@ -163,6 +163,8 @@
 </template>
 
 <script>
+import { DialogService } from "@/services/DialogService";
+
 import IconField from "primevue/iconfield";
 import InputIcon from "primevue/inputicon";
 import InputText from "primevue/inputtext";
@@ -254,13 +256,14 @@ export default {
     },
   },
   methods: {
-    confirmDeletion() {
+    async confirmDeletion() {
       const idsSelected = this.itemsSelected.map((x) => x.item_id || x.collection_id);
-      if (
-        confirm(
-          `Are you sure you want to delete ${this.itemsSelected.length} selected items? (${idsSelected})`,
-        )
-      ) {
+      const confirmed = await DialogService.confirm({
+        title: "Confirm Deletion",
+        message: `Are you sure you want to delete ${this.itemsSelected.length} selected items? (${idsSelected})`,
+        type: "warning",
+      });
+      if (confirmed) {
         this.deleteItems(idsSelected);
         this.$emit("delete-selected-items");
       }
@@ -322,12 +325,14 @@ export default {
     columnLabel(option) {
       return option.label || option.header || option.field;
     },
-    resetTable() {
-      if (
-        window.confirm(
+    async resetTable() {
+      const confirmed = await DialogService.confirm({
+        title: "Confirm reset",
+        message:
           "Are you sure you want to reset your preferences (visible columns, widths) for this table?",
-        )
-      ) {
+        type: "info",
+      });
+      if (confirmed) {
         this.$emit("reset-table");
       }
     },

--- a/webapp/src/components/EditAccountSettingsModal.vue
+++ b/webapp/src/components/EditAccountSettingsModal.vue
@@ -125,6 +125,8 @@
 </template>
 
 <script>
+import { DialogService } from "@/services/DialogService";
+
 import { API_URL } from "@/resources.js";
 import Modal from "@/components/Modal.vue";
 import UserBubble from "@/components/UserBubble.vue";
@@ -204,17 +206,22 @@ export default {
     },
     async requestAPIKey(event) {
       event.preventDefault();
-      if (
-        window.confirm(
+      const confirmed = await DialogService.confirm({
+        title: "Generate New API Key",
+        message:
           "Requesting a new API key will remove your old one. Are you sure you want to proceed?",
-        )
-      ) {
+        type: "warning",
+      });
+      if (confirmed) {
         const newKey = await requestNewAPIKey();
         this.apiKey = newKey;
         this.apiKeyDisplayed = true;
-        window.alert(
-          `A new API key has been generated. Please note that when you close the "Account Settings" window, the key will not be displayed again. `,
-        );
+        await DialogService.alert({
+          title: "API Key Generated",
+          message:
+            'A new API key has been generated. Please note that when you close the "Account Settings" window, the key will not be displayed again.',
+          type: "success",
+        });
       }
     },
     copyToClipboard() {

--- a/webapp/src/components/FileList.vue
+++ b/webapp/src/components/FileList.vue
@@ -70,6 +70,8 @@
 </template>
 
 <script>
+import { DialogService } from "@/services/DialogService";
+
 import { deleteFileFromSample } from "@/server_fetch_utils";
 import { formatDistance } from "date-fns";
 
@@ -91,8 +93,13 @@ export default {
   },
   methods: {
     formatDistance,
-    deleteFile(event, file_id) {
-      if (window.confirm("Are you sure you want to unlink this file from this entry?")) {
+    async deleteFile(event, file_id) {
+      const confirmed = await DialogService.confirm({
+        title: "Unlink File",
+        message: "Are you sure you want to unlink this file from this entry?",
+        type: "warning",
+      });
+      if (confirmed) {
         deleteFileFromSample(this.item_id, file_id);
       }
     },

--- a/webapp/src/components/ToggleableCreatorsFormGroup.vue
+++ b/webapp/src/components/ToggleableCreatorsFormGroup.vue
@@ -33,6 +33,8 @@
 </template>
 
 <script>
+import { DialogService } from "@/services/DialogService";
+
 import Creators from "@/components/Creators";
 import UserSelect from "@/components/UserSelect";
 import { OnClickOutside } from "@vueuse/components";
@@ -84,8 +86,12 @@ export default {
           if (this.shadowValue.length == 0) {
             throw new Error("You must have at least one creator.");
           }
-          let answer = confirm("Are you sure you want to update the permissions of this item?");
-          if (answer) {
+          const confirmed = await DialogService.confirm({
+            title: "Update Permissions",
+            message: "Are you sure you want to update the permissions of this item?",
+            type: "warning",
+          });
+          if (confirmed) {
             await updateItemPermissions(this.refcode, this.shadowValue);
             this.$emit("update:modelValue", [...this.shadowValue]);
           } else {

--- a/webapp/src/components/ToggleableCreatorsFormGroup.vue
+++ b/webapp/src/components/ToggleableCreatorsFormGroup.vue
@@ -99,7 +99,10 @@ export default {
           }
         } catch (error) {
           // Reset value to original
-          alert("Error updating permissions: " + error);
+          DialogService.error({
+            title: "Permission Update Failed",
+            message: "Error updating permissions: " + error,
+          });
           this.shadowValue = [...this.value];
         }
       }

--- a/webapp/src/components/UserTable.vue
+++ b/webapp/src/components/UserTable.vue
@@ -69,6 +69,8 @@
 </template>
 
 <script>
+import { DialogService } from "@/services/DialogService";
+
 import { getUsersList, saveRole, saveUser } from "@/server_fetch_utils.js";
 
 export default {
@@ -99,11 +101,12 @@ export default {
         return;
       }
 
-      if (
-        window.confirm(
-          `Are you sure you want to change ${originalCurrentUser.display_name}'s role to ${new_role} ?`,
-        )
-      ) {
+      const confirmed = await DialogService.confirm({
+        title: "Change User Role",
+        message: `Are you sure you want to change ${originalCurrentUser.display_name}'s role to ${new_role}?`,
+        type: "warning",
+      });
+      if (confirmed) {
         await this.updateUserRole(user_id, new_role);
       } else {
         this.users.find((user) => user._id.$oid === user_id).role = originalCurrentUser.role;
@@ -112,11 +115,12 @@ export default {
     async confirmUpdateUserStatus(user_id, new_status) {
       const originalCurrentUser = this.original_users.find((user) => user._id.$oid === user_id);
 
-      if (
-        window.confirm(
-          `Are you sure you want to change ${originalCurrentUser.display_name}'s status from "${originalCurrentUser.account_status}" to "${new_status}" ?`,
-        )
-      ) {
+      const confirmed = await DialogService.confirm({
+        title: "Change User Status",
+        message: `Are you sure you want to change ${originalCurrentUser.display_name}'s status from "${originalCurrentUser.account_status}" to "${new_status}"?`,
+        type: "warning",
+      });
+      if (confirmed) {
         this.users.find((user) => user._id.$oid == user_id).account_status = new_status;
         await this.updateUserStatus(user_id, new_status);
       } else {

--- a/webapp/src/components/UserTable.vue
+++ b/webapp/src/components/UserTable.vue
@@ -96,7 +96,10 @@ export default {
       const originalCurrentUser = this.original_users.find((user) => user._id.$oid === user_id);
 
       if (originalCurrentUser.role === "admin") {
-        window.alert("You can't change an admin's role.");
+        DialogService.error({
+          title: "Role Change Error",
+          message: "You can't change an admin's role.",
+        });
         this.users.find((user) => user._id.$oid === user_id).role = originalCurrentUser.role;
         return;
       }

--- a/webapp/src/components/datablocks/DataBlockBase.vue
+++ b/webapp/src/components/datablocks/DataBlockBase.vue
@@ -140,6 +140,8 @@
  * moved, deleted and annotated with a title and description.
  *
  */
+import { DialogService } from "@/services/DialogService";
+
 import { createComputedSetterForBlockField } from "@/field_utils.js";
 import TinyMceInline from "@/components/TinyMceInline";
 import StyledBlockInfo from "@/components/StyledBlockInfo";
@@ -242,8 +244,15 @@ export default {
         event.detail,
       );
     },
-    deleteThisBlock() {
-      deleteBlock(this.item_id, this.block_id);
+    async deleteThisBlock() {
+      const confirmed = await DialogService.confirm({
+        title: "Delete Block",
+        message: "Are you sure you want to delete this block?",
+        type: "warning",
+      });
+      if (confirmed) {
+        deleteBlock(this.item_id, this.block_id);
+      }
     },
     swapUp() {
       this.$store.commit("swapBlockDisplayOrder", {

--- a/webapp/src/file_upload.js
+++ b/webapp/src/file_upload.js
@@ -6,6 +6,8 @@ import Dashboard from "@uppy/dashboard";
 import XHRUpload from "@uppy/xhr-upload";
 import Webcam from "@uppy/webcam";
 
+import { DialogService } from "@/services/DialogService";
+
 import store from "@/store/index.js";
 import { construct_headers } from "@/server_fetch_utils.js";
 
@@ -42,9 +44,11 @@ export default function setupUppy(item_id, trigger_selector, reactive_file_list)
     var matching_file_id = null;
     for (const file_id in reactive_file_list) {
       if (reactive_file_list[file_id].name == file.name) {
-        alert(
-          "A file with this name already exists in the sample. If you upload this, it will be duplicated on the current item.",
-        );
+        DialogService.warning({
+          title: "Duplicate File",
+          message:
+            "A file with this name already exists in the sample. If you upload this, it will be duplicated on the current item.",
+        });
       }
     }
 

--- a/webapp/src/main.js
+++ b/webapp/src/main.js
@@ -49,6 +49,7 @@ import {
   faCopy,
   faInfoCircle,
   faPlus,
+  faCheckCircle,
 } from "@fortawesome/free-solid-svg-icons";
 import { faPlusSquare } from "@fortawesome/free-regular-svg-icons";
 import { faGithub, faOrcid } from "@fortawesome/free-brands-svg-icons";
@@ -96,6 +97,7 @@ library.add(
   faEllipsisH,
   faCopy,
   faInfoCircle,
+  faCheckCircle,
 );
 
 // Import TinyMCE

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -10,6 +10,8 @@ import {
   EQUIPMENT_TABLE_TYPES,
 } from "@/resources.js";
 
+import { DialogService } from "@/services/DialogService";
+
 // ****************************************************************************
 // A simple wrapper to simplify response handling for fetch calls
 // ****************************************************************************
@@ -372,13 +374,15 @@ export function deleteSample(item_id) {
       console.log("delete successful" + response_json);
       store.commit("deleteFromSampleList", item_id);
     })
-    .catch(() =>
-      alert(
-        "Unable to delete item with ID '" +
+    .catch(() => {
+      DialogService.error({
+        title: "Permission Error",
+        message:
+          "Unable to delete item with ID '" +
           item_id +
           "': check that you have the appropriate permissions.",
-      ),
-    );
+      });
+    });
 }
 
 export function deleteStartingMaterial(item_id) {
@@ -389,13 +393,15 @@ export function deleteStartingMaterial(item_id) {
       console.log("delete successful" + response_json);
       store.commit("deleteFromStartingMaterialList", item_id);
     })
-    .catch(() =>
-      alert(
-        "Unable to delete item with ID '" +
+    .catch(() => {
+      DialogService.error({
+        title: "Permission Error",
+        message:
+          "Unable to delete item with ID '" +
           item_id +
           "': check that you have the appropriate permissions.",
-      ),
-    );
+      });
+    });
 }
 
 export function deleteCollection(collection_id, collection_summary) {
@@ -404,13 +410,15 @@ export function deleteCollection(collection_id, collection_summary) {
       console.log("delete successful" + response_json);
       store.commit("deleteFromCollectionList", collection_summary);
     })
-    .catch(() =>
-      alert(
-        "Unable to delete collection with ID '" +
+    .catch(() => {
+      DialogService.error({
+        title: "Permission Error",
+        message:
+          "Unable to delete collection with ID '" +
           collection_id +
           "': check that you have the appropriate permissions.",
-      ),
-    );
+      });
+    });
 }
 
 export function deleteEquipment(item_id) {
@@ -421,20 +429,21 @@ export function deleteEquipment(item_id) {
       console.log("delete successful" + response_json);
       store.commit("deleteFromEquipmentList", item_id);
     })
-    .catch(() =>
-      alert(
-        "Unable to delete item with ID '" +
+    .catch(() => {
+      DialogService.error({
+        title: "Permission Error",
+        message:
+          "Unable to delete item with ID '" +
           item_id +
           "': check that you have the appropriate permissions.",
-      ),
-    );
+      });
+    });
 }
 
 export function removeItemsFromCollection(collection_id, refcodes) {
   return fetch_delete(`${API_URL}/collections/${collection_id}/items`, {
     refcodes: refcodes,
-  })
-    .then(function (response_json) {
+  }).then(function (response_json) {
       console.log("Items removed from collection successfully", response_json);
 
       store.commit("removeItemsFromCollection", {
@@ -445,8 +454,10 @@ export function removeItemsFromCollection(collection_id, refcodes) {
       return response_json;
     })
     .catch((error) => {
-      alert(`Failed to remove items from collection ${collection_id}: ${error}`);
-      throw error;
+      DialogService.error({
+        title: "Delete Failed",
+        message: "Collection delete failed for " + collection_id + ": " + error,
+      });
     });
 }
 
@@ -463,7 +474,12 @@ export async function getItemData(item_id) {
 
       return "success";
     })
-    .catch((error) => alert("Error getting sample data: " + error));
+    .catch((error) => {
+      DialogService.error({
+        title: "Data Retrieval Error",
+        message: "Error getting sample data: " + error,
+      });
+    });
 }
 
 export async function getItemByRefcode(refcode) {
@@ -478,7 +494,12 @@ export async function getItemByRefcode(refcode) {
       });
       return "success";
     })
-    .catch((error) => alert("Error getting item data: " + error));
+    .catch((error) => {
+      DialogService.error({
+        title: "Data Retrieval Error",
+        message: "Error getting item data: " + error,
+      });
+    });
 }
 
 export async function getCollectionData(collection_id) {
@@ -493,7 +514,12 @@ export async function getCollectionData(collection_id) {
 
       return "success";
     })
-    .catch((error) => alert("Error getting collection data: " + error));
+    .catch((error) => {
+      DialogService.error({
+        title: "Data Retrieval Error",
+        message: "Error getting collection data: " + error,
+      });
+    });
 }
 
 export async function updateBlockFromServer(
@@ -596,7 +622,10 @@ export function saveItem(item_id) {
       }
     })
     .catch(function (error) {
-      alert("Save unsuccessful :(", error);
+      DialogService.error({
+        title: "Save Failed",
+        message: "Save unsuccessful: " + error,
+      });
     });
 }
 
@@ -611,7 +640,10 @@ export function saveCollection(collection_id) {
       }
     })
     .catch(function (error) {
-      alert("Save unsuccessful :(", error);
+      DialogService.error({
+        title: "Save Failed",
+        message: "Save unsuccessful: " + error,
+      });
     });
 }
 
@@ -622,11 +654,17 @@ export function saveUser(user_id, user) {
         getUserInfo();
         console.log("Save successful!");
       } else {
-        alert("User save unsuccessful", response_json.detail);
+        DialogService.error({
+          title: "User Save Failed",
+          message: "User save unsuccessful: " + response_json.detail,
+        });
       }
     })
     .catch(function (error) {
-      alert(`User save unsuccessful: ${error}`);
+      DialogService.error({
+        title: "User Save Failed",
+        message: `User save unsuccessful: ${error}`,
+      });
     });
 }
 
@@ -636,11 +674,17 @@ export function saveRole(user_id, role) {
       if (response_json.status === "success") {
         console.log("Save successful!");
       } else {
-        alert("Role save unsuccessful", response_json.detail);
+        DialogService.error({
+          title: "Role Save Failed",
+          message: "Role save unsuccessful: " + response_json.detail,
+        });
       }
     })
     .catch(function (error) {
-      alert(`Role save unsuccessful: ${error}`);
+      DialogService.error({
+        title: "Role Save Failed",
+        message: `Role save unsuccessful: ${error}`,
+      });
     });
 }
 
@@ -659,7 +703,12 @@ export function deleteBlock(item_id, block_id) {
       });
       // currently, we don't actually delete the block from the store, so it may get re-added to the db on the next save. Fix once new schemas are established
     })
-    .catch((error) => alert(`Delete unsuccessful :(\n error: ${error}`));
+    .catch((error) => {
+      DialogService.error({
+        title: "Delete Failed",
+        message: `Delete unsuccessful: ${error}`,
+      });
+    });
 }
 
 export function deleteFileFromSample(item_id, file_id) {
@@ -673,7 +722,12 @@ export function deleteFileFromSample(item_id, file_id) {
         file_id: file_id,
       });
     })
-    .catch((error) => alert(`Delete unsuccessful :(\n error: ${error}`));
+    .catch((error) => {
+      DialogService.error({
+        title: "Delete Failed",
+        message: `Delete unsuccessful: ${error}`,
+      });
+    });
 }
 
 export async function fetchRemoteTree(invalidate_cache) {
@@ -776,7 +830,10 @@ export function addItemsToCollection(collection_id, refcodes) {
       }
     })
     .catch(function (error) {
-      alert("Error adding items to collection: ", error);
+      DialogService.error({
+        title: "Collection Update Failed",
+        message: "Error adding items to collection: " + error,
+      });
       throw error;
     });
 }
@@ -791,7 +848,10 @@ export async function getSupportedSchemasList() {
       }
     })
     .catch(function (error) {
-      alert(`Error to get schemas from API: ${error}`);
+      DialogService.error({
+        title: "Schema Retrieval Failed",
+        message: `Error retrieving schemas from API: ${error}`,
+      });
       throw error;
     });
 }
@@ -806,7 +866,10 @@ export async function getSchema(type) {
       }
     })
     .catch(function (error) {
-      alert(`Error to get ${type} schema from API: ${error}`);
+      DialogService.error({
+        title: "Schema Retrieval Failed",
+        message: `Error retrieving ${type} schema from API: ${error}`,
+      });
       throw error;
     });
 }

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -84,9 +84,6 @@ function fetch_delete(url, body) {
 
 function handleResponse(response) {
   return response.text().then((text) => {
-    console.log("fetch was successful");
-    console.log(response);
-    console.log(text);
     const data = text && JSON.parse(text);
 
     if (!response.ok) {
@@ -124,11 +121,6 @@ export function createNewItem(
       ...startingData,
     },
   }).then(function (response_json) {
-    console.log("received the following data from fetch new-sample:");
-    console.log(response_json.sample_list_entry);
-    console.log(
-      `created a new item with item_id: ${item_id}, type: ${response_json.sample_list_entry.type}`,
-    );
     if (SAMPLE_TABLE_TYPES.includes(response_json.sample_list_entry.type)) {
       store.commit("prependToSampleList", response_json.sample_list_entry);
     }
@@ -152,9 +144,6 @@ export function createNewSamples(
     new_sample_datas: newSampleDatas,
     generate_ids_automatically: generateIDsAutomatically,
   }).then(function (response_json) {
-    console.log("received the following data from fetch new-samples:");
-    console.log(response_json);
-
     response_json.responses.forEach((response) => {
       if (response.status == "success") {
         store.commit("prependToSampleList", response.sample_list_entry);
@@ -186,7 +175,6 @@ export async function getStats() {
       return response_json.counts;
     })
     .catch((error) => {
-      console.error("Error when fetching stats");
       throw error;
     });
 }
@@ -198,7 +186,10 @@ export async function getInfo() {
       return response_json.data.attributes;
     })
     .catch((error) => {
-      console.error("Error when fetching info");
+      DialogService.error({
+        title: "Unable to retrieve API",
+        message: `Unable to connect to the datalab instance at ${API_URL}.`,
+      });
       throw error;
     });
 }
@@ -206,22 +197,18 @@ export async function getInfo() {
 export function getSampleList() {
   return fetch_get(`${API_URL}/samples/`)
     .then(function (response_json) {
-      console.log(response_json);
       store.commit("setSampleList", response_json.samples);
     })
     .catch((error) => {
       if (error === "UNAUTHORIZED") {
         store.commit("setSampleList", []);
       } else {
-        console.error("Error when fetching sample list");
-        console.error(error);
         throw error;
       }
     });
 }
 
 export function getCollectionSampleList(collection_id) {
-  console.log("getCollectionSampleList");
   return fetch_get(`${API_URL}/collections/${collection_id}`)
     .then(function (response_json) {
       store.commit("setCollectionSampleList", response_json);
@@ -230,11 +217,6 @@ export function getCollectionSampleList(collection_id) {
       if (error === "UNAUTHORIZED") {
         store.commit("setCollectionSampleList", []);
       } else {
-        console.error(
-          "Error when fetching collection sample list for collection_id",
-          collection_id,
-        );
-        console.error(error);
         throw error;
       }
     });
@@ -249,8 +231,6 @@ export function getCollectionList() {
       if (error === "UNAUTHORIZED") {
         store.commit("setCollectionList", []);
       } else {
-        console.error("Error when fetching collection list");
-        console.error(error);
         throw error;
       }
     });
@@ -266,8 +246,6 @@ export function getUsersList() {
       return response_json.data;
     })
     .catch((error) => {
-      console.error("Error when fetching users list");
-      console.error(error);
       throw error;
     });
 }
@@ -281,8 +259,6 @@ export function getStartingMaterialList() {
       if (error === "UNAUTHORIZED") {
         store.commit("setStartingMaterialList", []);
       } else {
-        console.error("Error when fetching starting material list");
-        console.error(error);
         throw error;
       }
     });
@@ -297,8 +273,6 @@ export function getEquipmentList() {
       if (error === "UNAUTHORIZED") {
         store.commit("setEquipmentList", []);
       } else {
-        console.error("Error when fetching equipment list");
-        console.error(error);
         throw error;
       }
     });
@@ -309,9 +283,6 @@ export function searchItems(query, nresults = 100, types = null) {
   var url = new URL(`${API_URL}/search-items/`);
   var params = { query: query, nresults: nresults, types: types };
   Object.keys(params).forEach((key) => url.searchParams.append(key, params[key]));
-  console.log(`using to construct url for searchItems: ${url}`);
-  console.log(url);
-  console.log(params);
   return fetch_get(url).then(function (response_json) {
     return response_json.items;
   });
@@ -336,6 +307,7 @@ export async function getUserInfo() {
       return response_json;
     })
     .catch(() => {
+      // If the user is not logged in, we return null.
       return null;
     });
 }
@@ -349,6 +321,10 @@ export async function requestMagicLink(email_address) {
       return response_json;
     })
     .catch((err) => {
+      DialogService.error({
+        title: "Magic link request failed",
+        message: `Failed to request magic link: ${err}`,
+      });
       return err;
     });
 }
@@ -358,9 +334,6 @@ export function searchUsers(query, nresults = 100) {
   var url = new URL(`${API_URL}/search-users/`);
   var params = { query: query, nresults: nresults };
   Object.keys(params).forEach((key) => url.searchParams.append(key, params[key]));
-  console.log(`using to construct url for searchUsers: ${url}`);
-  console.log(url);
-  console.log(params);
   return fetch_get(url).then(function (response_json) {
     return response_json.users;
   });
@@ -371,17 +344,20 @@ export function deleteSample(item_id) {
     item_id: item_id,
   })
     .then(function (response_json) {
-      console.log("delete successful" + response_json);
+      if (response_json.status !== "success") {
+        throw new Error("Failed to delete sample: " + response_json.message);
+      }
       store.commit("deleteFromSampleList", item_id);
     })
-    .catch(() => {
+    .catch((error) => {
       DialogService.error({
-        title: "Permission Error",
+        title: "Permission error",
         message:
           "Unable to delete item with ID '" +
           item_id +
           "': check that you have the appropriate permissions.",
       });
+      throw error;
     });
 }
 
@@ -390,34 +366,40 @@ export function deleteStartingMaterial(item_id) {
     item_id: item_id,
   })
     .then(function (response_json) {
-      console.log("delete successful" + response_json);
+      if (response_json.status !== "success") {
+        throw new Error("Failed to delete starting material: " + response_json.message);
+      }
       store.commit("deleteFromStartingMaterialList", item_id);
     })
-    .catch(() => {
+    .catch((error) => {
       DialogService.error({
-        title: "Permission Error",
+        title: "Permission error",
         message:
           "Unable to delete item with ID '" +
           item_id +
           "': check that you have the appropriate permissions.",
       });
+      throw error;
     });
 }
 
 export function deleteCollection(collection_id, collection_summary) {
   return fetch_delete(`${API_URL}/collections/${collection_id}`)
     .then(function (response_json) {
-      console.log("delete successful" + response_json);
+      if (response_json.status !== "success") {
+        throw new Error("Failed to delete collection: " + response_json.message);
+      }
       store.commit("deleteFromCollectionList", collection_summary);
     })
-    .catch(() => {
+    .catch((error) => {
       DialogService.error({
-        title: "Permission Error",
+        title: "Permission error",
         message:
           "Unable to delete collection with ID '" +
           collection_id +
           "': check that you have the appropriate permissions.",
       });
+      throw error;
     });
 }
 
@@ -426,26 +408,28 @@ export function deleteEquipment(item_id) {
     item_id: item_id,
   })
     .then(function (response_json) {
-      console.log("delete successful" + response_json);
+      if (response_json.status !== "success") {
+        throw new Error("Failed to delete equipment: " + response_json.message);
+      }
       store.commit("deleteFromEquipmentList", item_id);
     })
-    .catch(() => {
+    .catch((error) => {
       DialogService.error({
-        title: "Permission Error",
+        title: "Permission error",
         message:
           "Unable to delete item with ID '" +
           item_id +
           "': check that you have the appropriate permissions.",
       });
+      throw error;
     });
 }
 
 export function removeItemsFromCollection(collection_id, refcodes) {
   return fetch_delete(`${API_URL}/collections/${collection_id}/items`, {
     refcodes: refcodes,
-  }).then(function (response_json) {
-      console.log("Items removed from collection successfully", response_json);
-
+  })
+    .then(function (response_json) {
       store.commit("removeItemsFromCollection", {
         collection_id: collection_id,
         refcodes: refcodes,
@@ -455,7 +439,7 @@ export function removeItemsFromCollection(collection_id, refcodes) {
     })
     .catch((error) => {
       DialogService.error({
-        title: "Delete Failed",
+        title: "Unable to remove item(s) from collection",
         message: "Collection delete failed for " + collection_id + ": " + error,
       });
     });
@@ -464,7 +448,6 @@ export function removeItemsFromCollection(collection_id, refcodes) {
 export async function getItemData(item_id) {
   return fetch_get(`${API_URL}/get-item-data/${item_id}`)
     .then((response_json) => {
-      console.log(response_json);
       store.commit("createItemData", {
         item_id: item_id,
         item_data: response_json.item_data,
@@ -476,7 +459,7 @@ export async function getItemData(item_id) {
     })
     .catch((error) => {
       DialogService.error({
-        title: "Data Retrieval Error",
+        title: "Unable to retrieve item",
         message: "Error getting sample data: " + error,
       });
     });
@@ -496,7 +479,7 @@ export async function getItemByRefcode(refcode) {
     })
     .catch((error) => {
       DialogService.error({
-        title: "Data Retrieval Error",
+        title: "Unable to retrieve item",
         message: "Error getting item data: " + error,
       });
     });
@@ -505,7 +488,6 @@ export async function getItemByRefcode(refcode) {
 export async function getCollectionData(collection_id) {
   return fetch_get(`${API_URL}/collections/${collection_id}`)
     .then((response_json) => {
-      console.log("get collection", response_json);
       store.commit("setCollectionData", {
         collection_id: collection_id,
         data: response_json.data,
@@ -516,7 +498,7 @@ export async function getCollectionData(collection_id) {
     })
     .catch((error) => {
       DialogService.error({
-        title: "Data Retrieval Error",
+        title: "Unable to retrieve collection",
         message: "Error getting collection data: " + error,
       });
     });
@@ -559,15 +541,14 @@ export async function updateBlockFromServer(
       });
       store.commit("setBlockImplementationError", { block_id, hasError: false });
     })
-    .catch((error) => {
-      console.warn(`Failed to update block ${block_id}:`, error);
+    .catch(() => {
+      // The block component renders errors, so no need to make a dialog here.
       store.commit("setBlockImplementationError", { block_id, hasError: true });
       store.commit("setBlockNotUpdating", block_id);
     });
 }
 
 export function addABlock(item_id, block_type, index = null) {
-  console.log("addABlock called with", item_id, block_type);
   var block_id_promise = fetch_post(`${API_URL}/add-data-block/`, {
     item_id: item_id,
     block_type: block_type,
@@ -581,16 +562,25 @@ export function addABlock(item_id, block_type, index = null) {
       });
       return response_json.new_block_obj.block_id;
     })
-    .catch((error) => console.error("Error in addABlock:", error));
+    .catch((error) => {
+      DialogService.error({
+        title: "Failed to add block",
+        message: `Error adding block to item ${item_id}: ${error}`,
+      });
+      throw error;
+    });
   return block_id_promise;
 }
 
 export function updateItemPermissions(refcode, creators) {
-  console.log("updateItemPermissions called with", refcode, creators);
   return fetch_patch(`${API_URL}/items/${refcode}/permissions`, {
     creators: creators,
   }).then(function (response_json) {
     if (response_json.status === "error") {
+      DialogService.error({
+        title: "Permission update failed",
+        message: `Failed to update permissions for item ${refcode}: ${response_json.message}`,
+      });
       throw new Error(response_json.message);
     }
     return response_json;
@@ -598,10 +588,7 @@ export function updateItemPermissions(refcode, creators) {
 }
 
 export function saveItem(item_id) {
-  console.log("saveItem Called!");
   var item_data = store.state.all_item_data[item_id];
-  console.log("Item data before saving:", item_data);
-
   store.commit("setItemSaved", { item_id: item_id, isSaved: false });
   fetch_post(`${API_URL}/save-item/`, {
     item_id: item_id,
@@ -609,8 +596,6 @@ export function saveItem(item_id) {
   })
     .then(function (response_json) {
       if (response_json.status === "success") {
-        // this should always be true if you've gotten this far...
-        console.log("Save successful!");
         store.commit("updateItemData", {
           item_id: item_id,
           item_data: { last_modified: response_json.last_modified },
@@ -623,7 +608,7 @@ export function saveItem(item_id) {
     })
     .catch(function (error) {
       DialogService.error({
-        title: "Save Failed",
+        title: "Failed to save item",
         message: "Save unsuccessful: " + error,
       });
     });
@@ -634,14 +619,12 @@ export function saveCollection(collection_id) {
   fetch_patch(`${API_URL}/collections/${collection_id}`, { data: data })
     .then(function (response_json) {
       if (response_json.status === "success") {
-        // this should always be true if you've gotten this far...
-        console.log("Save successful!");
         store.commit("setSavedCollection", { collection_id: collection_id, isSaved: true });
       }
     })
     .catch(function (error) {
       DialogService.error({
-        title: "Save Failed",
+        title: "Failed to save collection",
         message: "Save unsuccessful: " + error,
       });
     });
@@ -652,17 +635,16 @@ export function saveUser(user_id, user) {
     .then(function (response_json) {
       if (response_json.status === "success") {
         getUserInfo();
-        console.log("Save successful!");
       } else {
         DialogService.error({
-          title: "User Save Failed",
+          title: "Failed to update user",
           message: "User save unsuccessful: " + response_json.detail,
         });
       }
     })
     .catch(function (error) {
       DialogService.error({
-        title: "User Save Failed",
+        title: "Failed to update user",
         message: `User save unsuccessful: ${error}`,
       });
     });
@@ -671,25 +653,19 @@ export function saveUser(user_id, user) {
 export function saveRole(user_id, role) {
   fetch_patch(`${API_URL}/roles/${user_id}`, role)
     .then(function (response_json) {
-      if (response_json.status === "success") {
-        console.log("Save successful!");
-      } else {
-        DialogService.error({
-          title: "Role Save Failed",
-          message: "Role save unsuccessful: " + response_json.detail,
-        });
+      if (response_json.status !== "success") {
+        throw new Error("Failed to save role: " + response_json.detail);
       }
     })
     .catch(function (error) {
       DialogService.error({
-        title: "Role Save Failed",
+        title: "Role save failed",
         message: `Role save unsuccessful: ${error}`,
       });
     });
 }
 
 export function deleteBlock(item_id, block_id) {
-  console.log("deleteBlock called!");
   fetch_post(`${API_URL}/delete-block/`, {
     item_id: item_id,
     block_id: block_id,
@@ -705,7 +681,7 @@ export function deleteBlock(item_id, block_id) {
     })
     .catch((error) => {
       DialogService.error({
-        title: "Delete Failed",
+        title: "Block deletion failed",
         message: `Delete unsuccessful: ${error}`,
       });
     });
@@ -724,7 +700,7 @@ export function deleteFileFromSample(item_id, file_id) {
     })
     .catch((error) => {
       DialogService.error({
-        title: "Delete Failed",
+        title: "Failed to unlink file",
         message: `Delete unsuccessful: ${error}`,
       });
     });
@@ -735,7 +711,6 @@ export async function fetchRemoteTree(invalidate_cache) {
   var url = new URL(
     `${API_URL}/list-remote-directories?invalidate_cache=${invalidate_cache_param}`,
   );
-  console.log("fetchRemoteTree called!");
   store.commit("setRemoteDirectoryTreeIsLoading", true);
   return fetch_get(url)
     .then(function (response_json) {
@@ -744,8 +719,10 @@ export async function fetchRemoteTree(invalidate_cache) {
       return response_json;
     })
     .catch((error) => {
-      console.error("Error when fetching cached remote tree");
-      console.error(error);
+      DialogService.error({
+        title: "Remote directory retrieval failed",
+        message: `Error retrieving remote directory tree from API: ${error}`,
+      });
       store.commit("setRemoteDirectoryTreeIsLoading", false);
       throw error;
     });
@@ -757,11 +734,7 @@ export async function addRemoteFileToSample(file_entry, item_id) {
     item_id: item_id,
   })
     .then(function (response_json) {
-      //store.commit("updateFiles", {
-      //  [response_json.file_id]: response_json.file_information,
-      //});
       if (!response_json.is_update) {
-        console.log("Adding file to sample", response_json.file_information);
         store.commit("addFileToSample", {
           item_id: item_id,
           file_id: response_json.file_id,
@@ -769,7 +742,12 @@ export async function addRemoteFileToSample(file_entry, item_id) {
         });
       }
     })
-    .catch((error) => `addRemoteFilesToSample unsuccessful. Error: ${error}`);
+    .catch((error) =>
+      DialogService.error({
+        title: "Remote File Linking Failed",
+        message: `Error adding remote file to sample: ${error}`,
+      }),
+    );
 }
 
 export async function getItemGraph({ item_id = null, collection_id = null } = {}) {
@@ -782,10 +760,14 @@ export async function getItemGraph({ item_id = null, collection_id = null } = {}
   }
   return fetch_get(url)
     .then(function (response_json) {
-      console.log("received graph");
       store.commit("setItemGraph", { nodes: response_json.nodes, edges: response_json.edges });
     })
-    .catch((error) => `getItemGraph unsuccessful. Error: ${error}`);
+    .catch((error) =>
+      DialogService.error({
+        title: "Graph Retrieval Failed",
+        message: `Error retrieving item graph from API: ${error}`,
+      }),
+    );
 }
 
 export async function requestNewAPIKey() {
@@ -793,12 +775,19 @@ export async function requestNewAPIKey() {
     const response_json = await fetch_get(`${API_URL}/get-api-key/`);
 
     if (response_json.key) {
-      console.log("New API key requested successfully!");
       return response_json.key;
     } else {
+      DialogService.error({
+        title: "API Key Request Failed",
+        message: "Failed to retrieve new API key. Please try again later or report this issue.",
+      });
       throw new Error(response_json.message);
     }
   } catch (error) {
+    DialogService.error({
+      title: "API Key Request Failed",
+      message: "Failed to retrieve new API key. Please try again later or report this issue.",
+    });
     throw new Error(`Failed to request new API key: ${error.message}`);
   }
 }
@@ -810,8 +799,10 @@ export async function getBlocksInfos() {
       return response_json.data;
     })
     .catch((error) => {
-      console.error("Error when fetching blocks info");
-      console.error(error);
+      DialogService.error({
+        title: "Block Info Retrieval Failed",
+        message: `Error retrieving block infos from API: ${error}`,
+      });
       throw error;
     });
 }
@@ -822,10 +813,8 @@ export function addItemsToCollection(collection_id, refcodes) {
   })
     .then(function (response_json) {
       if (response_json.status === "success") {
-        console.log("Items added to collection successfully!");
         return response_json;
       } else {
-        console.error("Failed to add items to collection.");
         throw new Error("Failed to add items to collection.");
       }
     })

--- a/webapp/src/services/DialogService.js
+++ b/webapp/src/services/DialogService.js
@@ -1,0 +1,124 @@
+import { reactive } from "vue";
+
+const state = reactive({
+  dialogQueue: [],
+  currentDialog: null,
+  isProcessing: false,
+});
+
+export const DialogService = {
+  /**
+   * Show an alert dialog
+   * @param {Object} options - Dialog options
+   * @param {string} options.title - Dialog title
+   * @param {string} options.message - Dialog message
+   * @param {string} options.type - Dialog type (info, success, warning, error)
+   * @param {string} options.confirmButtonText - Text for the confirm button
+   * @returns {Promise} Resolves when dialog is closed
+   */
+  alert(options) {
+    return this.showDialog({
+      ...options,
+      type: options.type || "info",
+      showCancelButton: false,
+      confirmButtonText: options.confirmButtonText || "OK",
+    });
+  },
+
+  /**
+   * Show a confirmation dialog
+   * @param {Object} options - Dialog options
+   * @param {string} options.title - Dialog title
+   * @param {string} options.message - Dialog message
+   * @param {string} options.type - Dialog type (default: 'confirm')
+   * @param {string} options.confirmButtonText - Text for the confirm button
+   * @param {string} options.cancelButtonText - Text for the cancel button
+   * @returns {Promise<boolean>} Resolves with true if confirmed, false if canceled
+   */
+  confirm(options) {
+    return this.showDialog({
+      ...options,
+      type: options.type || "confirm",
+      showCancelButton: true,
+      confirmButtonText: options.confirmButtonText || "Confirm",
+      cancelButtonText: options.cancelButtonText || "Cancel",
+    });
+  },
+
+  /**
+   * Show an error dialog
+   * @param {string|Object} messageOrOptions - Error message or options object
+   * @returns {Promise} Resolves when dialog is closed
+   */
+  error(messageOrOptions) {
+    const options =
+      typeof messageOrOptions === "string" ? { message: messageOrOptions } : messageOrOptions;
+
+    return this.alert({
+      title: options.title || "Error",
+      message: options.message,
+      type: "error",
+      confirmButtonText: options.confirmButtonText || "OK",
+    });
+  },
+
+  /**
+   * Show a dialog with the provided options
+   * @param {Object} options - Dialog options
+   * @returns {Promise} Resolves when dialog is confirmed or canceled
+   */
+  showDialog(options) {
+    return new Promise((resolve) => {
+      const dialogConfig = {
+        ...options,
+        onConfirm: () => resolve(true),
+        onCancel: () => resolve(false),
+      };
+
+      state.dialogQueue.push(dialogConfig);
+      this.processQueue();
+    });
+  },
+
+  /**
+   * Process the dialog queue
+   */
+  processQueue() {
+    if (state.isProcessing || state.dialogQueue.length === 0) {
+      return;
+    }
+
+    state.isProcessing = true;
+    state.currentDialog = state.dialogQueue.shift();
+  },
+
+  /**
+   * Close the current dialog
+   * @param {boolean} confirmed - Whether the dialog was confirmed
+   */
+  closeCurrentDialog(confirmed) {
+    if (!state.currentDialog) {
+      return;
+    }
+
+    if (confirmed) {
+      state.currentDialog.onConfirm && state.currentDialog.onConfirm();
+    } else {
+      state.currentDialog.onCancel && state.currentDialog.onCancel();
+    }
+
+    state.currentDialog = null;
+    state.isProcessing = false;
+
+    // Process the next dialog in the queue
+    this.processQueue();
+  },
+
+  /**
+   * Get the current dialog state
+   * @returns {Object} The current dialog state
+   */
+  getState() {
+    return state;
+  },
+};

--- a/webapp/src/services/DialogService.js
+++ b/webapp/src/services/DialogService.js
@@ -7,15 +7,6 @@ const state = reactive({
 });
 
 export const DialogService = {
-  /**
-   * Show an alert dialog
-   * @param {Object} options - Dialog options
-   * @param {string} options.title - Dialog title
-   * @param {string} options.message - Dialog message
-   * @param {string} options.type - Dialog type (info, success, warning, error)
-   * @param {string} options.confirmButtonText - Text for the confirm button
-   * @returns {Promise} Resolves when dialog is closed
-   */
   alert(options) {
     return this.showDialog({
       ...options,
@@ -25,16 +16,6 @@ export const DialogService = {
     });
   },
 
-  /**
-   * Show a confirmation dialog
-   * @param {Object} options - Dialog options
-   * @param {string} options.title - Dialog title
-   * @param {string} options.message - Dialog message
-   * @param {string} options.type - Dialog type (default: 'confirm')
-   * @param {string} options.confirmButtonText - Text for the confirm button
-   * @param {string} options.cancelButtonText - Text for the cancel button
-   * @returns {Promise<boolean>} Resolves with true if confirmed, false if canceled
-   */
   confirm(options) {
     return this.showDialog({
       ...options,
@@ -45,11 +26,6 @@ export const DialogService = {
     });
   },
 
-  /**
-   * Show an error dialog
-   * @param {string|Object} messageOrOptions - Error message or options object
-   * @returns {Promise} Resolves when dialog is closed
-   */
   error(messageOrOptions) {
     const options =
       typeof messageOrOptions === "string" ? { message: messageOrOptions } : messageOrOptions;
@@ -62,11 +38,6 @@ export const DialogService = {
     });
   },
 
-  /**
-   * Show a dialog with the provided options
-   * @param {Object} options - Dialog options
-   * @returns {Promise} Resolves when dialog is confirmed or canceled
-   */
   showDialog(options) {
     return new Promise((resolve) => {
       const dialogConfig = {
@@ -80,9 +51,6 @@ export const DialogService = {
     });
   },
 
-  /**
-   * Process the dialog queue
-   */
   processQueue() {
     if (state.isProcessing || state.dialogQueue.length === 0) {
       return;
@@ -92,10 +60,6 @@ export const DialogService = {
     state.currentDialog = state.dialogQueue.shift();
   },
 
-  /**
-   * Close the current dialog
-   * @param {boolean} confirmed - Whether the dialog was confirmed
-   */
   closeCurrentDialog(confirmed) {
     if (!state.currentDialog) {
       return;
@@ -110,14 +74,9 @@ export const DialogService = {
     state.currentDialog = null;
     state.isProcessing = false;
 
-    // Process the next dialog in the queue
     this.processQueue();
   },
 
-  /**
-   * Get the current dialog state
-   * @returns {Object} The current dialog state
-   */
   getState() {
     return state;
   },

--- a/webapp/src/views/CollectionPage.vue
+++ b/webapp/src/views/CollectionPage.vue
@@ -37,6 +37,8 @@
 </template>
 
 <script>
+import { DialogService } from "@/services/DialogService";
+
 import CollectionInformation from "@/components/CollectionInformation";
 import { getCollectionData, saveCollection } from "@/server_fetch_utils";
 import FormattedItemName from "@/components/FormattedItemName.vue";
@@ -50,12 +52,17 @@ export default {
     CollectionInformation,
     FormattedItemName,
   },
-  beforeRouteLeave(to, from, next) {
+  async beforeRouteLeave(to, from, next) {
     // give warning before leaving the page by the vue router (which would not trigger "beforeunload")
     if (this.savedStatus) {
       next();
     } else {
-      if (window.confirm("Unsaved changes present. Would you like to leave without saving?")) {
+      const confirmed = await DialogService.confirm({
+        title: "Unsaved Changes",
+        message: "Unsaved changes present. Would you like to leave without saving?",
+        type: "warning",
+      });
+      if (confirmed) {
         next();
       } else {
         next(false);

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -96,6 +96,8 @@
 </template>
 
 <script>
+import { DialogService } from "@/services/DialogService";
+
 import TinyMceInline from "@/components/TinyMceInline";
 import SelectableFileTree from "@/components/SelectableFileTree";
 
@@ -133,12 +135,17 @@ export default {
     FormattedItemName,
     StyledBlockHelp,
   },
-  beforeRouteLeave(to, from, next) {
+  async beforeRouteLeave(to, from, next) {
     // give warning before leaving the page by the vue router (which would not trigger "beforeunload")
     if (this.savedStatus) {
       next();
     } else {
-      if (window.confirm("Unsaved changes present. Would you like to leave without saving?")) {
+      const confirmed = await DialogService.confirm({
+        title: "Unsaved Changes",
+        message: "Unsaved changes present. Would you like to leave without saving?",
+        type: "warning",
+      });
+      if (confirmed) {
         this.$store.commit("setItemSaved", { item_id: this.item_id, isSaved: true });
         next();
       } else {


### PR DESCRIPTION
Closes #1180 

This PR replaces all browser-native alert and confirm dialogs (`window.confirm`) with custom Datalab components.
Uses a DialogService that manages dialogs and displays them through Vue components

Implemented 4 different modal styles to match various use cases:

- Error:

![Screenshot 2025-05-21 at 17 45 33](https://github.com/user-attachments/assets/b216d15b-4371-41c8-84b5-d087d7831082)

- Warning:

![Screenshot 2025-05-21 at 17 45 06](https://github.com/user-attachments/assets/df3b6d30-aeaf-4b8f-90b2-d3d3acdc9c7f)

- Info:

![Screenshot 2025-05-21 at 17 45 21](https://github.com/user-attachments/assets/c18bb2e6-592b-416d-a4dd-5a0b0ffdce8b)

- Success:

![Screenshot 2025-05-21 at 17 45 12](https://github.com/user-attachments/assets/4c6f0b46-97e5-4a33-9daa-8e1ebfa74f86)
