### PR TITLE
Improve 1D Raman tests and extract more information from file headers

### DIFF
--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -135,11 +135,6 @@ filterwarnings = [
     "error",
     "ignore:.*np.bool8*:DeprecationWarning",
     "ignore::pytest.PytestUnraisableExceptionWarning",
-    "ignore:.*Polyfit may be poorly conditioned*:numpy.RankWarning",
-    "ignore:.*invalid value encountered in sqrt*:RuntimeWarning",
-    "ignore:.*kernel_size exceeds volume extent*:UserWarning",
-    "ignore:.*divide by zero encountered in log10*:RuntimeWarning",
-    "ignore:.*invalid value encountered in log10*:RuntimeWarning",
     "ignore:.*JCAMP-DX key without value*:UserWarning",
 ]
 

--- a/pydatalab/tests/apps/test_raman.py
+++ b/pydatalab/tests/apps/test_raman.py
@@ -1,16 +1,58 @@
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from pydatalab.apps.raman.blocks import RamanBlock
 
 
 @pytest.fixture
-def data_files():
-    return (Path(__file__).parent.parent.parent / "example_data" / "raman").glob("*")
+def wdf_example():
+    return Path(__file__).parent.parent.parent / "example_data" / "raman" / "raman_example.wdf"
 
 
-def test_load(data_files):
-    for f in data_files:
-        df, metadata, y_options = RamanBlock.load(f)
-        assert all(y in df.columns for y in y_options)
+@pytest.fixture
+def labspec_txt_example():
+    return (
+        Path(__file__).parent.parent.parent / "example_data" / "raman" / "labspec_raman_example.txt"
+    )
+
+
+@pytest.fixture
+def renishaw_txt_example():
+    return Path(__file__).parent.parent.parent / "example_data" / "raman" / "raman_example.txt"
+
+
+def test_load_wdf(wdf_example):
+    df, metadata, y_options = RamanBlock.load(wdf_example)
+    assert all(y in df.columns for y in y_options)
+    assert df.shape == (1011, 11)
+    np.testing.assert_almost_equal(df["wavenumber"].min(), 44.812868, decimal=5)
+    np.testing.assert_almost_equal(df["wavenumber"].max(), 1919.855951, decimal=5)
+    np.testing.assert_almost_equal(df["intensity"].mean(), 364.2936, decimal=5)
+    np.testing.assert_almost_equal(df["normalized intensity"].max(), 1.0, decimal=5)
+    np.testing.assert_almost_equal(
+        df["wavenumber"][np.argmax(df["intensity"])], 1587.546335309901, decimal=5
+    )
+
+
+def test_load_renishaw_txt(renishaw_txt_example):
+    with pytest.warns(UserWarning, match="Unable to find wavenumber unit"):
+        with pytest.warns(UserWarning, match="Unable to find wavenumber offset"):
+            df, metadata, y_options = RamanBlock.load(renishaw_txt_example)
+    assert all(y in df.columns for y in y_options)
+    assert df.shape == (1011, 11)
+    np.testing.assert_almost_equal(df["wavenumber"].min(), 0.380859, decimal=5)
+    np.testing.assert_almost_equal(df["wavenumber"].max(), 1879.449219, decimal=5)
+    np.testing.assert_almost_equal(df["intensity"].mean(), 364.293613265, decimal=5)
+    np.testing.assert_almost_equal(df["normalized intensity"].max(), 1.0, decimal=5)
+    np.testing.assert_almost_equal(
+        df["wavenumber"][np.argmax(df["intensity"])], 1581.730469, decimal=5
+    )
+
+
+def test_load_labspec_txt(labspec_txt_example):
+    df, metadata, y_options = RamanBlock.load(labspec_txt_example)
+    assert all(y in df.columns for y in y_options)
+    assert df.shape == (341, 11)
+    np.testing.assert_almost_equal(df["normalized intensity"].max(), 1.0, decimal=5)


### PR DESCRIPTION
This PR updates the Raman tests to check for peak positions, localises and capture warnings when doing baseline corrections for XRD/Raman and more robustly parses units out of Raman data files.