### PR TITLE
Fix collection creation modal error display for duplicate IDs

### DIFF
--- a/webapp/src/components/CreateCollectionModal.vue
+++ b/webapp/src/components/CreateCollectionModal.vue
@@ -67,16 +67,21 @@ export default {
       title: "",
       selectedCollectionToCopy: null,
       startingMembers: [],
+      takenCollectionIds: [],
     };
   },
   computed: {
-    takenCollectionIds() {
+    collectionIdsFromStore() {
       return this.$store.state.collection_list
         ? this.$store.state.collection_list.map((x) => x.collection_id)
         : [];
     },
     isValidEntryID() {
-      return validateEntryID(this.collection_id, this.takenCollectionIds);
+      return validateEntryID(
+        this.collection_id,
+        this.takenCollectionIds,
+        this.collectionIdsFromStore,
+      );
     },
   },
   methods: {


### PR DESCRIPTION
Closes #1364

The collection creation modal now properly displays API errors when attempting to create a collection with an ID already in use by another user.