### PR TITLE
Add spectrum selection controls to NMR insitu datablock

### DIFF
--- a/webapp/src/components/datablocks/NMRInsituBlock.vue
+++ b/webapp/src/components/datablocks/NMRInsituBlock.vue
@@ -159,7 +159,7 @@ export default {
     hasParameterChanges() {
       const currentStartExp = this.start_exp || 1;
       const currentEndExp = this.end_exp || this.maxExperiments;
-      const currentStepExp = this.step_exp || 1;
+      const currentStepExp = this.step_exp || null;
       const currentExcludeExp = this.exclude_exp || "";
 
       const hasChanges =


### PR DESCRIPTION
**Dependencies:**
* Required for: [datalab-app-plugin-insitu PR#38](https://github.com/datalab-org/datalab-app-plugin-insitu/pull/38)

**Features:**
* Added user controls to select which NMR experiments to process and visualize:
  - Start/end experiment range selection  
  - Step parameter for sampling
  - Input validation for parameter combinations