### PR TITLE
Minor fix for email auth notifications with automatically activated accounts

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/auth.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/auth.py
@@ -516,13 +516,25 @@ def _send_admin_email_notification(user: Person) -> None:
             "Please review the registration in your admin panel and verify the user if appropriate."
         )
 
-    if user.account_status == AccountStatus.DEACTIVATED:
+    elif user.account_status == AccountStatus.DEACTIVATED:
         subject = "Deactivated User Login Attempt Notification"
         subject += f": {CONFIG.APP_URL}" if CONFIG.APP_URL else ""
         body = (
             f"A deactivated user with display name {user.display_name} attempted to log in to the datalab instance at {CONFIG.APP_URL}.\n\n"
             "No action is required unless you wish to reactivate this user."
         )
+
+    elif user.account_status == AccountStatus.ACTIVE:
+        subject = "New User Created"
+        subject += f": {CONFIG.APP_URL}" if CONFIG.APP_URL else ""
+        body = (
+            f"A new user with display name {user.display_name} has registered on the datalab instance at {CONFIG.APP_URL}.\n\n"
+            "No action is required unless you wish to deactivate this user."
+        )
+
+    else:
+        LOGGER.critical("Unknown user status %s for new user %s", user.account_status, user)
+        return
 
     try:
         for email in admin_emails:

--- a/pydatalab/tests/server/conftest.py
+++ b/pydatalab/tests/server/conftest.py
@@ -63,6 +63,8 @@ def app_config(tmp_path_factory, secret_key):
         "TESTING": False,
         "ROOT_PATH": "/",
         "SECRET_KEY": secret_key,
+        "AUTO_ACTIVATE_ACCOUNTS": False,
+        "EMAIL_AUTO_ACTIVATE_ACCOUNTS": False,
         "EMAIL_AUTH_SMTP_SETTINGS": {
             "MAIL_SERVER": "smtp.example.com",
             "MAIL_PORT": 587,

--- a/pydatalab/tests/server/test_auth.py
+++ b/pydatalab/tests/server/test_auth.py
@@ -29,8 +29,9 @@ def test_magic_link_account_creation(unauthenticated_client, app, database):
     with app.extensions["mail"].record_messages() as outbox:
         response = unauthenticated_client.get(f"/login/email?token={doc['jwt']}")
         assert response.status_code == 307
-        assert database.users.find_one({"contact_email": "test@ml-evs.science"})
-
+        new_user = database.users.find_one({"contact_email": "test@ml-evs.science"})
+        assert new_user
+        assert new_user["account_status"] == "unverified"
         assert len(outbox) == 1  # Should be a notification to admins
 
 


### PR DESCRIPTION
PR #1457 introduced an issue when auto-activate accounts has been enabled locally. This PR makes sure that setting is disabled during testing, and adds an extra guard to notify admins when a new user is created with this setting turned on.