### PR TITLE
Add persistent per-item access tokens that can be used in QR codes

### DIFF
--- a/pydatalab/src/pydatalab/permissions.py
+++ b/pydatalab/src/pydatalab/permissions.py
@@ -10,7 +10,7 @@ from pydatalab.config import CONFIG
 from pydatalab.logger import LOGGER
 from pydatalab.login import UserRole
 from pydatalab.models.people import AccountStatus
-from pydatalab.mongo import get_database
+from pydatalab.mongo import flask_mongo, get_database
 
 PUBLIC_USER_ID = ObjectId(24 * "0")
 
@@ -18,11 +18,24 @@ PUBLIC_USER_ID = ObjectId(24 * "0")
 def active_users_or_get_only(func):
     """Decorator to ensure that only active user accounts can access the route,
     unless it is a GET-route, in which case deactivated accounts can also access it.
-
+    Now also allows access with valid access tokens.
     """
 
     @wraps(func)
     def wrapped_route(*args, **kwargs):
+        access_token = request.args.get("at")
+        refcode = kwargs.get("refcode")
+
+        if not refcode and access_token:
+            path_parts = request.path.strip("/").split("/")
+            if len(path_parts) >= 2 and path_parts[0] == "items":
+                refcode = path_parts[1]
+
+        if access_token and refcode:
+            token_valid = check_access_token(refcode, access_token)
+            if token_valid:
+                return func(*args, **kwargs)
+
         if (
             (
                 current_user.is_authenticated
@@ -35,6 +48,45 @@ def active_users_or_get_only(func):
             or request.method in ("OPTIONS",)
         ):
             return func(*args, **kwargs)
+
+        return {"error": "Unauthorized"}, 401
+
+    return wrapped_route
+
+
+def access_token_or_active_users(func):
+    """Decorator that checks for access tokens first, then falls back to normal authentication.
+    If an access token is provided but invalid, the request is rejected regardless of normal permissions.
+    """
+
+    @wraps(func)
+    def wrapped_route(*args, **kwargs):
+        access_token = request.args.get("at")
+        refcode = kwargs.get("refcode")
+
+        if not refcode and access_token:
+            path_parts = request.path.strip("/").split("/")
+            if len(path_parts) >= 2 and path_parts[0] == "items":
+                refcode = path_parts[1]
+
+        if access_token:
+            if refcode and check_access_token(refcode, access_token):
+                return func(*args, elevate_permissions=True, **kwargs)
+            else:
+                return {"error": "Invalid access token"}, 401
+
+        if (
+            (
+                current_user.is_authenticated
+                and (
+                    current_user.account_status == AccountStatus.ACTIVE
+                    or request.method in ("OPTIONS", "GET")
+                )
+            )
+            or CONFIG.TESTING
+            or request.method in ("OPTIONS",)
+        ):
+            return func(*args, elevate_permissions=False, **kwargs)
 
         return {"error": "Unauthorized"}, 401
 
@@ -70,21 +122,23 @@ def check_access_token(refcode: str, token: str | None = None) -> bool:
 
     """
 
-    if not token:
+    if not token or not refcode:
         return False
 
-    db = get_database()
+    try:
+        if len(refcode.split(":")) != 2:
+            refcode = f"{CONFIG.IDENTIFIER_PREFIX}:{refcode}"
 
-    hashed_token = sha512(token.encode("utf-8")).hexdigest()
+        token_hash = sha512(token.encode("utf-8")).hexdigest()
 
-    access_document = db.api_keys.find_one(
-        {"token": hashed_token}, projection={"refcode": 1, "valid": 1}
-    )
-    if refcode == access_document["refcode"] and access_document["active"]:
-        LOGGER.info("Access to refcode %s granted with token", refcode, token)
-        return True
+        access_token_doc = flask_mongo.db.api_keys.find_one(
+            {"token": token_hash, "refcode": refcode, "active": True, "type": "access_token"}
+        )
 
-    return False
+        return bool(access_token_doc)
+
+    except Exception:
+        return False
 
 
 def get_default_permissions(

--- a/pydatalab/src/pydatalab/routes/v0_1/admin.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/admin.py
@@ -1,4 +1,4 @@
-from hashlib import sha512
+import datetime
 
 from bson import ObjectId
 from flask import Blueprint, jsonify, request
@@ -97,17 +97,82 @@ def save_role(user_id):
     return (jsonify({"status": "success"}), 200)
 
 
-@ADMIN.route("/items/<refcode>/invalidate-access-token")
-def invalidate_access_token(refcode: str, METHODS=["POST"]):
-    request_json = request.get_json()  # noqa: F821 pylint: disable=undefined-variable
-    token = request_json.get("token")
-    if not token:
-        return jsonify({"status": "error", "detail": "No token provided."}), 400
+@ADMIN.route("/items/<refcode>/invalidate-access-token", methods=["POST"])
+def invalidate_access_token(refcode: str):
+    if len(refcode.split(":")) != 2:
+        refcode = f"{CONFIG.IDENTIFIER_PREFIX}:{refcode}"
+
+    query = {"refcode": refcode, "active": True, "type": "access_token"}
 
     response = flask_mongo.db.api_keys.update_one(
-        {"token": sha512(token.encode("utf-8")).hexdigest()}, {"$set": {"active": False}}
+        query,
+        {
+            "$set": {
+                "active": False,
+                "invalidated_at": datetime.datetime.now(tz=datetime.timezone.utc),
+                "invalidated_by": ObjectId(current_user.id),
+            }
+        },
     )
+
     if response.modified_count == 1:
         return jsonify({"status": "success"}), 200
+    else:
+        return jsonify({"status": "error", "detail": "Token not found or already invalidated"}), 404
 
-    return jsonify({"status": "error", "detail": "Unable to invalidate token"}), 400
+
+@ADMIN.route("/access-tokens", methods=["GET"])
+def list_access_tokens():
+    """List all access tokens with their status and metadata."""
+
+    pipeline = [
+        {"$match": {"type": "access_token"}},
+        {
+            "$lookup": {
+                "from": "items",
+                "localField": "refcode",
+                "foreignField": "refcode",
+                "as": "item_info",
+            }
+        },
+        {
+            "$lookup": {
+                "from": "users",
+                "localField": "user",
+                "foreignField": "_id",
+                "as": "user_info",
+            }
+        },
+        {
+            "$project": {
+                "_id": 1,
+                "refcode": 1,
+                "active": 1,
+                "created_at": 1,
+                "invalidated_at": 1,
+                "token": "$token",
+                "item_name": {
+                    "$cond": {
+                        "if": {"$gt": [{"$size": "$item_info"}, 0]},
+                        "then": {"$arrayElemAt": ["$item_info.name", 0]},
+                        "else": None,
+                    }
+                },
+                "item_id": {"$arrayElemAt": ["$item_info.item_id", 0]},
+                "item_type": {
+                    "$cond": {
+                        "if": {"$gt": [{"$size": "$item_info"}, 0]},
+                        "then": {"$arrayElemAt": ["$item_info.type", 0]},
+                        "else": "deleted",
+                    }
+                },
+                "created_by": {"$arrayElemAt": ["$user_info.display_name", 0]},
+                "created_by_info": {"$arrayElemAt": ["$user_info", 0]},
+            }
+        },
+        {"$sort": {"created_at": -1}},
+    ]
+
+    tokens = list(flask_mongo.db.api_keys.aggregate(pipeline))
+
+    return jsonify({"status": "success", "tokens": tokens}), 200

--- a/pydatalab/src/pydatalab/routes/v0_1/blocks.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/blocks.py
@@ -4,7 +4,10 @@ from werkzeug.exceptions import BadRequest, NotImplemented
 from pydatalab.apps import BLOCK_TYPES
 from pydatalab.blocks.base import DataBlock
 from pydatalab.mongo import flask_mongo
-from pydatalab.permissions import active_users_or_get_only, get_default_permissions
+from pydatalab.permissions import (
+    active_users_or_get_only,
+    get_default_permissions,
+)
 
 BLOCKS = Blueprint("blocks", __name__)
 
@@ -136,7 +139,7 @@ def add_collection_data_block():
     )
 
 
-def _save_block_to_db(block: DataBlock) -> None:
+def _save_block_to_db(block: DataBlock):
     """Save data for a single block within an item to the database,
     overwriting previous data saved there.
 
@@ -183,7 +186,7 @@ def update_block():
     block_type = block_data["blocktype"]
 
     if block_type not in BLOCK_TYPES:
-        raise NotImplemented(  # noqa
+        raise NotImplemented(  # noqa: F901
             f"Invalid block type {block_type!r}, must be one of {BLOCK_TYPES.keys()}"
         )
 

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -23,6 +23,7 @@ from pydatalab.models.utils import generate_unique_refcode
 from pydatalab.mongo import ITEMS_FTS_FIELDS, flask_mongo
 from pydatalab.permissions import (
     PUBLIC_USER_ID,
+    access_token_or_active_users,
     active_users_or_get_only,
     check_access_token,
     get_default_permissions,
@@ -793,11 +794,11 @@ def update_item_permissions(refcode: str):
     return jsonify({"status": "success"}), 200
 
 
-@ITEMS.route("/items/<refcode>/issue-access-token", methods=["GET"])
+@ITEMS.route("/items/<refcode>/issue-access-token", methods=["POST"])
 def issue_physical_token(refcode: str):
     """Issue a token that will give semi-permanent access to an
     item with this refcode. This should be used when generating
-    physicsl labels to attach to a container.
+    physical labels to attach to a container.
 
     """
 
@@ -807,50 +808,62 @@ def issue_physical_token(refcode: str):
     current_item = flask_mongo.db.items.find_one(
         {"refcode": refcode, **get_default_permissions(user_only=True)},
         {"refcode": 1},
-    )  # type: ignore
+    )
 
     if not current_item:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "message": f"No valid item found with the given {refcode=}.",
-                }
-            ),
-            401,
-        )
+        return jsonify(
+            {
+                "status": "error",
+                "message": f"No valid item found with the given {refcode=}.",
+            }
+        ), 404
 
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "message": "No valid creator IDs found in the request.",
-                }
-            ),
-            400,
-        )
-
-    # generate token and store it in `api_keys` collection
     token = str(uuid.uuid1())
     access_document = {
         "token": sha512(token.encode("utf-8")).hexdigest(),
         "refcode": refcode,
         "user": ObjectId(current_user.id),
         "active": True,
+        "created_at": datetime.datetime.now(tz=datetime.timezone.utc),
+        "version": 1,
+        "type": "access_token",
     }
-    save_key = flask_mongo.db.api_keys.insert_one(**access_document)
-    if not save_key:
+
+    try:
+        result = flask_mongo.db.api_keys.insert_one(access_document)
+        if not result.inserted_id:
+            return jsonify(
+                {"status": "error", "message": "Unknown error generating token for item."}
+            ), 500
+    except Exception as e:
+        LOGGER.error(f"Error inserting access token: {e}")
         return jsonify(
-            {"status": "error", "message": "Unknown error generating token for item."}
+            {"status": "error", "message": "Database error generating token for item."}
         ), 500
 
-    return jsonify({"status": "success", "token": token}), 200
+    return jsonify({"status": "success", "token": token}), 201
 
 
 @ITEMS.route("/delete-sample/", methods=["POST"])
 def delete_sample():
     request_json = request.get_json()  # noqa: F821 pylint: disable=undefined-variable
     item_id = request_json["item_id"]
+
+    item = flask_mongo.db.items.find_one(
+        {"item_id": item_id, **get_default_permissions(user_only=True, deleting=True)},
+        {"refcode": 1},
+    )
+
+    if not item:
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": f"Authorization required to attempt to delete sample with {item_id=} from the database.",
+                }
+            ),
+            401,
+        )
 
     result = flask_mongo.db.items.delete_one(
         {"item_id": item_id, **get_default_permissions(user_only=True, deleting=True)}
@@ -861,27 +874,36 @@ def delete_sample():
             jsonify(
                 {
                     "status": "error",
-                    "message": f"Authorization required to attempt to delete sample with {item_id=} from the database.",
+                    "message": f"Failed to delete item with {item_id=}.",
                 }
             ),
-            401,
+            400,
         )
-    return (
-        jsonify(
-            {
-                "status": "success",
-            }
-        ),
-        200,
-    )
+
+    flask_mongo.db.api_keys.delete_many({"refcode": item["refcode"], "type": "access_token"})
+
+    return jsonify({"status": "success"}), 200
 
 
 @ITEMS.route("/items/<refcode>", methods=["GET"])
+@access_token_or_active_users
+def get_item_by_refcode(refcode: str, elevate_permissions: bool = False):
+    return get_item_data(refcode=refcode, elevate_permissions=elevate_permissions)
+
+
 @ITEMS.route("/get-item-data/<item_id>", methods=["GET"])
-def get_item_data(item_id: str | None = None, refcode: str | None = None):
+@active_users_or_get_only
+def get_item_by_id(item_id: str):
+    return get_item_data(item_id=item_id, elevate_permissions=False)
+
+
+def get_item_data(
+    item_id: str | None = None, refcode: str | None = None, elevate_permissions: bool = False
+):
     """Generates a JSON response for the item with the given `item_id`,
     or `refcode` additionally resolving relationships to files and other items.
     """
+
     redirect_to_ui = bool(request.args.get("redirect-to-ui", default=False, type=json.loads))
     access_token = request.args.get("at")
     if refcode and redirect_to_ui and CONFIG.APP_URL:
@@ -889,15 +911,6 @@ def get_item_data(item_id: str | None = None, refcode: str | None = None):
         if access_token:
             redirect_url += f"?at={access_token}"
         return redirect(redirect_url, code=307)
-
-    valid_access_token: bool = False
-    if refcode and access_token:
-        valid_access_token = check_access_token(refcode, access_token)
-        if not valid_access_token:
-            return (
-                jsonify({"status": "error", "message": "Invalid access token"}),
-                401,
-            )
 
     if item_id:
         match = {"item_id": item_id}
@@ -916,7 +929,7 @@ def get_item_data(item_id: str | None = None, refcode: str | None = None):
                 "$match": {
                     **match,
                     **get_default_permissions(
-                        user_only=False, elevate_permissions=valid_access_token
+                        user_only=False, elevate_permissions=elevate_permissions
                     ),
                 }
             },
@@ -931,11 +944,7 @@ def get_item_data(item_id: str | None = None, refcode: str | None = None):
     except IndexError:
         doc = None
 
-    if not doc or (
-        not current_user.is_authenticated
-        and not CONFIG.TESTING
-        and doc["type"] != "starting_materials"
-    ):
+    if not doc:
         return (
             jsonify(
                 {
@@ -1183,3 +1192,67 @@ def search_users():
     return jsonify(
         {"status": "success", "users": list(json.loads(Person(**d).json()) for d in cursor)}
     ), 200
+
+
+@ITEMS.route("/items/<refcode>/access-token-info", methods=["GET"])
+def get_access_token_info(refcode: str):
+    """Get information about existing access token for this item (if any).
+
+    Returns token info (with masked token) if user has permissions to this item.
+    """
+    access_token = request.args.get("at")
+    if access_token and check_access_token(refcode, access_token):
+        pass
+    elif not (current_user.is_authenticated):
+        return jsonify({"status": "error", "message": "Authentication required."}), 401
+
+    if len(refcode.split(":")) != 2:
+        refcode = f"{CONFIG.IDENTIFIER_PREFIX}:{refcode}"
+
+    current_item = flask_mongo.db.items.find_one(
+        {"refcode": refcode, **get_default_permissions(user_only=True)},
+        {"refcode": 1},
+    )
+
+    if not current_item:
+        return jsonify(
+            {
+                "status": "error",
+                "message": f"No valid item found with the given {refcode=}.",
+            }
+        ), 404
+
+    existing_token = flask_mongo.db.api_keys.find_one(
+        {"refcode": refcode, "active": True, "type": "access_token"},
+        {"token": 1, "created_at": 1, "user": 1},
+    )
+
+    if existing_token:
+        token_hash = existing_token["token"]
+        masked_token = token_hash[:8] + "..." + token_hash[-8:]
+
+        user_info = None
+        if existing_token.get("user"):
+            user_doc = flask_mongo.db.users.find_one(
+                {"_id": existing_token["user"]}, {"display_name": 1, "contact_email": 1}
+            )
+            if user_doc:
+                user_info = {
+                    "display_name": user_doc.get("display_name"),
+                    "contact_email": user_doc.get("contact_email"),
+                }
+
+        return jsonify(
+            {
+                "status": "success",
+                "has_token": True,
+                "token_info": {
+                    "token": masked_token,
+                    "created_at": existing_token["created_at"],
+                    "created_by": str(existing_token["user"]),
+                    "created_by_info": user_info,
+                },
+            }
+        ), 200
+    else:
+        return jsonify({"status": "success", "has_token": False}), 200

--- a/pydatalab/tests/server/test_permissions.py
+++ b/pydatalab/tests/server/test_permissions.py
@@ -89,25 +89,25 @@ def test_basic_permissions_update(admin_client, admin_user_id, client, user_id):
 def test_access_token_permissions(client, unauthenticated_client, admin_client, database):
     response = client.post("/new-sample/", json={"type": "samples", "item_id": "private-sample"})
     assert response.status_code == 201
-    response = response.json()
+    response = response.json
 
     refcode = response["sample_list_entry"]["refcode"]
     assert refcode
 
-    response = client.get(f"/items/{refcode}/issue-access-token")
-    response = response.json()
+    response = client.post(f"/items/{refcode}/issue-access-token")
+    response = response.json
     assert response["status"] == "success"
     token = response["token"]
     assert token
 
     response = unauthenticated_client.get(f"/items/{refcode}")
-    assert response.status_code == 404
+    assert response.status_code == 401
 
     response = unauthenticated_client.get(f"/items/{refcode}?at={token}")
     assert response.status_code == 200
 
     response = unauthenticated_client.get(f"/items/{refcode}?at={token}123")
-    assert response.status_code == 200
+    assert response.status_code == 401
 
     response = admin_client.get(f"/items/{refcode}")
     assert response.status_code == 200
@@ -115,7 +115,7 @@ def test_access_token_permissions(client, unauthenticated_client, admin_client, 
     response = admin_client.get(f"/items/{refcode}?at={token}")
     assert response.status_code == 200
 
-    database.api_keys.drop()
+    database.api_keys.delete_many({"type": "access_token"})
 
     response = admin_client.get(f"/items/{refcode}?at={token}")
     assert response.status_code == 401

--- a/webapp/src/components/AdminDisplay.vue
+++ b/webapp/src/components/AdminDisplay.vue
@@ -1,15 +1,24 @@
 <template>
   <div class="admin-display">
-    <template v-if="selectedItem === 'Users'"> <UserTable /> </template>
+    <template v-if="selectedItem === 'Users'">
+      <UserTable />
+    </template>
+    <template v-if="selectedItem === 'Access Tokens'">
+      <TokenTable />
+    </template>
   </div>
 </template>
 
 <script>
 import UserTable from "./UserTable.vue";
+import TokenTable from "./TokenTable.vue";
 
 export default {
   name: "AdminDisplay",
-  components: { UserTable },
+  components: {
+    UserTable,
+    TokenTable,
+  },
   props: {
     selectedItem: {
       type: String,

--- a/webapp/src/components/DialogModal.vue
+++ b/webapp/src/components/DialogModal.vue
@@ -1,8 +1,12 @@
 <template>
   <Teleport to="body">
-    <div v-if="isVisible" class="modal fade show d-block" @click.self="handleOverlayClick">
-      <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content">
+    <div
+      v-if="isVisible"
+      class="modal fade show d-block dialog-modal-overlay"
+      @click.self="handleOverlayClick"
+    >
+      <div class="modal-dialog modal-dialog-centered dialog-modal-container">
+        <div class="modal-content dialog-modal-content">
           <div class="modal-header">
             <h5 class="modal-title">{{ title }}</h5>
             <button v-if="showCloseButton" type="button" class="close" @click="cancel">
@@ -54,7 +58,7 @@
         </div>
       </div>
     </div>
-    <div v-if="isVisible" class="modal-backdrop fade show"></div>
+    <div v-if="isVisible" class="modal-backdrop fade show dialog-modal-backdrop"></div>
   </Teleport>
 </template>
 
@@ -130,3 +134,13 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.dialog-modal-overlay {
+  z-index: 9999 !important;
+}
+
+.dialog-modal-backdrop {
+  z-index: 9998 !important;
+}
+</style>

--- a/webapp/src/components/QRCode.vue
+++ b/webapp/src/components/QRCode.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="text-center">
     <QRCodeVue3
-      :value="QRCodeUrl"
+      :key="currentQRCodeUrl"
+      :value="currentQRCodeUrl"
       :width="width"
       :height="width"
       :qr-options="{ typeNumber: 0, mode: 'Byte', errorCorrectionLevel: 'Q' }"
@@ -15,6 +16,7 @@
       :corners-dot-options="{ type: 'square', color: 'black' }"
       file-ext="png"
     />
+
     <div
       id="qrcode-text-label"
       :style="{ width: width }"
@@ -22,8 +24,76 @@
     >
       {{ refcode }}
     </div>
+
+    <div class="mt-2">
+      <span v-if="!isPublicMode" class="badge bg-primary">Private QR Code</span>
+      <span v-else class="badge bg-warning text-dark">Public QR Code</span>
+    </div>
   </div>
-  <div v-if="!federatedQR" class="alert alert-info">
+
+  <div v-if="isLoading" class="text-center mt-3">
+    <div class="spinner-border spinner-border-sm" role="status">
+      <span class="visually-hidden">Loading...</span>
+    </div>
+    <small class="d-block mt-1">Checking existing tokens...</small>
+  </div>
+
+  <div v-if="!isPublicMode" class="mt-3">
+    <div class="alert alert-info">
+      <strong v-if="hasExistingToken">Public QR Code Exists:</strong>
+      <strong v-else>Generate Public QR Code:</strong>
+      <br />
+      <span v-if="hasExistingToken">
+        A public QR code already exists for this item. You can generate a new token. Both tokens
+        will remain valid until manually revoked by an administrator.
+      </span>
+      <span v-else>
+        This QR code requires authentication to access. You can generate a public QR code that
+        allows access without login.
+      </span>
+    </div>
+
+    <button
+      class="btn btn-warning w-100"
+      :disabled="isGenerating"
+      @click.prevent="generatePublicQRCode()"
+    >
+      <span v-if="isGenerating">
+        <span class="spinner-border spinner-border-sm me-2" role="status"></span>
+        Generating...
+      </span>
+      <span v-else-if="hasExistingToken"> <i class="fas fa-plus me-2"></i>Generate New Token </span>
+      <span v-else> <i class="fas fa-unlock me-2"></i>Generate Public QR Code </span>
+    </button>
+  </div>
+
+  <div v-else class="mt-3">
+    <div class="alert alert-warning">
+      <strong><i class="fas fa-exclamation-triangle me-2"></i>Public QR Code Active</strong><br />
+      This QR code can be accessed by anyone with the link. No authentication required.
+      <div class="mt-2">
+        <small><strong>Created:</strong> {{ formattedCreationDate }}</small>
+      </div>
+    </div>
+
+    <button
+      class="btn btn-danger w-100"
+      :disabled="isInvalidating"
+      @click.stop.prevent="invalidateToken"
+    >
+      <span v-if="isInvalidating">
+        <span class="spinner-border spinner-border-sm me-2" role="status"></span>
+        Deleting...
+      </span>
+      <span v-else> <i class="fas fa-trash me-1"></i>Delete Token </span>
+    </button>
+  </div>
+
+  <div v-if="errorMessage" class="alert alert-danger mt-3">
+    <i class="fas fa-exclamation-triangle me-2"></i>{{ errorMessage }}
+  </div>
+
+  <div v-if="!federatedQR" class="alert alert-info mt-3">
     QR_CODE_RESOLVER_URL is not set to the federation resolver URL for this deployment.<br />
     Links embedded within QR codes generated here will only work if this <i>datalab</i> instance
     remains at the same URL.<br /><br />
@@ -35,6 +105,9 @@
 
 <script>
 import QRCodeVue3 from "qrcode-vue3";
+
+import { DialogService } from "@/services/DialogService";
+
 import { FEDERATION_QR_CODE_RESOLVER_URL, QR_CODE_RESOLVER_URL, API_URL } from "@/resources.js";
 
 export default {
@@ -52,27 +125,198 @@ export default {
       default: 200,
     },
   },
+  emits: ["public-token-generated", "public-token-invalidated"],
   data() {
     return {
       federationQRCodeUrl: FEDERATION_QR_CODE_RESOLVER_URL,
+      isPublicMode: false,
+      publicToken: null,
+      tokenInfo: null,
+      isLoading: false,
+      isGenerating: false,
+      isInvalidating: false,
+      errorMessage: null,
     };
   },
   computed: {
-    accessToken() {
-      return "v1-aaaaaaabbbbbbbbcccccccc";
-    },
     federatedQR() {
       return FEDERATION_QR_CODE_RESOLVER_URL == QR_CODE_RESOLVER_URL;
     },
-    QRCodeUrl() {
-      // If the QR_CODE_RESOLVER_URL is not set, use the API_URL
-      // with the redirect-to-ui option
+    privateQRCodeUrl() {
       if (QR_CODE_RESOLVER_URL == null) {
-        return (
-          API_URL + "/items/" + this.refcode + "?redirect-to-ui=true" + "&token=" + this.accessToken
-        );
+        return API_URL + "/items/" + this.refcode + "?redirect-to-ui=true";
       }
-      return QR_CODE_RESOLVER_URL + "/" + this.refcode + "&token=" + this.accessToken;
+      return QR_CODE_RESOLVER_URL + "/" + this.refcode;
+    },
+    publicQRCodeUrl() {
+      if (!this.publicToken) return this.privateQRCodeUrl;
+
+      if (QR_CODE_RESOLVER_URL == null) {
+        return `${API_URL}/items/${this.refcode}?redirect-to-ui=true&at=${this.publicToken}`;
+      }
+      return `${QR_CODE_RESOLVER_URL}/${this.refcode}?at=${this.publicToken}`;
+    },
+    currentQRCodeUrl() {
+      const url = this.isPublicMode ? this.publicQRCodeUrl : this.privateQRCodeUrl;
+      return url;
+    },
+    formattedCreationDate() {
+      if (!this.tokenInfo?.created_at) return "Unknown";
+
+      try {
+        const date = new Date(this.tokenInfo.created_at);
+        return date.toLocaleDateString() + " at " + date.toLocaleTimeString();
+      } catch {
+        return "Unknown";
+      }
+    },
+    hasExistingToken() {
+      return this.tokenInfo && this.publicToken === "existing-token";
+    },
+  },
+  mounted() {
+    this.checkExistingToken();
+  },
+  beforeUnmount() {
+    this.errorMessage = null;
+  },
+  methods: {
+    async checkExistingToken() {
+      this.isLoading = true;
+      this.errorMessage = null;
+
+      const urlParams = new URLSearchParams(window.location.search);
+      const accessToken = urlParams.get("at");
+      if (accessToken) {
+        this.isLoading = false;
+        return;
+      }
+
+      try {
+        const response = await fetch(`${API_URL}/items/${this.refcode}/access-token-info`, {
+          method: "GET",
+          credentials: "include",
+        });
+
+        const data = await response.json();
+
+        if (response.ok && data.status === "success") {
+          if (data.has_token) {
+            this.tokenInfo = data.token_info;
+            this.publicToken = "existing-token";
+          }
+        } else if (response.status === 404) {
+          console.debug("No access to item or item not found");
+        } else {
+          console.warn("Error checking token:", data.message);
+        }
+      } catch (error) {
+        console.error("Error checking existing token:", error);
+      } finally {
+        this.isLoading = false;
+      }
+    },
+    async generatePublicQRCode() {
+      setTimeout(async () => {
+        const confirmationMessage = this.hasExistingToken
+          ? "This will generate a new public QR code. The old token will remain valid until manually revoked by an administrator. Are you sure you want to proceed?"
+          : "This will create a QR code that can be accessed by anyone without authentication. Are you sure you want to proceed?";
+
+        const confirmed = await DialogService.confirm({
+          title: this.hasExistingToken ? "Generate New Public QR Code" : "Generate Public QR Code",
+          message: confirmationMessage,
+          type: "warning",
+          confirmButtonText: this.hasExistingToken
+            ? "Generate New Token"
+            : "Generate Public QR Code",
+          cancelButtonText: "Cancel",
+        });
+
+        if (!confirmed) {
+          return;
+        }
+
+        this.isGenerating = true;
+
+        try {
+          const response = await fetch(`${API_URL}/items/${this.refcode}/issue-access-token`, {
+            method: "POST",
+            credentials: "include",
+            headers: {
+              "Content-Type": "application/json",
+            },
+          });
+
+          const data = await response.json();
+
+          if (response.ok && data.status === "success") {
+            this.publicToken = data.token;
+            this.isPublicMode = true;
+            this.tokenInfo = {
+              created_at: new Date().toISOString(),
+              created_by: this.$store.state.currentUserID,
+            };
+            this.$emit("public-token-generated", {
+              refcode: this.refcode,
+              token: data.token,
+            });
+          } else {
+            throw new Error(data.message || "Failed to generate access token");
+          }
+        } catch (error) {
+          console.error("Error generating public QR code:", error);
+          this.errorMessage = `Failed to generate public QR code: ${error.message}`;
+        } finally {
+          this.isGenerating = false;
+        }
+      }, 100);
+    },
+    async invalidateToken() {
+      const confirmed = await DialogService.confirm({
+        title: "Delete Public QR Code",
+        message:
+          "This will permanently invalidate the public QR code. Anyone with the current link will no longer be able to access this item. Are you sure?",
+        type: "warning",
+        confirmButtonText: "Delete Token",
+        cancelButtonText: "Cancel",
+      });
+
+      if (!confirmed) {
+        return;
+      }
+
+      this.isInvalidating = true;
+      this.errorMessage = null;
+
+      try {
+        const response = await fetch(`${API_URL}/items/${this.refcode}/invalidate-access-token`, {
+          method: "POST",
+          credentials: "include",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({}),
+        });
+
+        const data = await response.json();
+
+        if (response.ok && data.status === "success") {
+          this.publicToken = null;
+          this.tokenInfo = null;
+          this.isPublicMode = false;
+          this.showInvalidateConfirm = false;
+          this.$emit("public-token-invalidated", { refcode: this.refcode });
+        } else if (response.status === 403) {
+          throw new Error("Only administrators can delete public tokens.");
+        } else {
+          throw new Error(data.detail || data.message || "Failed to invalidate token");
+        }
+      } catch (error) {
+        console.error("Error invalidating token:", error);
+        this.errorMessage = `Failed to invalidate token: ${error.message}`;
+      } finally {
+        this.isInvalidating = false;
+      }
     },
   },
 };

--- a/webapp/src/components/TokenTable.vue
+++ b/webapp/src/components/TokenTable.vue
@@ -1,0 +1,205 @@
+<template>
+  <table class="table table-hover table-sm" data-testid="tokens-table">
+    <thead>
+      <tr>
+        <th scope="col">Item</th>
+        <th scope="col">Token Status</th>
+        <th scope="col">Refcode</th>
+        <th scope="col">Item Type</th>
+        <th scope="col">Created By</th>
+        <th scope="col">Date Created</th>
+        <th scope="col">Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-if="isLoading">
+        <td colspan="6" class="text-center">
+          <div class="spinner-border spinner-border-sm" role="status"></div>
+          Loading tokens...
+        </td>
+      </tr>
+      <tr v-else-if="tokens.length === 0">
+        <td colspan="6" class="text-center text-muted">No access tokens found</td>
+      </tr>
+      <tr v-for="token in sortedTokens" v-else :key="token._id">
+        <td align="left">
+          <FormattedItemName
+            v-if="token.item_id"
+            :item_id="token.item_id"
+            :item-type="token.item_type"
+            enable-click
+          />
+        </td>
+        <td align="left">
+          <span v-if="token.active" class="badge badge-success text-uppercase"> Active </span>
+          <span v-else class="badge badge-danger text-uppercase"> Invalidated </span>
+        </td>
+        <td align="left">
+          <FormattedRefcode
+            :refcode="token.refcode"
+            :enable-q-r-code="token.item_type !== 'deleted'"
+          />
+        </td>
+        <td align="left">{{ token.item_type || "Unknown" }}</td>
+        <td>
+          <div v-if="token.created_by_info" class="d-flex align-items-center">
+            <UserBubble :creator="token.created_by_info" :size="24" />
+            <span class="ms-2">{{ token.created_by_info.display_name }}</span>
+          </div>
+          <span v-else class="text-muted">Unknown</span>
+        </td>
+        <td align="left">{{ formatDate(token.created_at) }}</td>
+        <td align="left">
+          <button
+            v-if="token.active"
+            class="btn btn-outline-danger btn-sm text-uppercase text-monospace"
+            :disabled="invalidatingTokens.has(token._id)"
+            @click="confirmInvalidateToken(token)"
+          >
+            <span v-if="invalidatingTokens.has(token._id)"> Invalidating... </span>
+            <span v-else> Invalidate </span>
+          </button>
+          <button
+            v-else
+            class="btn btn-outline-secondary btn-sm text-uppercase text-monospace"
+            disabled
+          >
+            Invalidated
+          </button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script>
+import { API_URL } from "@/resources.js";
+
+import { DialogService } from "@/services/DialogService";
+
+import FormattedItemName from "@/components/FormattedItemName.vue";
+import FormattedRefcode from "@/components/FormattedRefcode.vue";
+import UserBubble from "@/components/UserBubble.vue";
+
+export default {
+  name: "TokenTable",
+  components: {
+    FormattedRefcode,
+    FormattedItemName,
+    UserBubble,
+  },
+  data() {
+    return {
+      tokens: [],
+      isLoading: false,
+      invalidatingTokens: new Set(),
+    };
+  },
+  computed: {
+    sortedTokens() {
+      return [...this.tokens].sort((a, b) => {
+        if (a.active !== b.active) {
+          return a.active ? -1 : 1;
+        }
+        return new Date(b.created_at) - new Date(a.created_at);
+      });
+    },
+  },
+
+  created() {
+    this.loadTokens();
+  },
+
+  methods: {
+    async loadTokens() {
+      this.isLoading = true;
+
+      try {
+        const response = await fetch(`${API_URL}/access-tokens`, {
+          method: "GET",
+          credentials: "include",
+        });
+
+        const data = await response.json();
+
+        if (response.ok && data.status === "success") {
+          this.tokens = data.tokens;
+        } else {
+          console.error("Failed to load tokens:", data.message);
+        }
+      } catch (error) {
+        console.error("Error loading tokens:", error);
+      } finally {
+        this.isLoading = false;
+      }
+    },
+    async confirmInvalidateToken(token) {
+      const confirmed = await DialogService.confirm({
+        title: "Invalidate Access Token",
+        message: `Are you sure you want to invalidate the access token for <strong>${token.item_id}</strong> (${token.refcode})? <br><br>This action cannot be undone and will immediately block access for anyone using this token.`,
+        type: "error",
+        confirmButtonText: "Invalidate Token",
+        cancelButtonText: "Cancel",
+      });
+
+      if (confirmed) {
+        await this.invalidateToken(token);
+      }
+    },
+    async invalidateToken(token) {
+      this.invalidatingTokens.add(token._id);
+
+      try {
+        const response = await fetch(`${API_URL}/items/${token.refcode}/invalidate-access-token`, {
+          method: "POST",
+          credentials: "include",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            token: "admin-invalidation",
+          }),
+        });
+
+        const data = await response.json();
+
+        if (response.ok && data.status === "success") {
+          // Mettre à jour le token dans la liste
+          const index = this.tokens.findIndex((t) => t._id === token._id);
+          if (index !== -1) {
+            this.tokens[index].active = false;
+            this.tokens[index].invalidated_at = new Date().toISOString();
+          }
+        } else {
+          alert(`Failed to invalidate token: ${data.detail || data.message}`);
+        }
+      } catch (error) {
+        console.error("Error invalidating token:", error);
+        alert(`Error invalidating token: ${error.message}`);
+      } finally {
+        this.invalidatingTokens.delete(token._id);
+      }
+    },
+
+    formatDate(dateString) {
+      if (!dateString) return "Unknown";
+      try {
+        return new Date(dateString).toLocaleDateString();
+      } catch {
+        return "Invalid date";
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+td {
+  vertical-align: middle;
+}
+
+.table-item-id {
+  font-size: 1.2em;
+  font-weight: normal;
+}
+</style>

--- a/webapp/src/views/Admin.vue
+++ b/webapp/src/views/Admin.vue
@@ -23,7 +23,7 @@ export default {
   },
   data() {
     return {
-      items: ["Users"],
+      items: ["Users", "Access Tokens"],
       selectedItem: "Users",
       user: null,
     };

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -294,29 +294,39 @@ export default {
       this.lastModified = "just now";
     },
     async getSampleData() {
+      const urlParams = new URLSearchParams(window.location.search);
+      const accessToken = urlParams.get("at");
+
       if (this.item_id == null) {
-        getItemByRefcode(this.refcode).then(() => {
-          this.itemDataLoaded = true;
-          this.$nextTick(() => {
-            this.$store.commit("setItemSaved", { item_id: this.item_id, isSaved: true });
+        getItemByRefcode(this.refcode, accessToken)
+          .then(() => {
+            this.itemDataLoaded = true;
+            this.$nextTick(() => {
+              this.$store.commit("setItemSaved", { item_id: this.item_id, isSaved: true });
+            });
+            this.item_id = this.$store.state.refcode_to_id[this.refcode];
+            this.updateBlocks();
+          })
+          .catch(() => {
+            this.itemDataLoaded = false;
           });
-          this.item_id = this.$store.state.refcode_to_id[this.refcode];
-          this.updateBlocks();
-        });
       } else {
-        getItemData(this.item_id).then(() => {
-          this.itemDataLoaded = true;
-          this.refcode = this.item_data.refcode;
-          this.$nextTick(() => {
-            this.$store.commit("setItemSaved", { item_id: this.item_id, isSaved: true });
+        getItemData(this.item_id, accessToken)
+          .then(() => {
+            this.itemDataLoaded = true;
+            this.refcode = this.item_data.refcode;
+            this.$nextTick(() => {
+              this.$store.commit("setItemSaved", { item_id: this.item_id, isSaved: true });
+            });
+            this.updateBlocks();
+          })
+          .catch(() => {
+            this.itemDataLoaded = false;
           });
-          this.updateBlocks();
-        });
       }
     },
-
     async updateBlocks() {
-      if (this.itemDataLoaded) {
+      if (this.itemDataLoaded && this.item_data && this.item_data.display_order) {
         // update each block asynchronously
         this.item_data.display_order.forEach((block_id) => {
           console.log(`calling update on block ${block_id}`);


### PR DESCRIPTION
This PR initiates the work on allowing QR codes to be generated that are
accessible by anyone who has printed one out, requested by @PeterKraus in #1053.

Closes #1053.

It does this by adding a `/items/<refcode>/issue-access-token` endpoint, which stores a token in the
database that can be used to access that refcode without login. A corresponding
admin endpoint for invalidating the token is added, in case of nefarious use.

Outstanding questions:

- [x] ~For the UI, this should likely be a conscious second step -- e.g., QR code -> generate public QR code. We may want to limit how many there are per item too, perhaps to 1. Admins should probably also have access to another UI that shows when tokens were generated, with the option to invalidate them, though I think this could be a future PR.~ Completed, including admin UI
- [x] ~Right now, a user with existing access to a sample could generate access tokens to all samples they have access to without using the UI. This is a bit of a harder problem to solve, and involves some trust on existing verified users. For now, the token is stored with the user account in place, so tokens can be invalidated programmatically that correspond to that user. We may also want to investigate a way of sharing a secret between the app and API so that the API can be sure that the generation is being done from a known UI, though this would probably be a relatively complicated deployment detail to implement.~ Shelved for now, given that admins can revoke if need be
- [x] ~As it stands in this PR, the user still has to be logged in to get access to the item (though they don't necessarily need to have permissions for it). I will relax this constraint once the rest is properly tested.~ Unauthenticated users can now access, and the federation has been updated accordingly
- [x] ~I am currently using `uuid.uuid1()` for the token generation (and storing a sha-512 hash of it in the database), but we might need to reduce the entropy a bit so that it fits into a printable QR.~ QRs seem eminently printable

These questions were answered by @BenjaminCharmes's follow up work. To summarise:

- unlimited public QR tokens per item
- hashed token stored alongside who created it and when
- admins can revoke any token through a new UI
- the token gives access to metadata but ignores blocks and files
- has to be regenerated every time "new public token" is made

Still to-do:

- [ ] potentially send an email to the admin every token that gets created, to avoid misuse (as described above) 