### PR TITLE
Fix item selection dropdown missing scrollbar in synthesis info

### DIFF
--- a/webapp/cypress/e2e/batchSampleFeature.cy.js
+++ b/webapp/cypress/e2e/batchSampleFeature.cy.js
@@ -131,7 +131,7 @@ describe("Batch sample creation", () => {
 
     cy.get('[data-testid="batch-modal-container"]').findByText("Submit").should("be.disabled");
     getBatchAddCell(1, 1).type("component1");
-    getBatchAddCell(1, 2).type("this component has a name");
+    getBatchAddCell(1, 2).type("this component has a name that is quite long");
     getBatchAddCell(2, 1).type("component2");
     getBatchAddCell(3, 1).type("component3");
     getBatchAddCell(4, 1).type("component4");
@@ -145,7 +145,7 @@ describe("Batch sample creation", () => {
     cy.findAllByText("Successfully created.").should("have.length", 4);
 
     cy.get("[data-testid=batch-modal-container]").contains("Close").click();
-    cy.verifySample("component1", "this component has a name");
+    cy.verifySample("component1", "this component has a name that is quite long");
     cy.verifySample("component2");
     cy.verifySample("component3");
     cy.verifySample("component4");
@@ -348,7 +348,7 @@ describe("Batch sample creation", () => {
     );
     cy.contains("this is a description of baseB.");
     cy.get("#synthesis-information table").contains("component1");
-    cy.get("#synthesis-information table").contains("this component ...");
+    cy.get("#synthesis-information table").contains("this component has a name...");
 
     cy.get("#synthesis-information table").contains("component3");
     cy.get("#synthesis-information table").contains("component4");
@@ -526,7 +526,7 @@ describe("Batch sample creation", () => {
       cy.get("#synthesis-information table").contains("component3");
       cy.get("#synthesis-information table").contains("component4");
       cy.get("#synthesis-information table").contains("component1");
-      cy.get("#synthesis-information table").contains("this component ...");
+      cy.get("#synthesis-information table").contains("this component has a name...");
 
       cy.get("#synthesis-information tbody tr:nth-of-type(1) input")
         .eq(0)
@@ -632,7 +632,7 @@ describe("Batch sample creation", () => {
       cy.get("#synthesis-information table").contains("component3");
       cy.get("#synthesis-information table").contains("component4");
       cy.get("#synthesis-information table").contains("component1");
-      cy.get("#synthesis-information table").contains("this component ...");
+      cy.get("#synthesis-information table").contains("this component has a name...");
 
       cy.get("#synthesis-information tbody tr:nth-of-type(1) input")
         .eq(0)

--- a/webapp/cypress/e2e/batchSampleFeature.cy.js
+++ b/webapp/cypress/e2e/batchSampleFeature.cy.js
@@ -348,7 +348,7 @@ describe("Batch sample creation", () => {
     );
     cy.contains("this is a description of baseB.");
     cy.get("#synthesis-information table").contains("component1");
-    cy.get("#synthesis-information table").contains("this component has a name");
+    cy.get("#synthesis-information table").contains("this component ...");
 
     cy.get("#synthesis-information table").contains("component3");
     cy.get("#synthesis-information table").contains("component4");
@@ -526,7 +526,7 @@ describe("Batch sample creation", () => {
       cy.get("#synthesis-information table").contains("component3");
       cy.get("#synthesis-information table").contains("component4");
       cy.get("#synthesis-information table").contains("component1");
-      cy.get("#synthesis-information table").contains("this component has a name");
+      cy.get("#synthesis-information table").contains("this component ...");
 
       cy.get("#synthesis-information tbody tr:nth-of-type(1) input")
         .eq(0)
@@ -632,7 +632,7 @@ describe("Batch sample creation", () => {
       cy.get("#synthesis-information table").contains("component3");
       cy.get("#synthesis-information table").contains("component4");
       cy.get("#synthesis-information table").contains("component1");
-      cy.get("#synthesis-information table").contains("this component has a name");
+      cy.get("#synthesis-information table").contains("this component ...");
 
       cy.get("#synthesis-information tbody tr:nth-of-type(1) input")
         .eq(0)

--- a/webapp/src/components/CompactConstituentTable.vue
+++ b/webapp/src/components/CompactConstituentTable.vue
@@ -33,7 +33,7 @@
             :item-type="constituent.item.type"
             :name="constituent.item.name"
             :chemform="constituent.item.chemform || ''"
-            :max-length="15"
+            :max-length="25"
             enable-click
             enable-modified-click
             @dblclick="turnOnRowSelect(index)"

--- a/webapp/src/components/CompactConstituentTable.vue
+++ b/webapp/src/components/CompactConstituentTable.vue
@@ -33,6 +33,7 @@
             :item-type="constituent.item.type"
             :name="constituent.item.name"
             :chemform="constituent.item.chemform || ''"
+            :max-length="15"
             enable-click
             enable-modified-click
             @dblclick="turnOnRowSelect(index)"

--- a/webapp/src/components/FormattedItemName.vue
+++ b/webapp/src/components/FormattedItemName.vue
@@ -61,11 +61,11 @@ export default {
       return itemTypes[this.itemType]?.lightColor || "LightGrey";
     },
     shortenedName() {
-      if (this.maxLength && this.maxLength < this.name.length) {
-        return this.name.substring(0, this.maxLength) + "...";
-      } else {
-        return this.name || "";
+      const safeName = this.name || "";
+      if (this.maxLength && this.maxLength < safeName.length) {
+        return safeName.substring(0, this.maxLength) + "...";
       }
+      return safeName;
     },
   },
   methods: {

--- a/webapp/src/components/SynthesisInformation.vue
+++ b/webapp/src/components/SynthesisInformation.vue
@@ -77,10 +77,14 @@ export default {
   },
   mounted() {
     this.selectShown = new Array((this.constituents || []).length).fill(false);
+
+    var content = this.$refs.contentContainer;
+
     // Auto-collapsed when initialised empty
     this.isExpanded =
       (this.constituents && this.constituents.length > 0) ||
       (this.SynthesisDescription && this.SynthesisDescription.trim() !== "");
+
     // If expanded set height to none, otherwise set to 0px
     if (this.isExpanded) {
       this.contentMaxHeight = "none";
@@ -88,7 +92,7 @@ export default {
     } else {
       this.contentMaxHeight = "0px";
     }
-    var content = this.$refs.contentContainer;
+
     content.addEventListener("transitionend", () => {
       if (this.isExpanded) {
         this.contentMaxHeight = "none";

--- a/webapp/src/components/SynthesisInformation.vue
+++ b/webapp/src/components/SynthesisInformation.vue
@@ -84,6 +84,7 @@ export default {
     // If expanded set height to none, otherwise set to 0px
     if (this.isExpanded) {
       this.contentMaxHeight = "none";
+      content.style.overflow = "visible";
     } else {
       this.contentMaxHeight = "0px";
     }
@@ -101,7 +102,9 @@ export default {
       if (!this.isExpanded) {
         this.contentMaxHeight = content.scrollHeight + 2 * this.padding_height + "px";
         this.isExpanded = true;
+        content.style.overflow = "visible";
       } else {
+        content.style.overflow = "hidden";
         requestAnimationFrame(() => {
           //must be an arrow function so that 'this' is still accessible!
           this.contentMaxHeight = content.scrollHeight + "px";


### PR DESCRIPTION
Closes #1278

The `vs__dropdown-menu` was getting cut off because the parent container had `overflow: hidden` for the collapse/expand animation