### PR TITLE
Fix for molar mass validation with invalid formula of starting materials

### DIFF
--- a/pydatalab/src/pydatalab/models/starting_materials.py
+++ b/pydatalab/src/pydatalab/models/starting_materials.py
@@ -74,6 +74,9 @@ class StartingMaterial(Item, HasSynthesisInfo):
         from periodictable import formula
 
         if v is None and values.get("chemform"):
-            return formula(values.get("chemform")).mass
+            try:
+                return formula(values.get("chemform")).mass
+            except Exception:
+                return None
 
         return v

--- a/pydatalab/tests/server/test_starting_materials.py
+++ b/pydatalab/tests/server/test_starting_materials.py
@@ -100,7 +100,10 @@ def test_new_starting_material_collision(client, default_starting_material_dict)
 @pytest.mark.dependency(depends=["test_new_starting_material"])
 def test_save_good_starting_material(admin_client, default_starting_material_dict):
     updated_starting_material = default_starting_material_dict.copy()
-    updated_starting_material.update({"description": "This is a newer test sample."})
+    # Also test a change to the description and weird chemical formula
+    updated_starting_material.update(
+        {"description": "This is a newer test sample.", "chemform": "Xe/Ar"}
+    )
     response = admin_client.post(
         "/save-item/",
         json={


### PR DESCRIPTION
Reported by @PeterKraus, this was causing weird errors when setting chemical formulae to e.g, `Xe/Ar`, which was failing to be turned into a molar mass by `periodictable` (and the error returned was no longer being caught).