### PR TITLE
Fix modal scrolling for large content

### DIFF
--- a/webapp/src/components/BatchCreateItemModal.vue
+++ b/webapp/src/components/BatchCreateItemModal.vue
@@ -722,14 +722,7 @@ export default {
 
 .modal-enclosure :deep(.modal-dialog) {
   max-width: 95vw;
-  min-height: 90vh;
-  margin-top: 2.5vh;
-  margin-bottom: 2.5vh;
-}
-
-.modal-enclosure :deep(.modal-content) {
-  height: 90vh;
-  overflow: scroll;
-  scroll-behavior: smooth;
+  max-height: 90vh;
+  margin: 5vh auto;
 }
 </style>

--- a/webapp/src/components/Modal.vue
+++ b/webapp/src/components/Modal.vue
@@ -111,4 +111,20 @@ export default {
 .btn:disabled {
   cursor: not-allowed;
 }
+
+.modal-dialog {
+  margin: 5vh auto;
+}
+
+.modal-content {
+  max-height: 90vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-body {
+  overflow: visible;
+  flex: 1;
+}
 </style>


### PR DESCRIPTION
Closes #1424

Makes modal bodies scrollable when content exceeds viewport height (Applies to all modals using the Modal.vue component).