### PR TITLE
Prevent double-click on modal submit button

### DIFF
--- a/webapp/src/components/AddToCollectionModal.vue
+++ b/webapp/src/components/AddToCollectionModal.vue
@@ -1,6 +1,10 @@
 <template>
   <form class="modal-enclosure" data-testid="add-to-collection-form" @submit.prevent="submitForm">
-    <Modal :model-value="modelValue" @update:model-value="$emit('update:modelValue', $event)">
+    <Modal
+      :model-value="modelValue"
+      @update:model-value="$emit('update:modelValue', $event)"
+      @submit="submitForm"
+    >
       <template #header> Add to collections </template>
       <template #body>
         <div class="form-row">

--- a/webapp/src/components/BatchCreateItemModal.vue
+++ b/webapp/src/components/BatchCreateItemModal.vue
@@ -8,6 +8,7 @@
         isValidBatchSize
       "
       @update:model-value="$emit('update:modelValue', $event)"
+      @submit="submitForm"
     >
       <template #header>
         <template v-if="beforeSubmit">Add new items</template>

--- a/webapp/src/components/CreateCollectionModal.vue
+++ b/webapp/src/components/CreateCollectionModal.vue
@@ -4,6 +4,7 @@
       :model-value="modelValue"
       :disable-submit="Boolean(isValidEntryID) || !Boolean(collection_id)"
       @update:model-value="$emit('update:modelValue', $event)"
+      @submit="submitForm"
     >
       <template #header> Create new collection </template>
 

--- a/webapp/src/components/CreateEquipmentModal.vue
+++ b/webapp/src/components/CreateEquipmentModal.vue
@@ -4,6 +4,7 @@
       :model-value="modelValue"
       :disable-submit="Boolean(isValidEntryID) || !Boolean(item_id)"
       @update:model-value="$emit('update:modelValue', $event)"
+      @submit="submitForm"
     >
       <template #header> Add equipment </template>
 

--- a/webapp/src/components/CreateItemModal.vue
+++ b/webapp/src/components/CreateItemModal.vue
@@ -4,6 +4,7 @@
       :model-value="modelValue"
       :disable-submit="Boolean(isValidEntryID) || (!generateIDAutomatically && !Boolean(item_id))"
       @update:model-value="$emit('update:modelValue', $event)"
+      @submit="submitForm"
     >
       <template #header> Add new item </template>
 

--- a/webapp/src/components/EditAccountSettingsModal.vue
+++ b/webapp/src/components/EditAccountSettingsModal.vue
@@ -6,6 +6,7 @@
         Boolean(displayNameValidationMessage) || Boolean(contactEmailValidationMessage)
       "
       @update:model-value="resetForm"
+      @submit="submitForm"
     >
       <template #header> Account settings </template>
 

--- a/webapp/src/components/GetEmailModal.vue
+++ b/webapp/src/components/GetEmailModal.vue
@@ -4,6 +4,7 @@
       :model-value="modelValue"
       :disable-submit="Boolean(successMessage) || !Boolean(emailAddress)"
       @update:model-value="$emit('update:modelValue', $event)"
+      @submit="submitForm"
     >
       <template #body>
         <div class="form-row">

--- a/webapp/src/components/Modal.vue
+++ b/webapp/src/components/Modal.vue
@@ -60,7 +60,7 @@ export default {
       default: true,
     },
   },
-  emits: ["update:modelValue"],
+  emits: ["update:modelValue", "submit"],
   data() {
     return {
       modalDisplayed: false,
@@ -79,34 +79,9 @@ export default {
     },
   },
   methods: {
-    lockAndSubmit(event) {
+    lockAndSubmit() {
       this.submitLocked = true;
-
-      let el = event && event.target ? event.target : null;
-      if (!el) return;
-
-      const form = el.closest && el.closest("form");
-
-      if (form) {
-        if (typeof form.requestSubmit === "function") {
-          form.requestSubmit();
-          return;
-        }
-
-        try {
-          const submitEvent = new Event("submit", { bubbles: true, cancelable: true });
-          const canceled = !form.dispatchEvent(submitEvent);
-          if (!canceled) {
-            if (typeof form.submit === "function") {
-              form.submit();
-            }
-          }
-        } catch (e) {
-          if (typeof form.submit === "function") {
-            form.submit();
-          }
-        }
-      }
+      this.$emit("submit");
     },
     async openModal() {
       this.submitLocked = false;


### PR DESCRIPTION
Closes #1453

Prevents double-clicking the submit button in modals by immediately locking it before the API responds.

Changes:
- Changed submit button from `type="submit"` to `type="button"` with manual form submission
- Added `submitLocked` flag that locks on first click
- Use `requestSubmit()` with fallbacks to trigger form submission

