### PR TITLE
Chat block fix: ignore available models list based on web app update

### DIFF
--- a/pydatalab/src/pydatalab/apps/chat/models.py
+++ b/pydatalab/src/pydatalab/apps/chat/models.py
@@ -1,7 +1,7 @@
 from langchain_anthropic import ChatAnthropic
 from langchain_core.language_models import BaseChatModel, ParrotFakeChatModel
 from langchain_openai import ChatOpenAI
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ModelCard(BaseModel):
@@ -9,7 +9,7 @@ class ModelCard(BaseModel):
     context_window: int
     input_cost_usd_per_MTok: float
     output_cost_usd_per_MTok: float
-    chat_client: type[BaseChatModel]
+    chat_client: type[BaseChatModel] | None = Field(exclude=True)
 
 
 __all__ = ("AVAILABLE_MODELS", "ModelCard")


### PR DESCRIPTION
Closes #1339. 

Previously the chatblock was storing the `available_models` list per block in the database, but the new chatblock model introduced recently stopped this, so we need to use the default values instead.