### PR TITLE
Allow item creation endpoints to use `PUT`

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -645,7 +645,7 @@ def _create_sample(
     return data
 
 
-@ITEMS.route("/new-sample/", methods=["POST"])
+@ITEMS.route("/new-sample/", methods=["POST", "PUT"])
 def create_sample():
     request_json = request.get_json()  # noqa: F821 pylint: disable=undefined-variable
     if "new_sample_data" in request_json:
@@ -660,7 +660,7 @@ def create_sample():
     return jsonify(response), http_code
 
 
-@ITEMS.route("/new-samples/", methods=["POST"])
+@ITEMS.route("/new-samples/", methods=["POST", "PUT"])
 def create_samples():
     """attempt to create multiple samples at once.
     Because each may result in success or failure, 207 is returned along with a

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -17,7 +17,7 @@ def test_empty_samples(client):
 
 @pytest.mark.dependency(depends=["test_empty_samples"])
 def test_new_sample(client, default_sample_dict):
-    response = client.post("/new-sample/", json=default_sample_dict)
+    response = client.put("/new-sample/", json=default_sample_dict)
     # Test that 201: Created is emitted
     assert response.status_code == 201, response.json
     assert response.json["status"] == "success"


### PR DESCRIPTION
Makes more semantic sense, though no reason not to allow both for backwards compat; triggered by https://github.com/datalab-org/datalab-api/issues/76