### PR TITLE
Fix some PyPI metadata

### DIFF
--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -1,12 +1,11 @@
 [project]
 name = "datalab-server"
-keywords = []
+keywords = ["research data management", "materials", "chemistry"]
+description = "datalab is a research data management platform for materials science and chemistry."
 readme = "README.md"
 license = "MIT"
 authors = [
-    { name = "Matthew Evans", email = "dev@datalab.industries" },
-    { name = "Joshua Bocarsly" },
-    { name = "datalab development team", email = "dev@datalab-org.io" },
+    {name = "datalab development team", email = "dev@datalab-org.io"},
 ]
 dynamic = ["version"]
 classifiers = [


### PR DESCRIPTION
- Add description and keywords for PyPI
- Author metadata is a bit janky when provided by pyproject.toml (it would only show @jdbocarsly's name with my email) so I've just pulled it back to "datalab dev team" with a generic email (that gets forwarded).