### PR TITLE
Fix copied items with blocks getting wrong IDs

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -452,6 +452,11 @@ def _create_sample(
         copied_doc["name"] = sample_dict.get("name")
         copied_doc["date"] = sample_dict.get("date")
 
+        copied_doc.pop("blocks_obj", None)
+        copied_doc.pop("display_order", None)
+        copied_doc.pop("blocks", None)
+        copied_doc.pop("file_ObjectIds", None)
+
         # any provided constituents will be added to the synthesis information table in
         # addition to the constituents copied from the copy_from_item_id, avoiding duplicates
         if copied_doc["type"] == "samples":

--- a/webapp/cypress/e2e/batchSampleFeature.cy.js
+++ b/webapp/cypress/e2e/batchSampleFeature.cy.js
@@ -233,13 +233,10 @@ describe("Batch sample creation", () => {
     cy.contains("baseA_copy").click();
     cy.findByLabelText("Name").should("have.value", "a copied sample");
     cy.findByText("this is a description of baseA.");
-    cy.findByText("a comment is added here.");
     cy.findByText("Home").click();
 
     cy.contains(/^baseB_copy$/).click();
     cy.findByText("this is a description of baseB.");
-    cy.findByText("a comment is added here.");
-    cy.findByText("a second comment is added here.");
     cy.findByText("a description of the synthesis here");
     cy.findAllByText("component3");
     cy.findAllByText("component4");
@@ -251,8 +248,6 @@ describe("Batch sample creation", () => {
 
     cy.findByText("baseB_copy2").click();
     cy.findByText("this is a description of baseB.");
-    cy.findByText("a comment is added here.");
-    cy.findByText("a second comment is added here.");
     cy.findByText("a description of the synthesis here");
     cy.findAllByText("component3");
     cy.findAllByText("component4");
@@ -347,7 +342,6 @@ describe("Batch sample creation", () => {
     cy.get("#synthesis-information table").contains("component2");
     cy.get("#synthesis-information tbody tr:nth-of-type(1) input").eq(0).should("have.value", "");
     cy.get("#synthesis-information tbody tr:nth-of-type(2) input").eq(0).should("have.value", "");
-    cy.findByText("a comment is added here.");
     cy.findByText("Home").click();
 
     cy.contains("test103").click();
@@ -379,8 +373,6 @@ describe("Batch sample creation", () => {
       "g",
     );
 
-    cy.findByText("a comment is added here.");
-    cy.findByText("a second comment is added here.");
     cy.findByText("Home").click();
 
     cy.contains("test104").click();
@@ -420,8 +412,6 @@ describe("Batch sample creation", () => {
     );
 
     cy.findByText("a description of the synthesis here");
-    cy.findByText("a comment is added here.");
-    cy.findByText("a second comment is added here.");
 
     cy.findByText("Home").click();
   });
@@ -545,8 +535,6 @@ describe("Batch sample creation", () => {
         .should("have.value", "100");
       cy.get("#synthesis-information tbody tr:nth-of-type(3) input").eq(0).should("have.value", "");
 
-      cy.findByText("a comment is added here.");
-      cy.findByText("a second comment is added here.");
       cy.findByText("Home").click();
     }
 
@@ -651,8 +639,6 @@ describe("Batch sample creation", () => {
         .should("have.value", "100");
       cy.get("#synthesis-information tbody tr:nth-of-type(3) input").eq(0).should("have.value", "");
 
-      cy.findByText("a comment is added here.");
-      cy.findByText("a second comment is added here.");
       cy.findByText("Home").click();
     }
 

--- a/webapp/cypress/e2e/sampleTablePage.cy.js
+++ b/webapp/cypress/e2e/sampleTablePage.cy.js
@@ -268,7 +268,6 @@ describe.only("Advanced sample creation features", () => {
     cy.findByText("testBcopy").click();
     cy.findByLabelText("Name").should("have.value", "COPY OF the second test sample");
     cy.findByText("this is a description of testB.");
-    cy.findByText("a comment is added here.");
     cy.findByText("a description of the synthesis here");
     cy.findAllByText("component3");
     cy.findAllByText("component4");
@@ -305,7 +304,6 @@ describe.only("Advanced sample creation features", () => {
     cy.findByText("testBcopy_copy").click();
     cy.findByLabelText("Name").should("have.value", "COPY OF COPY OF the second test sample");
     cy.findByText("this is a description of testB.");
-    cy.findByText("a comment is added here.");
     cy.findByText("a description of the synthesis here");
     cy.findAllByText("component3");
     cy.findAllByText("component4");


### PR DESCRIPTION
Closes #1168

Removes blocks and attached files from copied items.
