### PR TITLE
Hardened `SECRET_KEY` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## Unreleased changes
 
+> [!WARNING]
+> This release hardens the `SECRET_KEY` configuration to enforce setting a custom key with a minimum entropy; old keys may need to be rotated.
+
 ### What's Changed
 
 * Major refactoring of block life cycle, with better possibilities for validation of block data before and after saving by @ml-evs in #1311
 * Replace browser-native dialogs with custom datalab dialog service by @BenjaminCharmes in https://github.com/datalab-org/datalab/pull/1212
 * Resolve CVEs on mermaid.js and cross-spawn by @dependabot[bot] in https://github.com/datalab-org/datalab/pull/1317
+* Hardened `SECRET_KEY` configuration by @ml-evs in #1324
 
 **Full Changelog**: https://github.com/datalab-org/datalab/compare/v0.6.2...main
 

--- a/pydatalab/src/pydatalab/feature_flags.py
+++ b/pydatalab/src/pydatalab/feature_flags.py
@@ -1,0 +1,164 @@
+import math
+import os
+from collections import Counter
+
+from pydantic import BaseModel
+
+from pydatalab.config import CONFIG
+from pydatalab.logger import LOGGER
+
+__all__ = ("FEATURE_FLAGS", "check_feature_flags", "FeatureFlags")
+
+
+class AuthMechanisms(BaseModel):
+    github: bool = False
+    orcid: bool = False
+    email: bool = False
+
+
+class AIIntegrations(BaseModel):
+    openai: bool = False
+    anthropic: bool = False
+
+
+class FeatureFlags(BaseModel):
+    auth_mechanisms: AuthMechanisms = AuthMechanisms()
+    ai_integrations: AIIntegrations = AIIntegrations()
+    email_notifications: bool = False
+
+
+FEATURE_FLAGS: FeatureFlags = FeatureFlags()
+"""The global feature flags object.
+
+This is a singleton of `FeatureFlags` that can be used to see
+the enabled features of the app at a higher-level to the
+configuration (e.g., includes runtime environment checks).
+"""
+
+
+def _check_key_strength(s: str, min_entropy: float = 3.8) -> None:
+    (
+        """Compute the Shannon entropy of a string and raise a `RuntimeError` if it is below a threshold.""",
+    )
+
+    def shannon_entropy(s: str) -> float:
+        return sum(-math.log2(c / len(s)) * (c / len(s)) for c in Counter(s).values())
+
+    if shannon_entropy(s) < min_entropy:
+        raise RuntimeError(
+            f"`SECRET_KEY` does not have enough Shannon entropy ({shannon_entropy(s)} vs {min_entropy}), please set `CONFIG.SECRET_KEY` or the `PYDATALAB_SECRET_KEY` environment variable to a more secure value."
+        )
+
+
+def check_feature_flags(app):
+    """Loop over various secrets and settings and populate the logs if
+    missing or invalid, as well as setting the global `FEATURE_FLAGS`
+    object reported by the API for use in UIs.
+
+    """
+
+    if CONFIG.EMAIL_AUTH_SMTP_SETTINGS is None:
+        LOGGER.warning(
+            "No email auth SMTP settings provided, email registration will not be enabled."
+        )
+    else:
+        FEATURE_FLAGS.email_notifications = True
+        if app.config["MAIL_SERVER"] and not app.config.get("MAIL_PASSWORD"):
+            LOGGER.critical(
+                "CONFIG.EMAIL_AUTH_SMTP_SETTINGS.MAIL_SERVER was set to '%s' but no `MAIL_PASSWORD` was provided. "
+                "This can be passed in a `.env` file (as `MAIL_PASSWORD`) or as an environment variable.",
+                app.config["MAIL_SERVER"],
+            )
+            FEATURE_FLAGS.email_notifications = False
+        if not app.config["MAIL_DEFAULT_SENDER"]:
+            LOGGER.critical(
+                "CONFIG.EMAIL_AUTH_SMTP_SETTINGS.MAIL_DEFAULT_SENDER is not set in the config. "
+                "Email authentication may not work correctly."
+                "This can be set in the config above or equivalently via `MAIL_DEFAULT_SENDER` in a `.env` file, "
+                "or as an environment variable."
+            )
+            FEATURE_FLAGS.email_notifications = False
+
+        if CONFIG.EMAIL_DOMAIN_ALLOW_LIST and FEATURE_FLAGS.email_notifications:
+            FEATURE_FLAGS.auth_mechanisms.email = True
+        else:
+            LOGGER.warning(
+                "`CONFIG.EMAIL_DOMAIN_ALLOW_LIST` is usnet or empty; email registration will not be enabled."
+            )
+
+    if CONFIG.IDENTIFIER_PREFIX == "test":
+        LOGGER.critical(
+            "You should configure an identifier prefix for this deployment. "
+            "You should attempt to make it unique to your deployment or group. "
+            "In the future these will be optionally globally validated versus all deployments for uniqueness. "
+            "For now the value of %s will be used.",
+            CONFIG.IDENTIFIER_PREFIX,
+        )
+
+    if not CONFIG.TESTING:
+        if not CONFIG.SECRET_KEY:
+            raise RuntimeError(
+                "No secret key provided, please set `CONFIG.SECRET_KEY` or the `PYDATALAB_SECRET_KEY` environment variable."
+            )
+
+            _check_key_strength(CONFIG.SECRET_KEY)
+
+    def _check_secret_and_warn(secret: str, error: str, environ: bool = False) -> bool:
+        """Checks if a secret has been set, and if so, return True.
+
+        Otherwise, warn and return False.
+
+        Parameters:
+            secret: The secret to check.
+            error: The error message to log if the secret is missing.
+            environ: Whether the secret should also be checked as an environment variable.
+        """
+        if not app.config.get(secret):
+            LOGGER.warning("%s: please set `%s`", error, secret)
+            return False
+        if environ and not os.environ.get(secret):
+            LOGGER.warning("%s: please set as an environment variable too `%s`", error, secret)
+            return False
+
+        return True
+
+    if _check_secret_and_warn(
+        "GITHUB_OAUTH_CLIENT_ID",
+        "No GitHub OAuth client ID provided, GitHub login will not work",
+    ) and _check_secret_and_warn(
+        "GITHUB_OAUTH_CLIENT_SECRET",
+        "No GitHub OAuth client secret provided, GitHub login will not work",
+    ):
+        FEATURE_FLAGS.auth_mechanisms.github = True
+    if _check_secret_and_warn(
+        "ORCID_OAUTH_CLIENT_SECRET",
+        "No ORCID OAuth client secret provided, ORCID login will not work",
+    ) and _check_secret_and_warn(
+        "ORCID_OAUTH_CLIENT_ID", "No ORCID OAuth client ID provided, ORCID login will not work"
+    ):
+        FEATURE_FLAGS.auth_mechanisms.orcid = True
+    if _check_secret_and_warn(
+        "OPENAI_API_KEY",
+        "No OpenAI API key provided, OpenAI-based ChatBlock will not work",
+        environ=True,
+    ):
+        FEATURE_FLAGS.ai_integrations.openai = True
+    if _check_secret_and_warn(
+        "ANTHROPIC_API_KEY",
+        "No Anthropic API key provided, Claude-based ChatBlock will not work",
+        environ=True,
+    ):
+        FEATURE_FLAGS.ai_integrations.anthropic = True
+
+    if CONFIG.DEBUG:
+        LOGGER.warning("Running with debug logs enabled")
+
+    if CONFIG.TESTING:
+        LOGGER.critical(
+            "Running in testing mode, with no authentication required; this is not recommended for production use: set `CONFIG.TESTING`"
+        )
+
+    if not CONFIG.DEPLOYMENT_METADATA:
+        LOGGER.warning(
+            "No deployment metadata provided, please set `CONFIG.DEPLOYMENT_METADATA` to allow the UI to provide helpful information to users"
+        )

--- a/pydatalab/src/pydatalab/main.py
+++ b/pydatalab/src/pydatalab/main.py
@@ -13,119 +13,14 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 import pydatalab.mongo
 from pydatalab import __version__
-from pydatalab.config import CONFIG, FEATURE_FLAGS
+from pydatalab.config import CONFIG
+from pydatalab.feature_flags import check_feature_flags
 from pydatalab.logger import LOGGER, setup_log
 from pydatalab.login import LOGIN_MANAGER
 from pydatalab.send_email import MAIL
 from pydatalab.utils import BSONProvider
 
 COMPRESS = Compress()
-
-
-def _check_feature_flags(app):
-    """Loop over various secrets and settings and populate the logs if
-    missing or invalid, as well as setting the global `FEATURE_FLAGS`
-    object reported by the API for use in UIs.
-
-    """
-
-    if CONFIG.EMAIL_AUTH_SMTP_SETTINGS is None:
-        LOGGER.warning(
-            "No email auth SMTP settings provided, email registration will not be enabled."
-        )
-    else:
-        FEATURE_FLAGS.email_notifications = True
-        if app.config["MAIL_SERVER"] and not app.config.get("MAIL_PASSWORD"):
-            LOGGER.critical(
-                "CONFIG.EMAIL_AUTH_SMTP_SETTINGS.MAIL_SERVER was set to '%s' but no `MAIL_PASSWORD` was provided. "
-                "This can be passed in a `.env` file (as `MAIL_PASSWORD`) or as an environment variable.",
-                app.config["MAIL_SERVER"],
-            )
-            FEATURE_FLAGS.email_notifications = False
-        if not app.config["MAIL_DEFAULT_SENDER"]:
-            LOGGER.critical(
-                "CONFIG.EMAIL_AUTH_SMTP_SETTINGS.MAIL_DEFAULT_SENDER is not set in the config. "
-                "Email authentication may not work correctly."
-                "This can be set in the config above or equivalently via `MAIL_DEFAULT_SENDER` in a `.env` file, "
-                "or as an environment variable."
-            )
-            FEATURE_FLAGS.email_notifications = False
-
-        if CONFIG.EMAIL_DOMAIN_ALLOW_LIST and FEATURE_FLAGS.email_notifications:
-            FEATURE_FLAGS.auth_mechanisms.email = True
-        else:
-            LOGGER.warning(
-                "`CONFIG.EMAIL_DOMAIN_ALLOW_LIST` is usnet or empty; email registration will not be enabled."
-            )
-
-    if CONFIG.IDENTIFIER_PREFIX == "test":
-        LOGGER.critical(
-            "You should configure an identifier prefix for this deployment. "
-            "You should attempt to make it unique to your deployment or group. "
-            "In the future these will be optionally globally validated versus all deployments for uniqueness. "
-            "For now the value of %s will be used.",
-            CONFIG.IDENTIFIER_PREFIX,
-        )
-
-    def _check_secret_and_warn(secret: str, error: str, environ: bool = False) -> bool:
-        """Checks if a secret has been set, and if so, return True.
-
-        Otherwise, warn and return False.
-
-        Parameters:
-            secret: The secret to check.
-            error: The error message to log if the secret is missing.
-            environ: Whether the secret should also be checked as an environment variable.
-        """
-        if not app.config.get(secret):
-            LOGGER.warning("%s: please set `%s`", error, secret)
-            return False
-        if environ and not os.environ.get(secret):
-            LOGGER.warning("%s: please set as an environment variable too `%s`", error, secret)
-            return False
-
-        return True
-
-    if _check_secret_and_warn(
-        "GITHUB_OAUTH_CLIENT_ID",
-        "No GitHub OAuth client ID provided, GitHub login will not work",
-    ) and _check_secret_and_warn(
-        "GITHUB_OAUTH_CLIENT_SECRET",
-        "No GitHub OAuth client secret provided, GitHub login will not work",
-    ):
-        FEATURE_FLAGS.auth_mechanisms.github = True
-    if _check_secret_and_warn(
-        "ORCID_OAUTH_CLIENT_SECRET",
-        "No ORCID OAuth client secret provided, ORCID login will not work",
-    ) and _check_secret_and_warn(
-        "ORCID_OAUTH_CLIENT_ID", "No ORCID OAuth client ID provided, ORCID login will not work"
-    ):
-        FEATURE_FLAGS.auth_mechanisms.orcid = True
-    if _check_secret_and_warn(
-        "OPENAI_API_KEY",
-        "No OpenAI API key provided, OpenAI-based ChatBlock will not work",
-        environ=True,
-    ):
-        FEATURE_FLAGS.ai_integrations.openai = True
-    if _check_secret_and_warn(
-        "ANTHROPIC_API_KEY",
-        "No Anthropic API key provided, Claude-based ChatBlock will not work",
-        environ=True,
-    ):
-        FEATURE_FLAGS.ai_integrations.anthropic = True
-
-    if CONFIG.DEBUG:
-        LOGGER.warning("Running with debug logs enabled")
-
-    if CONFIG.TESTING:
-        LOGGER.critical(
-            "Running in testing mode, with no authentication required; this is not recommended for production use: set `CONFIG.TESTING`"
-        )
-
-    if not CONFIG.DEPLOYMENT_METADATA:
-        LOGGER.warning(
-            "No deployment metadata provided, please set `CONFIG.DEPLOYMENT_METADATA` to allow the UI to provide helpful information to users"
-        )
 
 
 def create_app(
@@ -179,7 +74,7 @@ def create_app(
     LOGGER.info("Launching datalab version %s", __version__)
     LOGGER.info("Starting app with Flask app.config: %s", app.config)
 
-    _check_feature_flags(app)
+    check_feature_flags(app)
 
     if CONFIG.BEHIND_REVERSE_PROXY:
         # Fix headers for reverse proxied app:

--- a/pydatalab/src/pydatalab/routes/v0_1/info.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/info.py
@@ -9,7 +9,8 @@ from pydantic import AnyUrl, BaseModel, Field, validator
 
 from pydatalab import __version__
 from pydatalab.apps import BLOCK_TYPES
-from pydatalab.config import CONFIG, FEATURE_FLAGS, FeatureFlags
+from pydatalab.config import CONFIG
+from pydatalab.feature_flags import FEATURE_FLAGS, FeatureFlags
 from pydatalab.models import Collection, Person
 from pydatalab.models.items import Item
 from pydatalab.mongo import flask_mongo

--- a/pydatalab/tests/conftest.py
+++ b/pydatalab/tests/conftest.py
@@ -1,6 +1,31 @@
+import hashlib
 from pathlib import Path
 
 import pytest
+
+
+@pytest.fixture(scope="session")
+def monkeypatch_session():
+    from _pytest.monkeypatch import MonkeyPatch
+
+    m = MonkeyPatch()
+    yield m
+    m.undo()
+
+
+@pytest.fixture(scope="session")
+def secret_key():
+    """Fixture to provide a secret key for testing purposes."""
+    return hashlib.sha512(b"test").hexdigest()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def override_environment_variables(monkeypatch_session, secret_key):
+    """Override the secret key and other environment variables that will
+    otherwise fallover outside of testing mode.
+
+    """
+    monkeypatch_session.setenv("PYDATALAB_SECRET_KEY", secret_key)
 
 
 @pytest.fixture(scope="session")

--- a/pydatalab/tests/server/conftest.py
+++ b/pydatalab/tests/server/conftest.py
@@ -8,7 +8,6 @@ from bson import ObjectId
 from flask.testing import FlaskClient
 
 import pydatalab.mongo
-from pydatalab.main import create_app
 from pydatalab.models import Cell, Collection, Equipment, Sample, StartingMaterial
 from pydatalab.models.people import AccountStatus
 
@@ -21,15 +20,6 @@ class PyMongoMock(mongomock.MongoClient):
 
 
 MONGO_URI = f"mongodb://localhost:27017/{TEST_DATABASE_NAME}"
-
-
-@pytest.fixture(scope="session")
-def monkeypatch_session():
-    from _pytest.monkeypatch import MonkeyPatch
-
-    m = MonkeyPatch()
-    yield m
-    m.undo()
 
 
 @pytest.fixture(scope="module")
@@ -53,7 +43,7 @@ def database(real_mongo_client):
 
 
 @pytest.fixture(scope="session")
-def app_config(tmp_path_factory):
+def app_config(tmp_path_factory, secret_key):
     example_remotes = [
         {
             "name": "example_data",
@@ -72,6 +62,7 @@ def app_config(tmp_path_factory):
         "FILE_DIRECTORY": str(tmp_path_factory.mktemp("files")),
         "TESTING": False,
         "ROOT_PATH": "/",
+        "SECRET_KEY": secret_key,
         "EMAIL_AUTH_SMTP_SETTINGS": {
             "MAIL_SERVER": "smtp.example.com",
             "MAIL_PORT": 587,
@@ -97,6 +88,7 @@ def app(real_mongo_client, monkeypatch_session, app_config):
     mongomock testing backend.
 
     """
+    from pydatalab.main import create_app
 
     try:
         mongo_cli = real_mongo_client

--- a/pydatalab/tests/server/test_info_and_health.py
+++ b/pydatalab/tests/server/test_info_and_health.py
@@ -1,10 +1,8 @@
-import os
-
 import pytest
 
 
 @pytest.mark.parametrize("url_prefix", ["", "/v0", "/v0.1", "/v0.1.0"])
-def test_info_endpoint(client, url_prefix):
+def test_info_endpoint(client, url_prefix, app):
     response = client.get(f"{url_prefix}/info")
     assert response.status_code == 200
     assert all(k in response.json for k in ("data", "meta", "links"))
@@ -13,14 +11,14 @@ def test_info_endpoint(client, url_prefix):
     assert (features := attributes.get("features"))
     assert (auth := features.get("auth_mechanisms"))
     assert auth["github"] is bool(
-        os.environ.get("GITHUB_OAUTH_CLIENT_ID", None)
-        and os.environ.get("GITHUB_OAUTH_CLIENT_SECRET", None)
+        app.config.get("GITHUB_OAUTH_CLIENT_ID", None)
+        and app.config.get("GITHUB_OAUTH_CLIENT_SECRET", None)
     )
     assert auth["orcid"] is bool(
-        os.environ.get("ORCID_OAUTH_CLIENT_ID", None)
-        and os.environ.get("ORCID_OAUTH_CLIENT_SECRET", None)
+        app.config.get("ORCID_OAUTH_CLIENT_ID", None)
+        and app.config.get("ORCID_OAUTH_CLIENT_SECRET", None)
     )
-    assert auth["email"] is bool(os.environ.get("MAIL_PASSWORD", None))
+    assert auth["email"] is bool(app.config.get("MAIL_PASSWORD", None))
 
 
 @pytest.mark.parametrize("url_prefix", ["", "/v0", "/v0.1", "/v0.1.0"])


### PR DESCRIPTION
This PR changes the config behaviour to only set a deterministic `SECRET_KEY` when in `TESTING` mode. It also validates the strength of any provided secret wrt. Shannon entropy.

- Do this with a validator in new feature flags module, moved out of main
- Add a minimum Shannon entropy for they secret key in production
- Reorder test imports to avoid failing config load
- Fix info endpoint tests locally