### PR TITLE
Add read-only group permissions model for items

### DIFF
--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -51,6 +51,21 @@
         "$ref": "#/definitions/Person"
       }
     },
+    "group_ids": {
+      "title": "Group Ids",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "groups": {
+      "title": "Groups",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Group"
+      }
+    },
     "type": {
       "title": "Type",
       "default": "cells",
@@ -563,6 +578,21 @@
             "$ref": "#/definitions/Person"
           }
         },
+        "group_ids": {
+          "title": "Group Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "groups": {
+          "title": "Groups",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Group"
+          }
+        },
         "type": {
           "title": "Type",
           "default": "collections",
@@ -635,6 +665,21 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Person"
+          }
+        },
+        "group_ids": {
+          "title": "Group Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "groups": {
+          "title": "Groups",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Group"
           }
         },
         "type": {

--- a/pydatalab/schemas/equipment.json
+++ b/pydatalab/schemas/equipment.json
@@ -51,6 +51,21 @@
         "$ref": "#/definitions/Person"
       }
     },
+    "group_ids": {
+      "title": "Group Ids",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "groups": {
+      "title": "Groups",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Group"
+      }
+    },
     "type": {
       "title": "Type",
       "default": "equipment",
@@ -527,6 +542,21 @@
             "$ref": "#/definitions/Person"
           }
         },
+        "group_ids": {
+          "title": "Group Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "groups": {
+          "title": "Groups",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Group"
+          }
+        },
         "type": {
           "title": "Type",
           "default": "collections",
@@ -599,6 +629,21 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Person"
+          }
+        },
+        "group_ids": {
+          "title": "Group Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "groups": {
+          "title": "Groups",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Group"
           }
         },
         "type": {

--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -63,6 +63,21 @@
         "$ref": "#/definitions/Person"
       }
     },
+    "group_ids": {
+      "title": "Group Ids",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "groups": {
+      "title": "Groups",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Group"
+      }
+    },
     "type": {
       "title": "Type",
       "default": "samples",
@@ -616,6 +631,21 @@
             "$ref": "#/definitions/Person"
           }
         },
+        "group_ids": {
+          "title": "Group Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "groups": {
+          "title": "Groups",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Group"
+          }
+        },
         "type": {
           "title": "Type",
           "default": "collections",
@@ -688,6 +718,21 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Person"
+          }
+        },
+        "group_ids": {
+          "title": "Group Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "groups": {
+          "title": "Groups",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Group"
           }
         },
         "type": {

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -63,6 +63,21 @@
         "$ref": "#/definitions/Person"
       }
     },
+    "group_ids": {
+      "title": "Group Ids",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "groups": {
+      "title": "Groups",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Group"
+      }
+    },
     "type": {
       "title": "Type",
       "default": "starting_materials",
@@ -669,6 +684,21 @@
             "$ref": "#/definitions/Person"
           }
         },
+        "group_ids": {
+          "title": "Group Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "groups": {
+          "title": "Groups",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Group"
+          }
+        },
         "type": {
           "title": "Type",
           "default": "collections",
@@ -741,6 +771,21 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Person"
+          }
+        },
+        "group_ids": {
+          "title": "Group Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "groups": {
+          "title": "Groups",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Group"
           }
         },
         "type": {

--- a/pydatalab/src/pydatalab/models/traits.py
+++ b/pydatalab/src/pydatalab/models/traits.py
@@ -3,7 +3,7 @@ from typing import Any
 from pydantic import BaseModel, Field, root_validator
 
 from pydatalab.models.blocks import DataBlockResponse
-from pydatalab.models.people import Person
+from pydatalab.models.people import Group, Person
 from pydatalab.models.utils import Constituent, InlineSubstance, PyObjectId
 
 
@@ -13,6 +13,12 @@ class HasOwner(BaseModel):
 
     creators: list[Person] | None = Field(None)
     """Inlined info for the people associated with this item."""
+
+    group_ids: list[PyObjectId] = Field([])
+    """The database IDs of the group(s) that have read-access to this item."""
+
+    groups: list[Group] | None = Field(None)
+    """Inlined info for the groups with access to this item."""
 
 
 class HasRevisionControl(BaseModel):

--- a/pydatalab/tests/server/conftest.py
+++ b/pydatalab/tests/server/conftest.py
@@ -193,6 +193,11 @@ def user_id():
 
 
 @pytest.fixture(scope="session")
+def group_id():
+    yield ObjectId(24 * "2")
+
+
+@pytest.fixture(scope="session")
 def another_user_id():
     yield ObjectId(24 * "7")
 
@@ -254,6 +259,7 @@ def insert_demo_users(
     unverified_user_id,
     unverified_user_api_key,
     real_mongo_client,
+    group_id,
 ):
     insert_user(
         user_id,
@@ -261,7 +267,7 @@ def insert_demo_users(
         "user",
         real_mongo_client,
         display_name="Test User",
-        group_immutable_id=ObjectId(24 * "2"),
+        group_immutable_id=group_id,
     )
     insert_user(
         another_user_id,
@@ -269,10 +275,10 @@ def insert_demo_users(
         "user",
         real_mongo_client,
         display_name="Another User",
-        group_immutable_id=ObjectId(24 * "2"),
+        group_immutable_id=group_id,
     )
     real_mongo_client.get_database(TEST_DATABASE_NAME).groups.insert_one(
-        {"_id": ObjectId(24 * "2"), "display_name": "Demo Group", "group_id": "demo"}
+        {"_id": group_id, "display_name": "Demo Group", "group_id": "demo"}
     )
     insert_user(admin_user_id, admin_api_key, "admin", real_mongo_client, display_name="Test Admin")
     insert_user(


### PR DESCRIPTION
This PR adds group-level read permissions to items on read. A future PR will add the UI for adding such a permission to a group.