### PR TITLE
Reorder (separator, skiprows) loop in XRD reader to accelerate most common cases

### DIFF
--- a/pydatalab/src/pydatalab/apps/xrd/blocks.py
+++ b/pydatalab/src/pydatalab/apps/xrd/blocks.py
@@ -80,39 +80,44 @@ class XRDBlock(DataBlock):
 
         else:
             columns = ["twotheta", "intensity", "error"]
+
+            def _try_read_csv(sep: str, skiprows: int) -> pd.DataFrame | None:
+                try:
+                    df = pd.read_csv(
+                        location, sep=sep, skiprows=skiprows, dtype=np.float64, names=columns
+                    )
+                    if df.empty:
+                        return None
+
+                    return df
+
+                except (ValueError, RuntimeError):
+                    return None
+
             possible_separators = (r"\s+", ",")
             df = pd.DataFrame()
-            for sep in possible_separators:
-                # Try to parse the file by incrementing skiprows until all lines can be cast to np.float64
-                skiprows: int = 0
-                # Set arbitrary limit to avoid infinite loop; a header of 10,000 lines is unlikely to be useful
-                while skiprows < 1_000:
-                    LOGGER.debug(
-                        "Trying to read %s with skiprows=%d, sep=%s",
-                        location.split("/")[-1],
-                        skiprows,
-                        sep,
-                    )
-                    try:
-                        df = pd.read_csv(
-                            location, sep=sep, names=columns, dtype=np.float64, skiprows=skiprows
-                        )
+            # Try to parse the file by incrementing skiprows until all lines can be cast to np.float64
+            # Set arbitrary limit to avoid infinite loop; a header of >1,000 lines is unlikely to be useful
+            max_skiprows: int = 1_000
+            final_skiprows: int = 0
+            for skiprows in range(max_skiprows):
+                for sep in possible_separators:
+                    df = _try_read_csv(sep, skiprows)
+                    if df is not None and not df.empty:
+                        final_skiprows = skiprows
                         break
-                    except (ValueError, RuntimeError):
-                        skiprows += 1
 
-                if df.empty:
-                    continue
+                if df is not None and not df.empty:
+                    final_skiprows = skiprows
+                    break
 
-                break
-
-            # If no valid separator was found, raise an error
+            # If no valid separator/skiprows combo was found, raise an error
             else:
                 raise RuntimeError(
                     f"Unable to extract XRD data from file {location}; check file header for irregularities"
                 )
 
-            if skiprows > 0:
+            if final_skiprows > 0:
                 with open(location) as f:
                     header = "".join([next(f) for _ in range(skiprows)])
                     df.attrs["header"] = header


### PR DESCRIPTION
This PR reorders the detection of `skiprows` and `sep` to avoid needing to try reading an XRD file ~1000 times before checking if the file is comma separated...