### PR TITLE
Add text-break to DialogModal

### DIFF
--- a/webapp/src/components/DialogModal.vue
+++ b/webapp/src/components/DialogModal.vue
@@ -10,23 +10,23 @@
             </button>
           </div>
           <div class="modal-body">
-            <div class="d-flex align-items-center">
+            <div class="d-flex align-items-start">
               <div v-if="type === 'error'" class="mr-3 text-danger">
                 <font-awesome-icon icon="exclamation-circle" size="2x" />
               </div>
-              <div v-else-if="type === 'warning'" class="mr-3 text-warning">
+              <div v-else-if="type === 'warning'" class="mr-3 text-warning flex-shrink-0">
                 <font-awesome-icon icon="exclamation-triangle" size="2x" />
               </div>
-              <div v-else-if="type === 'info'" class="mr-3 text-info">
+              <div v-else-if="type === 'info'" class="mr-3 text-info flex-shrink-0">
                 <font-awesome-icon icon="info-circle" size="2x" />
               </div>
-              <div v-else-if="type === 'success'" class="mr-3 text-success">
+              <div v-else-if="type === 'success'" class="mr-3 text-success flex-shrink-0">
                 <font-awesome-icon icon="check-circle" size="2x" />
               </div>
 
-              <div class="flex-grow-1 d-flex align-items-center">
+              <div class="flex-grow-1 text-break">
                 <!-- eslint-disable-next-line vue/no-v-html -->
-                <p v-if="message" class="mb-0" v-html="message"></p>
+                <p v-if="message" class="mb-0 text-break" v-html="message"></p>
                 <slot></slot>
               </div>
             </div>


### PR DESCRIPTION
Prevents DialogModal message text from overflowing.

- Before:

<img width="873" height="244" alt="Screenshot 2025-09-12 at 16 37 40" src="https://github.com/user-attachments/assets/a28f0152-e00e-4e80-9cf1-1c09ca507850" />

- After:

<img width="525" height="578" alt="Screenshot 2025-09-15 at 13 13 41" src="https://github.com/user-attachments/assets/c5bd73bf-9d13-45d2-b8b3-32956224f035" />

