### PR TITLE
Switch access token generating scheme to `secrets.token_urlsafe(16)`

### DIFF
--- a/pydatalab/src/pydatalab/permissions.py
+++ b/pydatalab/src/pydatalab/permissions.py
@@ -135,6 +135,9 @@ def check_access_token(refcode: str, token: str | None = None) -> bool:
             {"token": token_hash, "refcode": refcode, "active": True, "type": "access_token"}
         )
 
+        if access_token_doc and access_token_doc["expires_at"] is not None:
+            raise NotImplementedError("Token expiration is not yet implemented")
+
         return bool(access_token_doc)
 
     except Exception:

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 import re
-import uuid
+import secrets
 from hashlib import sha512
 
 from bson import ObjectId
@@ -818,13 +818,14 @@ def issue_physical_token(refcode: str):
             }
         ), 404
 
-    token = str(uuid.uuid1())
+    token = secrets.token_urlsafe(16)
     access_document = {
         "token": sha512(token.encode("utf-8")).hexdigest(),
         "refcode": refcode,
         "user": ObjectId(current_user.id),
         "active": True,
         "created_at": datetime.datetime.now(tz=datetime.timezone.utc),
+        "expires_at": None,
         "version": 1,
         "type": "access_token",
     }


### PR DESCRIPTION
Only spotted this in #1220 after merging -- uuid1 was a temporary use by me, but its not sufficiently random to use for this use case. Instead we should use `secrets.token_urlsafe(16)`. I've also added expiry fields for futureproofing and implementation of magic links that expire (#413).