### PR TITLE
Fix copy functionality for equipment and starting materials

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -635,6 +635,10 @@ def _create_sample(
     if copy_from_item_id:
         sample_dict = _copy_sample_from_id(sample_dict, copy_from_item_id)
 
+        else:
+            copied_doc.update(sample_dict)
+            sample_dict = copied_doc
+
     try:
         # If passed collection data, dereference it and check if the collection exists
         sample_dict["collections"] = _check_collections(sample_dict)


### PR DESCRIPTION
Closes #766

Equipment and starting materials now properly copy all fields (description, manufacturer, location, etc.) when creating from existing entry, not just the name.