### PR TITLE
Log more informative block errors

### DIFF
--- a/pydatalab/src/pydatalab/blocks/base.py
+++ b/pydatalab/src/pydatalab/blocks/base.py
@@ -222,7 +222,9 @@ class DataBlock:
                             f"Could not create plot for {self.__class__.__name__} due to "
                             f"error at {last.filename}:{last.lineno} "
                             f"in {last.name} → {last.line!r}:\n\t{type(e).__name__}: {e}"
-                            f"\n\nthe full data for the block is:\n{pprint.pformat(self.data)}\n\n"
+                        )
+                        LOGGER.debug(
+                            f"The full data for the errored block is:\n{pprint.pformat(self.data)}"
                         )
                     finally:
                         if captured_warnings:


### PR DESCRIPTION
Edits the Warning log message printed by datablocks when a block experiences an error. Now, the errors look something like this:
<img width="1336" height="322" alt="Screenshot 2025-10-30 at 12 22 37 PM" src="https://github.com/user-attachments/assets/b5d0afc9-4ea2-4763-8044-e9d07b7dc7b7" />


(note, the first commit adds the line numbers and filenames of the actual log, the second commit pretty prints the data, which previously we were just printing. Pretty printing could lead to some long logs in the case of blocks with lots of data, so we can take this out if needed. We were already printing the data dictionary, so it could get long regardless.)

addresses issue #1392 