### PR TITLE
Use OAuth2 `prompt` to force login/account selection by provider

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/auth.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/auth.py
@@ -214,7 +214,7 @@ AUTH = Blueprint("auth", __name__)
 
 OAUTH: dict[IdentityType, Blueprint] = {
     IdentityType.ORCID: make_orcid_blueprint(
-        scope="/authenticate",
+        scope="openid",
         authorization_url_params={"prompt": "login"},
         sandbox=os.environ.get("OAUTH_ORCID_SANDBOX", False),
     ),


### PR DESCRIPTION
Closes #1269.

This PR forces user's to login or select a logged in account whenever they hit the datalab login button. This is a requirement for using datalab on multi-user machines, as otherwise when one user logs out, the login button will automatically use the stored information according to the oauth provider.

Unfortunately, I had to vendor the flask-dance blueprints in order to expose the setting I needed, but these very rarely change (and indeed one of them was contributed upstream by me anyway).