### PR TITLE
Enforce refcode requirement for synthesis constituent references

### DIFF
--- a/pydatalab/src/pydatalab/models/utils.py
+++ b/pydatalab/src/pydatalab/models/utils.py
@@ -276,11 +276,21 @@ class EntryReference(BaseModel):
 
     @root_validator
     def check_id_fields(cls, values):
-        """Check that at least one of the possible identifier fields is provided."""
+        """Check that refcode is provided for item references.
+
+        The refcode is immutable and should always be used to reference items.
+        The item_id is mutable and should not be used alone for persistent references.
+        """
         id_fields = ("immutable_id", "item_id", "refcode")
 
         if all(values.get(f) is None for f in id_fields):
             raise ValueError(f"Must provide at least one of {id_fields!r}")
+
+        if values.get("item_id") and not values.get("refcode") and not values.get("immutable_id"):
+            raise ValueError(
+                "When referencing an item, 'refcode' must be provided alongside 'item_id'. "
+                "The 'item_id' alone is insufficient as it is mutable and not suitable for persistent references."
+            )
 
         return values
 

--- a/pydatalab/tests/server/conftest.py
+++ b/pydatalab/tests/server/conftest.py
@@ -328,19 +328,34 @@ def fixture_default_cell(user_id):
             "date": "1970-02-01",
             "negative_electrode": [
                 {
-                    "item": {"item_id": "test", "chemform": "Li15Si4", "type": "samples"},
+                    "item": {
+                        "item_id": "test",
+                        "refcode": "test:TESTNE1",
+                        "chemform": "Li15Si4",
+                        "type": "samples",
+                    },
                     "quantity": 2.0,
                     "unit": "mg",
                 },
                 {
-                    "item": {"item_id": "test", "chemform": "C", "type": "samples"},
+                    "item": {
+                        "item_id": "test",
+                        "refcode": "test:TESTNE2",
+                        "chemform": "C",
+                        "type": "samples",
+                    },
                     "quantity": 2.0,
                     "unit": "mg",
                 },
             ],
             "positive_electrode": [
                 {
-                    "item": {"item_id": "test_cathode", "chemform": "LiCoO2", "type": "samples"},
+                    "item": {
+                        "item_id": "test_cathode",
+                        "refcode": "test:TESTPE",
+                        "chemform": "LiCoO2",
+                        "type": "samples",
+                    },
                     "quantity": 2000,
                     "unit": "kg",
                 }
@@ -406,6 +421,7 @@ def fixture_complicated_sample(user_id):
     return Sample(
         **{
             "item_id": "sample_with_synthesis",
+            "refcode": "test:COMPLEX",
             "name": "complex_sample",
             "date": "1970-02-01",
             "chemform": "Na3P",
@@ -416,6 +432,7 @@ def fixture_complicated_sample(user_id):
                     **{
                         "item": {
                             "item_id": "starting_material_1",
+                            "refcode": "test:SM1",
                             "name": "first Na",
                             "chemform": "Na",
                             "type": "starting_materials",
@@ -427,6 +444,7 @@ def fixture_complicated_sample(user_id):
                     **{
                         "item": {
                             "item_id": "starting_material_2",
+                            "refcode": "test:SM2",
                             "name": "second Na",
                             "chemform": "Na",
                             "type": "starting_materials",
@@ -439,6 +457,7 @@ def fixture_complicated_sample(user_id):
                     **{
                         "item": {
                             "item_id": "starting_material_3",
+                            "refcode": "test:SM3",
                             "name": "liquid Na",
                             "chemform": "Na",
                             "type": "starting_materials",

--- a/pydatalab/tests/server/test_graph.py
+++ b/pydatalab/tests/server/test_graph.py
@@ -9,14 +9,23 @@ def test_simple_graph(admin_client):
     All samples are uploaded without a creator so the test client needs admin priveleges.
 
     """
+
     parent = Sample(
         item_id="parent",
+        refcode="test:PARENT",
     )
 
     child_1 = Sample(
         item_id="child_1",
         synthesis_constituents=[
-            Constituent(item={"type": "samples", "item_id": "parent"}, quantity=None),
+            Constituent(
+                item={
+                    "type": "samples",
+                    "item_id": parent.item_id,
+                    "refcode": parent.refcode,
+                },
+                quantity=None,
+            ),
         ],
     )
 
@@ -24,28 +33,56 @@ def test_simple_graph(admin_client):
         item_id="child_2",
         refcode="test:TEST02",
         synthesis_constituents=[
-            Constituent(item={"type": "samples", "item_id": "parent"}, quantity=None),
+            Constituent(
+                item={
+                    "type": "samples",
+                    "item_id": parent.item_id,
+                    "refcode": parent.refcode,
+                },
+                quantity=None,
+            ),
         ],
     )
 
     child_3 = Sample(
         item_id="child_3",
         synthesis_constituents=[
-            Constituent(item={"type": "samples", "item_id": "parent"}, quantity=None),
+            Constituent(
+                item={
+                    "type": "samples",
+                    "item_id": parent.item_id,
+                    "refcode": parent.refcode,
+                },
+                quantity=None,
+            ),
         ],
     )
 
     child_4 = Sample(
         item_id="child_4",
         synthesis_constituents=[
-            Constituent(item={"type": "samples", "item_id": "parent"}, quantity=None),
+            Constituent(
+                item={
+                    "type": "samples",
+                    "item_id": parent.item_id,
+                    "refcode": parent.refcode,
+                },
+                quantity=None,
+            ),
         ],
     )
 
     missing_child = Sample(
         item_id="missing_child",
         synthesis_constituents=[
-            Constituent(item={"type": "samples", "item_id": "parent"}, quantity=None),
+            Constituent(
+                item={
+                    "type": "samples",
+                    "item_id": parent.item_id,
+                    "refcode": parent.refcode,
+                },
+                quantity=None,
+            ),
         ],
     )
 

--- a/pydatalab/tests/server/test_item_graph.py
+++ b/pydatalab/tests/server/test_item_graph.py
@@ -20,6 +20,8 @@ def test_single_starting_material(admin_client, client):
 
     assert creation.status_code == 201
 
+    material_refcode = creation.json["sample_list_entry"]["refcode"]
+
     # A single material without connections should be ignored
     graph = client.get("/item-graph").json
     assert len(graph["nodes"]) == 0
@@ -33,7 +35,14 @@ def test_single_starting_material(admin_client, client):
     parent = Sample(
         item_id="parent",
         synthesis_constituents=[
-            {"item": {"item_id": item_id, "type": "starting_materials"}, "quantity": None}
+            {
+                "item": {
+                    "item_id": item_id,
+                    "refcode": material_refcode,
+                    "type": "starting_materials",
+                },
+                "quantity": None,
+            }
         ],
     )
 
@@ -58,11 +67,21 @@ def test_single_starting_material(admin_client, client):
     assert len(graph["nodes"]) == 2
     assert len(graph["edges"]) == 1
 
+    parent_response = client.get("/get-item-data/parent")
+    parent_refcode = parent_response.json["item_data"]["refcode"]
+
     # Now add a few more samples in a chain and check that only the relevant ones are shown
     child = Sample(
         item_id="child",
         synthesis_constituents=[
-            {"item": {"item_id": "parent", "type": "samples"}, "quantity": None}
+            {
+                "item": {
+                    "item_id": "parent",
+                    "refcode": parent_refcode,
+                    "type": "samples",
+                },
+                "quantity": None,
+            }
         ],
     )
 
@@ -71,10 +90,22 @@ def test_single_starting_material(admin_client, client):
         json={"new_sample_data": json.loads(child.json())},
     )
 
+    assert creation.status_code == 201
+
+    child_response = client.get("/get-item-data/child")
+    child_refcode = child_response.json["item_data"]["refcode"]
+
     grandchild = Sample(
         item_id="grandchild",
         synthesis_constituents=[
-            {"item": {"item_id": "child", "type": "samples"}, "quantity": None}
+            {
+                "item": {
+                    "item_id": "child",
+                    "refcode": child_refcode,
+                    "type": "samples",
+                },
+                "quantity": None,
+            }
         ],
     )
 
@@ -83,10 +114,22 @@ def test_single_starting_material(admin_client, client):
         json={"new_sample_data": json.loads(grandchild.json())},
     )
 
+    assert creation.status_code == 201
+
+    grandchild_response = client.get("/get-item-data/grandchild")
+    grandchild_refcode = grandchild_response.json["item_data"]["refcode"]
+
     great_grandchild = Sample(
         item_id="great-grandchild",
         synthesis_constituents=[
-            {"item": {"item_id": "grandchild", "type": "samples"}, "quantity": None}
+            {
+                "item": {
+                    "item_id": "grandchild",
+                    "refcode": grandchild_refcode,
+                    "type": "samples",
+                },
+                "quantity": None,
+            }
         ],
     )
 
@@ -94,6 +137,8 @@ def test_single_starting_material(admin_client, client):
         "/new-sample/",
         json={"new_sample_data": json.loads(great_grandchild.json())},
     )
+
+    assert creation.status_code == 201
 
     graph = client.get("/item-graph").json
     assert len(graph["nodes"]) == 5
@@ -104,11 +149,21 @@ def test_single_starting_material(admin_client, client):
     assert len(graph["nodes"]) == 2
     assert len(graph["edges"]) == 1
 
+    great_grandchild_response = admin_client.get("/get-item-data/great-grandchild")
+    great_grandchild_refcode = great_grandchild_response.json["item_data"]["refcode"]
+
     # Add an admin only item and check that the non-admin user still sees the same graph
     admin_great_great_grandchild = Sample(
         item_id="admin-great-great-grandchild",
         synthesis_constituents=[
-            {"item": {"item_id": "great-grandchild", "type": "samples"}, "quantity": None}
+            {
+                "item": {
+                    "item_id": "great-grandchild",
+                    "refcode": great_grandchild_refcode,
+                    "type": "samples",
+                },
+                "quantity": None,
+            }
         ],
     )
 

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -220,8 +220,10 @@ def test_item_old_regex_search(
     "user,query,expected_result_ids",
     [
         ("user", "query=mater&types=samples,starting_materials", ["material", "12345"]),
-        ("user", "query=mater&types=equipment", []),  # Tests avoidance of different types
-        ("admin", "query=mater", ["material", "12345", "123456"]),  # Test search obeys permissions
+        # Tests avoidance of different types
+        ("user", "query=mater&types=equipment", []),
+        # Test search obeys permissions
+        ("admin", "query=mater", ["material", "12345", "123456"]),
         (
             "admin",
             "query='magic'",
@@ -235,9 +237,11 @@ def test_item_old_regex_search(
         ("admin", "query='vanadium('&types=samples", ["sample_2"]),  # Test unclosed brackets
         ("admin", "query='vanadium oxide'&types=samples", ["sample_2"]),  # Test two words
         ("admin", "query='oxide vanadium'&types=samples", ["sample_2"]),  # Test reverse order
-        ("admin", "query='v'", ["sample_2"]),  # Test single char at start of word
+        # Test single char at start of word
+        ("admin", "query='v'", ["sample_2"]),
         ("admin", "query='van'", ["sample_2"]),  # Test prefix at start of word
-        ("admin", "query='oxid'", ["sample_2"]),  # Test prefix at start of word
+        # Test prefix at start of word
+        ("admin", "query='oxid'", ["sample_2"]),
         (
             "admin",
             "query='anadium'&types=samples",
@@ -348,8 +352,8 @@ def test_new_sample_with_relationships(client, complicated_sample):
     ]
 
     assert [d.get("refcode") for d in response.json["item_data"]["relationships"]] == [
-        None,
-        None,
+        "test:SM1",
+        "test:SM2",
         new_refcode,
         None,
         # i.e., "starting_material_3", has been removed
@@ -380,7 +384,11 @@ def test_saved_sample_has_new_relationships(client, default_sample_dict, complic
     sample_dict = response.json["item_data"]
     sample_dict["synthesis_constituents"] = [
         {
-            "item": {"item_id": complicated_sample.item_id, "type": "samples"},
+            "item": {
+                "item_id": complicated_sample.item_id,
+                "refcode": complicated_sample.refcode,
+                "type": "samples",
+            },
             "quantity": 25.2,
             "unit": "g",
         }

--- a/pydatalab/tests/test_models.py
+++ b/pydatalab/tests/test_models.py
@@ -20,12 +20,15 @@ from pydatalab.models.utils import HumanReadableIdentifier, Refcode
 def test_sample_with_inlined_reference():
     from pydatalab.models.samples import Sample
 
-    a = Sample(item_id="test_anode", chemform="C")
+    a = Sample(item_id="test_anode", refcode="test:TESTA", chemform="C")
 
     b = Sample(
         item_id="abcd-1-2-3",
         synthesis_constituents=[
-            {"item": {"item_id": a.item_id, "type": "samples"}, "quantity": None}
+            {
+                "item": {"item_id": a.item_id, "refcode": a.refcode, "type": "samples"},
+                "quantity": None,
+            }
         ],
     )
 
@@ -35,7 +38,10 @@ def test_sample_with_inlined_reference():
     c = Sample(
         item_id="c-123",
         synthesis_constituents=[
-            {"item": {"item_id": a.item_id, "type": "samples"}, "quantity": None},
+            {
+                "item": {"item_id": a.item_id, "refcode": a.refcode, "type": "samples"},
+                "quantity": None,
+            },
             {"item": {"name": "inline"}, "quantity": None},
         ],
     )
@@ -251,7 +257,7 @@ def test_cell_with_inlined_reference():
     from pydatalab.models.cells import Cell
     from pydatalab.models.samples import Sample
 
-    anode = Sample(item_id="test_anode", chemform="C")
+    anode = Sample(item_id="test_anode", refcode="test:ANODE", chemform="C")
 
     cell = Cell(
         item_id="abcd-1-2-3",
@@ -275,7 +281,15 @@ def test_cell_with_inlined_reference():
     cell_json = {
         "item_id": "abcd-1-2-3",
         "positive_electrode": [
-            {"item": {"type": "samples", "item_id": "test_anode", "chemform": "C"}, "quantity": 2}
+            {
+                "item": {
+                    "type": "samples",
+                    "item_id": "test_anode",
+                    "refcode": "test:ANODE",
+                    "chemform": "C",
+                },
+                "quantity": 2,
+            }
         ],
         "negative_electrode": [
             {"item": {"name": "My secret cathode", "chemform": "NaCoO2"}, "quantity": 3}
@@ -309,7 +323,14 @@ def test_cell_with_inlined_reference():
     cell_json_3 = {
         "item_id": "abcd-1-2-3",
         "positive_electrode": [
-            {"item": {"type": "samples", "item_id": "real_item"}, "quantity": 2}
+            {
+                "item": {
+                    "type": "samples",
+                    "item_id": "real_item",
+                    "refcode": "test:REALITEM",
+                },
+                "quantity": 2,
+            }
         ],
         "negative_electrode": [
             {"item": {"name": "My secret cathode", "chemform": "NaCoO2"}, "quantity": 3}


### PR DESCRIPTION
Closes #1173 

Prevents creating synthesis constituents via API with only `item_id`.

**Changes:**
- Modified `EntryReference` validator to require `refcode` or `immutable_id` when `item_id` is present
- Updated test fixtures to include refcodes in constituent references
