### PR TITLE
Fix dialog boxes font consistency

### DIFF
--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -113,4 +113,8 @@ body {
 .clickable {
   cursor: pointer;
 }
+
+.modal {
+  font-family: var(--font-primary);
+}
 </style>


### PR DESCRIPTION
Closes #1426 

Dialogs were not using Figtree font because they're outside #app. 
