### PR TITLE
Add file-based suggestions to "add a block" menu and add bottom menu below blocks

### DIFF
--- a/webapp/cypress/e2e/batchSampleFeature.cy.js
+++ b/webapp/cypress/e2e/batchSampleFeature.cy.js
@@ -165,8 +165,8 @@ describe("Batch sample creation", () => {
     cy.findByText("baseA").click();
     cy.expandIfCollapsed("[data-testid=synthesis-block]");
     cy.findByLabelText("Description").type("this is a description of baseA.");
-    cy.findByText("Add a block").click();
-    cy.findByLabelText("Add a block").contains("Comment").click();
+    cy.get('[data-testid="add-block-button-top"]').click();
+    cy.get('[data-testid="add-block-dropdown"]').findByText("Comment").click();
 
     cy.get(".datablock-content div").first().type("a comment is added here.");
 
@@ -179,14 +179,14 @@ describe("Batch sample creation", () => {
     cy.findByText("baseB").click();
     cy.expandIfCollapsed("[data-testid=synthesis-block]");
     cy.findByLabelText("Description").type("this is a description of baseB.");
-    cy.findByText("Add a block").click();
-    cy.findByLabelText("Add a block").contains("Comment").click();
+    cy.get('[data-testid="add-block-button-top"]').click();
+    cy.get('[data-testid="add-block-dropdown"]').findByText("Comment").click();
     cy.get(".datablock-content div").first().type("a comment is added here.");
 
     cy.findByLabelText("Procedure").type("a description of the synthesis here");
 
-    cy.findByText("Add a block").click();
-    cy.findByLabelText("Add a block").findByText("Comment").click();
+    cy.get('[data-testid="add-block-button-top"]').click();
+    cy.get('[data-testid="add-block-dropdown"]').findByText("Comment").click();
     cy.get(".datablock-content").eq(1).type("a second comment is added here.");
 
     cy.searchAndSelectItem("component3", "#synthesis-information .vs__search");

--- a/webapp/cypress/e2e/editPage.cy.js
+++ b/webapp/cypress/e2e/editPage.cy.js
@@ -214,12 +214,12 @@ describe("Edit Page", () => {
     cy.get('[data-testid="search-input"]').type("editable_sample");
     cy.findByText("editable_sample").click();
 
-    cy.findByText("Add a block").click();
+    cy.get('[data-testid="add-block-button-top"]').click();
     cy.get('[data-testid="add-block-dropdown"]').findByText("Comment").click();
 
     cy.contains("Unsaved changes").should("not.exist");
 
-    cy.findByText("Add a block").click();
+    cy.get('[data-testid="add-block-button-top"]').click();
     cy.get('[data-testid="add-block-dropdown"]').findByText("Comment").click();
 
     cy.contains("Unsaved changes").should("not.exist");
@@ -286,7 +286,7 @@ describe("Edit Page", () => {
     cy.get('[data-testid="search-input"]').type("editable_sample");
     cy.findByText("editable_sample").click();
 
-    cy.findByText("Add a block").click();
+    cy.get('[data-testid="add-block-button-top"]').click();
     cy.get('[data-testid="add-block-dropdown"]').findByText("Powder XRD").click();
 
     cy.findByText("Select a file:").should("exist");
@@ -313,7 +313,7 @@ describe("Edit Page", () => {
     cy.get('[data-testid="search-input"]').type("editable_sample");
     cy.findByText("editable_sample").click();
 
-    cy.findByText("Add a block").click();
+    cy.get('[data-testid="add-block-button-top"]').click();
     cy.get('[data-testid="add-block-dropdown"]').findByText("Media").click();
     cy.findAllByText("Select a file:").eq(1).should("exist");
     cy.get("select.file-select-dropdown").eq(1).select(test_fname);
@@ -330,7 +330,7 @@ describe("Edit Page", () => {
     cy.get('[data-testid="search-input"]').type("editable_sample");
     cy.findByText("editable_sample").click();
 
-    cy.findByText("Add a block").click();
+    cy.get('[data-testid="add-block-button-top"]').click();
     cy.get('[data-testid="add-block-dropdown"]').findByText("Media").click();
     cy.findAllByText("Select a file:").eq(2).should("exist");
     cy.get("select.file-select-dropdown").eq(2).select(test_fname);
@@ -356,7 +356,7 @@ describe("Edit Page", () => {
     cy.get('[data-testid="search-input"]').type("editable_sample");
     cy.findByText("editable_sample").click();
 
-    cy.findByText("Add a block").click();
+    cy.get('[data-testid="add-block-button-top"]').click();
     cy.get('[data-testid="add-block-dropdown"]').findByText("Raman spectroscopy").click();
     cy.findAllByText("Select a file:").eq(3).should("exist");
     cy.get("select.file-select-dropdown")
@@ -364,5 +364,84 @@ describe("Edit Page", () => {
       .select("example_data_raman_labspec_raman_example.txt");
     cy.contains("label", "X axis").should("exist");
     cy.contains("label", "Y axis").should("exist");
+  });
+
+  it("Tests the bottom 'Add a block' button without files", () => {
+    cy.get('[data-testid="search-input"]').type("editable_sample");
+    cy.findByText("editable_sample").click();
+
+    cy.scrollTo("bottom");
+
+    cy.get("#bottomAddBlockDropdown").should("exist");
+    cy.get("#bottomAddBlockDropdown").click();
+    cy.get('[data-testid="add-block-dropdown-bottom"]').should("be.visible");
+
+    cy.get('[data-testid="add-block-dropdown-bottom"]').contains("All block types").should("exist");
+
+    cy.get('[data-testid="add-block-dropdown-bottom"]').findByText("Comment").click();
+
+    cy.wait(500);
+    cy.get(".data-block").should("exist");
+  });
+
+  it("Tests the bottom 'Add a block' button with suggested blocks", () => {
+    cy.uploadFileViaAPI("editable_sample", "example_data/XRD/example_bmb.xye");
+
+    cy.get('[data-testid="search-input"]').type("editable_sample");
+    cy.findByText("editable_sample").click();
+
+    cy.scrollTo("bottom");
+
+    cy.get("#bottomAddBlockDropdown").click();
+    cy.get('[data-testid="add-block-dropdown-bottom"]').should("be.visible");
+
+    // Should show suggested header
+    cy.get('[data-testid="add-block-dropdown-bottom"]')
+      .contains("Suggested based on your files")
+      .should("exist");
+
+    // Check that XRD is in the suggested section (appears before the divider)
+    cy.get('[data-testid="add-block-dropdown-bottom"]').findByText("Powder XRD").should("exist");
+
+    // Should also show "All block types" header
+    cy.get('[data-testid="add-block-dropdown-bottom"]').contains("All block types").should("exist");
+  });
+
+  it("Creates a block from the bottom dropdown suggested section", () => {
+    cy.uploadFileViaAPI("editable_sample", "example_data/raman/labspec_raman_example.txt");
+
+    cy.get('[data-testid="search-input"]').type("editable_sample");
+    cy.findByText("editable_sample").click();
+
+    cy.scrollTo("bottom");
+
+    cy.get("#bottomAddBlockDropdown").click();
+
+    cy.get('[data-testid="add-block-dropdown-bottom"]')
+      .findByText("Raman spectroscopy")
+      .first()
+      .click();
+
+    cy.wait(1000);
+    cy.get(".data-block").should("exist");
+    cy.findAllByText("Select a file:").should("exist");
+  });
+
+  it("Verifies bottom and top 'Add a block' dropdowns work independently", () => {
+    cy.get('[data-testid="search-input"]').type("editable_sample");
+    cy.findByText("editable_sample").click();
+
+    cy.get("#navbarDropdown").click();
+    cy.get('[data-testid="add-block-dropdown"]').should("be.visible");
+
+    cy.scrollTo("bottom");
+
+    cy.get("#bottomAddBlockDropdown").click();
+    cy.get('[data-testid="add-block-dropdown-bottom"]').should("be.visible");
+
+    cy.get('[data-testid="add-block-dropdown-bottom"]').findByText("Comment").click();
+
+    cy.wait(500);
+    cy.get('[data-testid="add-block-dropdown-bottom"]').should("not.be.visible");
   });
 });

--- a/webapp/cypress/e2e/editPage.cy.js
+++ b/webapp/cypress/e2e/editPage.cy.js
@@ -215,12 +215,12 @@ describe("Edit Page", () => {
     cy.findByText("editable_sample").click();
 
     cy.get('[data-testid="add-block-button-top"]').click();
-    cy.get('[data-testid="add-block-dropdown"]').findByText("Comment").click();
+    cy.get('[data-testid="add-block-dropdown"]').contains("Comment").click();
 
     cy.contains("Unsaved changes").should("not.exist");
 
     cy.get('[data-testid="add-block-button-top"]').click();
-    cy.get('[data-testid="add-block-dropdown"]').findByText("Comment").click();
+    cy.get('[data-testid="add-block-dropdown"]').contains("Comment").click();
 
     cy.contains("Unsaved changes").should("not.exist");
 
@@ -287,7 +287,7 @@ describe("Edit Page", () => {
     cy.findByText("editable_sample").click();
 
     cy.get('[data-testid="add-block-button-top"]').click();
-    cy.get('[data-testid="add-block-dropdown"]').findByText("Powder XRD").click();
+    cy.get('[data-testid="add-block-dropdown"]').contains("Powder XRD").click();
 
     cy.findByText("Select a file:").should("exist");
     cy.get("select.file-select-dropdown").select("example_data_XRD_example_bmb.xye");
@@ -314,7 +314,7 @@ describe("Edit Page", () => {
     cy.findByText("editable_sample").click();
 
     cy.get('[data-testid="add-block-button-top"]').click();
-    cy.get('[data-testid="add-block-dropdown"]').findByText("Media").click();
+    cy.get('[data-testid="add-block-dropdown"]').contains("Media").click();
     cy.findAllByText("Select a file:").eq(1).should("exist");
     cy.get("select.file-select-dropdown").eq(1).select(test_fname);
 
@@ -331,7 +331,7 @@ describe("Edit Page", () => {
     cy.findByText("editable_sample").click();
 
     cy.get('[data-testid="add-block-button-top"]').click();
-    cy.get('[data-testid="add-block-dropdown"]').findByText("Media").click();
+    cy.get('[data-testid="add-block-dropdown"]').contains("Media").click();
     cy.findAllByText("Select a file:").eq(2).should("exist");
     cy.get("select.file-select-dropdown").eq(2).select(test_fname);
 
@@ -357,7 +357,7 @@ describe("Edit Page", () => {
     cy.findByText("editable_sample").click();
 
     cy.get('[data-testid="add-block-button-top"]').click();
-    cy.get('[data-testid="add-block-dropdown"]').findByText("Raman spectroscopy").click();
+    cy.get('[data-testid="add-block-dropdown"]').contains("Raman spectroscopy").click();
     cy.findAllByText("Select a file:").eq(3).should("exist");
     cy.get("select.file-select-dropdown")
       .eq(3)
@@ -378,7 +378,7 @@ describe("Edit Page", () => {
 
     cy.get('[data-testid="add-block-dropdown-bottom"]').contains("All block types").should("exist");
 
-    cy.get('[data-testid="add-block-dropdown-bottom"]').findByText("Comment").click();
+    cy.get('[data-testid="add-block-dropdown-bottom"]').contains("Comment").click();
 
     cy.wait(500);
     cy.get(".data-block").should("exist");
@@ -401,7 +401,7 @@ describe("Edit Page", () => {
       .should("exist");
 
     // Check that XRD is in the suggested section (appears before the divider)
-    cy.get('[data-testid="add-block-dropdown-bottom"]').findByText("Powder XRD").should("exist");
+    cy.get('[data-testid="add-block-dropdown-bottom"]').contains("Powder XRD").should("exist");
 
     // Should also show "All block types" header
     cy.get('[data-testid="add-block-dropdown-bottom"]').contains("All block types").should("exist");
@@ -417,10 +417,7 @@ describe("Edit Page", () => {
 
     cy.get("#bottomAddBlockDropdown").click();
 
-    cy.get('[data-testid="add-block-dropdown-bottom"]')
-      .findByText("Raman spectroscopy")
-      .first()
-      .click();
+    cy.get('[data-testid="add-block-dropdown-bottom"]').contains("Raman spectroscopy").click();
 
     cy.wait(1000);
     cy.get(".data-block").should("exist");
@@ -439,7 +436,7 @@ describe("Edit Page", () => {
     cy.get("#bottomAddBlockDropdown").click();
     cy.get('[data-testid="add-block-dropdown-bottom"]').should("be.visible");
 
-    cy.get('[data-testid="add-block-dropdown-bottom"]').findByText("Comment").click();
+    cy.get('[data-testid="add-block-dropdown-bottom"]').contains("Comment").click();
 
     cy.wait(500);
     cy.get('[data-testid="add-block-dropdown-bottom"]').should("not.be.visible");

--- a/webapp/cypress/e2e/equipment.cy.js
+++ b/webapp/cypress/e2e/equipment.cy.js
@@ -143,8 +143,8 @@ describe("Equipment edit page", () => {
     cy.findByLabelText("Date").type("2000-01-01T00:00");
     cy.findByLabelText("Location").type("room 101");
 
-    cy.findByText("Add a block").click();
-    cy.findByLabelText("Add a block").contains("Comment").click();
+    cy.get('[data-testid="add-block-button-top"]').click();
+    cy.get('[data-testid="add-block-dropdown"]').findByText("Comment").click();
 
     cy.get(".datablock-content div").first().type("a comment is added here.");
 

--- a/webapp/cypress/e2e/sampleTablePage.cy.js
+++ b/webapp/cypress/e2e/sampleTablePage.cy.js
@@ -231,8 +231,8 @@ describe.only("Advanced sample creation features", () => {
   it("modifies some data in the second sample", () => {
     cy.findByText("testB").click();
     cy.findByLabelText("Description").type("this is a description of testB.");
-    cy.findByText("Add a block").click();
-    cy.findByLabelText("Add a block").contains("Comment").click();
+    cy.get('[data-testid="add-block-button-top"]').click();
+    cy.get('[data-testid="add-block-dropdown"]').findByText("Comment").click();
 
     cy.get(".datablock-content div").first().type("a comment is added here.");
     cy.expandIfCollapsed("[data-testid=synthesis-block]");

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -33,11 +33,28 @@
           style="display: block"
           aria-labelledby="navbarDropdown"
         >
-          <template v-for="blockInfo in blocksInfos" :key="blockInfo.id">
-            <span v-if="blockInfo.id !== 'notsupported'" @click="newBlock($event, blockInfo.id)">
-              <BlockTooltip :block-info="blockInfo.attributes" />
-            </span>
-          </template>
+          <h6 v-if="suggestedBlockTypes.length > 0" class="dropdown-header">
+            Suggested based on your files
+          </h6>
+          <span
+            v-for="blockInfo in suggestedBlockTypes"
+            :key="'nav-suggested-' + blockInfo.id"
+            @click="newBlock($event, blockInfo.id)"
+          >
+            <BlockTooltip :block-info="blockInfo.attributes" />
+          </span>
+          <div
+            v-if="suggestedBlockTypes.length > 0 && allBlockTypes.length > 0"
+            class="dropdown-divider"
+          ></div>
+          <h6 v-if="allBlockTypes.length > 0" class="dropdown-header">All block types</h6>
+          <span
+            v-for="blockInfo in allBlockTypes"
+            :key="'nav-all-' + blockInfo.id"
+            @click="newBlock($event, blockInfo.id)"
+          >
+            <BlockTooltip :block-info="blockInfo.attributes" />
+          </span>
         </div>
       </div>
       <ExportDropdown
@@ -108,7 +125,7 @@
       </div>
 
       <div class="mt-4 text-center">
-        <div class="dropdown d-inline-block">
+        <div class="dropup d-inline-block">
           <button
             id="bottomAddBlockDropdown"
             class="btn btn-primary dropdown-toggle"
@@ -132,19 +149,19 @@
             </h6>
             <span
               v-for="blockInfo in suggestedBlockTypes"
-              :key="'suggested-' + blockInfo.id"
+              :key="'bottom-suggested-' + blockInfo.id"
               @click="newBlock($event, blockInfo.id)"
             >
               <BlockTooltip :block-info="blockInfo.attributes" />
             </span>
             <div
-              v-if="suggestedBlockTypes.length > 0 && otherBlockTypes.length > 0"
+              v-if="suggestedBlockTypes.length > 0 && allBlockTypes.length > 0"
               class="dropdown-divider"
             ></div>
-            <h6 v-if="otherBlockTypes.length > 0" class="dropdown-header">All block types</h6>
+            <h6 v-if="allBlockTypes.length > 0" class="dropdown-header">All block types</h6>
             <span
-              v-for="blockInfo in otherBlockTypes"
-              :key="'other-' + blockInfo.id"
+              v-for="blockInfo in allBlockTypes"
+              :key="'bottom-all-' + blockInfo.id"
               @click="newBlock($event, blockInfo.id)"
             >
               <BlockTooltip :block-info="blockInfo.attributes" />
@@ -316,15 +333,12 @@ export default {
         );
       });
     },
-    otherBlockTypes() {
+    allBlockTypes() {
       if (!this.blockInfoLoaded) {
         return [];
       }
 
-      const suggestedIds = this.suggestedBlockTypes.map((b) => b.id);
-      return this.blocksInfos.filter(
-        (blockInfo) => blockInfo.id !== "notsupported" && !suggestedIds.includes(blockInfo.id),
-      );
+      return this.blocksInfos.filter((blockInfo) => blockInfo.id !== "notsupported");
     },
   },
   watch: {


### PR DESCRIPTION
Closes #1478

Adds a new "Add a block" button at the bottom of edit pages that suggests block types based on uploaded file extensions.


