### PR TITLE
Add `DataBlockResponse` model to sanitize `blocks_obj` in API

### DIFF
--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -6,7 +6,10 @@
     "blocks_obj": {
       "title": "Blocks Obj",
       "default": {},
-      "type": "object"
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/DataBlockResponse"
+      }
     },
     "display_order": {
       "title": "Display Order",
@@ -171,6 +174,63 @@
     "item_id"
   ],
   "definitions": {
+    "DataBlockResponse": {
+      "title": "DataBlockResponse",
+      "description": "A generic response model for a block, i.e., what is stored in `self.data`\nin the corresponding DataBlock class.",
+      "type": "object",
+      "properties": {
+        "blocktype": {
+          "title": "Blocktype",
+          "type": "string"
+        },
+        "block_id": {
+          "title": "Block Id",
+          "type": "string"
+        },
+        "item_id": {
+          "title": "Item Id",
+          "type": "string"
+        },
+        "collection_id": {
+          "title": "Collection Id",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "freeform_comment": {
+          "title": "Freeform Comment",
+          "type": "string"
+        },
+        "file_id": {
+          "title": "File Id",
+          "type": "string"
+        },
+        "file_ids": {
+          "title": "File Ids",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "b64_encoded_image": {
+          "title": "B64 Encoded Image",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "bokeh_plot_data": {
+          "title": "Bokeh Plot Data",
+          "type": "string"
+        }
+      },
+      "required": [
+        "blocktype",
+        "block_id"
+      ]
+    },
     "RelationshipType": {
       "title": "RelationshipType",
       "description": "An enumeration of the possible types of relationship between two entries.\n\n```mermaid\nclassDiagram\nclass entryC\nentryC --|> entryA: parent\nentryC ..|> entryD\nentryA <..> entryD: sibling\nentryA --|> entryB : child\n```",
@@ -356,7 +416,10 @@
         "blocks_obj": {
           "title": "Blocks Obj",
           "default": {},
-          "type": "object"
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/DataBlockResponse"
+          }
         },
         "display_order": {
           "title": "Display Order",

--- a/pydatalab/schemas/equipment.json
+++ b/pydatalab/schemas/equipment.json
@@ -6,7 +6,10 @@
     "blocks_obj": {
       "title": "Blocks Obj",
       "default": {},
-      "type": "object"
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/DataBlockResponse"
+      }
     },
     "display_order": {
       "title": "Display Order",
@@ -135,6 +138,63 @@
     "item_id"
   ],
   "definitions": {
+    "DataBlockResponse": {
+      "title": "DataBlockResponse",
+      "description": "A generic response model for a block, i.e., what is stored in `self.data`\nin the corresponding DataBlock class.",
+      "type": "object",
+      "properties": {
+        "blocktype": {
+          "title": "Blocktype",
+          "type": "string"
+        },
+        "block_id": {
+          "title": "Block Id",
+          "type": "string"
+        },
+        "item_id": {
+          "title": "Item Id",
+          "type": "string"
+        },
+        "collection_id": {
+          "title": "Collection Id",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "freeform_comment": {
+          "title": "Freeform Comment",
+          "type": "string"
+        },
+        "file_id": {
+          "title": "File Id",
+          "type": "string"
+        },
+        "file_ids": {
+          "title": "File Ids",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "b64_encoded_image": {
+          "title": "B64 Encoded Image",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "bokeh_plot_data": {
+          "title": "Bokeh Plot Data",
+          "type": "string"
+        }
+      },
+      "required": [
+        "blocktype",
+        "block_id"
+      ]
+    },
     "RelationshipType": {
       "title": "RelationshipType",
       "description": "An enumeration of the possible types of relationship between two entries.\n\n```mermaid\nclassDiagram\nclass entryC\nentryC --|> entryA: parent\nentryC ..|> entryD\nentryA <..> entryD: sibling\nentryA --|> entryB : child\n```",
@@ -320,7 +380,10 @@
         "blocks_obj": {
           "title": "Blocks Obj",
           "default": {},
-          "type": "object"
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/DataBlockResponse"
+          }
         },
         "display_order": {
           "title": "Display Order",

--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -18,7 +18,10 @@
     "blocks_obj": {
       "title": "Blocks Obj",
       "default": {},
-      "type": "object"
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/DataBlockResponse"
+      }
     },
     "display_order": {
       "title": "Display Order",
@@ -224,6 +227,63 @@
         "quantity"
       ]
     },
+    "DataBlockResponse": {
+      "title": "DataBlockResponse",
+      "description": "A generic response model for a block, i.e., what is stored in `self.data`\nin the corresponding DataBlock class.",
+      "type": "object",
+      "properties": {
+        "blocktype": {
+          "title": "Blocktype",
+          "type": "string"
+        },
+        "block_id": {
+          "title": "Block Id",
+          "type": "string"
+        },
+        "item_id": {
+          "title": "Item Id",
+          "type": "string"
+        },
+        "collection_id": {
+          "title": "Collection Id",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "freeform_comment": {
+          "title": "Freeform Comment",
+          "type": "string"
+        },
+        "file_id": {
+          "title": "File Id",
+          "type": "string"
+        },
+        "file_ids": {
+          "title": "File Ids",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "b64_encoded_image": {
+          "title": "B64 Encoded Image",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "bokeh_plot_data": {
+          "title": "Bokeh Plot Data",
+          "type": "string"
+        }
+      },
+      "required": [
+        "blocktype",
+        "block_id"
+      ]
+    },
     "RelationshipType": {
       "title": "RelationshipType",
       "description": "An enumeration of the possible types of relationship between two entries.\n\n```mermaid\nclassDiagram\nclass entryC\nentryC --|> entryA: parent\nentryC ..|> entryD\nentryA <..> entryD: sibling\nentryA --|> entryB : child\n```",
@@ -409,7 +469,10 @@
         "blocks_obj": {
           "title": "Blocks Obj",
           "default": {},
-          "type": "object"
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/DataBlockResponse"
+          }
         },
         "display_order": {
           "title": "Display Order",

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -18,7 +18,10 @@
     "blocks_obj": {
       "title": "Blocks Obj",
       "default": {},
-      "type": "object"
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/DataBlockResponse"
+      }
     },
     "display_order": {
       "title": "Display Order",
@@ -277,6 +280,63 @@
         "quantity"
       ]
     },
+    "DataBlockResponse": {
+      "title": "DataBlockResponse",
+      "description": "A generic response model for a block, i.e., what is stored in `self.data`\nin the corresponding DataBlock class.",
+      "type": "object",
+      "properties": {
+        "blocktype": {
+          "title": "Blocktype",
+          "type": "string"
+        },
+        "block_id": {
+          "title": "Block Id",
+          "type": "string"
+        },
+        "item_id": {
+          "title": "Item Id",
+          "type": "string"
+        },
+        "collection_id": {
+          "title": "Collection Id",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "freeform_comment": {
+          "title": "Freeform Comment",
+          "type": "string"
+        },
+        "file_id": {
+          "title": "File Id",
+          "type": "string"
+        },
+        "file_ids": {
+          "title": "File Ids",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "b64_encoded_image": {
+          "title": "B64 Encoded Image",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "bokeh_plot_data": {
+          "title": "Bokeh Plot Data",
+          "type": "string"
+        }
+      },
+      "required": [
+        "blocktype",
+        "block_id"
+      ]
+    },
     "RelationshipType": {
       "title": "RelationshipType",
       "description": "An enumeration of the possible types of relationship between two entries.\n\n```mermaid\nclassDiagram\nclass entryC\nentryC --|> entryA: parent\nentryC ..|> entryD\nentryA <..> entryD: sibling\nentryA --|> entryB : child\n```",
@@ -462,7 +522,10 @@
         "blocks_obj": {
           "title": "Blocks Obj",
           "default": {},
-          "type": "object"
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/DataBlockResponse"
+          }
         },
         "display_order": {
           "title": "Display Order",

--- a/pydatalab/src/pydatalab/models/blocks.py
+++ b/pydatalab/src/pydatalab/models/blocks.py
@@ -1,0 +1,44 @@
+from pydantic import BaseModel
+
+from pydatalab.models.utils import JSON_ENCODERS, PyObjectId
+
+
+class DataBlockResponse(BaseModel):
+    """A generic response model for a block, i.e., what is stored in `self.data`
+    in the corresponding DataBlock class.
+    """
+
+    blocktype: str
+    """The type of the block."""
+
+    block_id: str
+    """A shorthand random ID for the block."""
+
+    item_id: str | None = None
+    """The item that the block is attached to, if any."""
+
+    collection_id: str | None = None
+    """The collection that the block is attached to, if any."""
+
+    title: str | None = None
+    """The title of the block, if any."""
+
+    freeform_comment: str | None = None
+    """A freeform comment for the block, if any."""
+
+    file_id: PyObjectId | None = None
+    """The ID of the file associated with the block, if any."""
+
+    file_ids: list[PyObjectId] | None = None
+    """A list of file IDs associated with the block, if any."""
+
+    b64_encoded_image: dict[PyObjectId, str] | None = None
+    """Any base64-encoded image data associated with the block, keyed by file_id, if any."""
+
+    bokeh_plot_data: str | None = None
+    """A JSON-encoded string containing the Bokeh plot data, if any."""
+
+    class Config:
+        allow_population_by_field_name = True
+        json_encoders = JSON_ENCODERS
+        extra = "allow"

--- a/pydatalab/src/pydatalab/models/traits.py
+++ b/pydatalab/src/pydatalab/models/traits.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field, root_validator
 
+from pydatalab.models.blocks import DataBlockResponse
 from pydatalab.models.people import Person
 from pydatalab.models.utils import Constituent, InlineSubstance, PyObjectId
 
@@ -23,7 +24,7 @@ class HasRevisionControl(BaseModel):
 
 
 class HasBlocks(BaseModel):
-    blocks_obj: dict[str, Any] = Field({})
+    blocks_obj: dict[str, DataBlockResponse] = Field({})
     """A mapping from block ID to block data."""
 
     display_order: list[str] = Field([])


### PR DESCRIPTION
In trying to ablate changes from #1285 that are not entirely necessary, I've found it helpful to define a model for the blocks response when it is embedded in an item.