### PR TITLE
Add batch sharing menu option in data table and API

### DIFF
--- a/webapp/src/components/BatchShareModal.vue
+++ b/webapp/src/components/BatchShareModal.vue
@@ -3,48 +3,50 @@
     <Modal :model-value="modelValue" @update:model-value="handleClose">
       <template #header> Share Items</template>
       <template #body>
-        <div class="form-row">
-          <div class="form-group col-md-12">
-            <label for="items-selected" class="col-form-label">Items Selected:</label>
-            <div id="items-selected" class="dynamic-input">
-              <FormattedItemName
-                v-for="(item, index) in itemsSelected"
-                :key="index"
-                :item_id="item.item_id"
-                :item-type="item.type"
-                enable-click
-              />
+        <div v-if="modelValue">
+          <div class="form-row">
+            <div class="form-group col-md-12">
+              <label for="items-selected" class="col-form-label">Items Selected:</label>
+              <div id="items-selected" class="dynamic-input">
+                <FormattedItemName
+                  v-for="(item, index) in itemsSelected"
+                  :key="index"
+                  :item_id="item.item_id"
+                  :item-type="item.type"
+                  enable-click
+                />
+              </div>
             </div>
           </div>
-        </div>
 
-        <div class="alert alert-info">
-          <small>
-            <font-awesome-icon icon="info-circle" class="mr-1" />
-            Select people and/or groups to add to these items. Existing permissions will be
-            preserved.
-          </small>
-        </div>
-
-        <div class="form-row">
-          <div class="col-md-6 form-group">
-            <label id="creatorsLabel">Add creators <br />(read/write access):</label>
-            <UserSelect v-model="newCreators" aria-labelledby="creatorsLabel" multiple />
+          <div class="alert alert-info">
+            <small>
+              <font-awesome-icon icon="info-circle" class="mr-1" />
+              Select people and/or groups to add to these items. Existing permissions will be
+              preserved.
+            </small>
           </div>
-          <div class="col-md-6 form-group">
-            <label id="groupsLabel"
-              >Add groups <br />
-              (read-only access):</label
-            >
-            <GroupSelect v-model="newGroups" aria-labelledby="groupsLabel" multiple />
-          </div>
-        </div>
 
-        <div v-if="newCreators.length === 0 && newGroups.length === 0" class="alert alert-warning">
-          <small>
-            <font-awesome-icon icon="exclamation-triangle" class="mr-1" />
-            Please select at least one person or group to add.
-          </small>
+          <div class="form-row">
+            <div class="col-md-6 form-group">
+              <label id="creatorsLabel">Add creators (read/write access):</label>
+              <UserSelect v-model="newCreators" aria-labelledby="creatorsLabel" multiple />
+            </div>
+            <div class="col-md-6 form-group">
+              <label id="groupsLabel">Add groups (read-only access):</label>
+              <GroupSelect v-model="newGroups" aria-labelledby="groupsLabel" multiple />
+            </div>
+          </div>
+
+          <div
+            v-if="newCreators.length === 0 && newGroups.length === 0"
+            class="alert alert-warning"
+          >
+            <small>
+              <font-awesome-icon icon="exclamation-triangle" class="mr-1" />
+              Please select at least one person or group to add.
+            </small>
+          </div>
         </div>
       </template>
     </Modal>

--- a/webapp/src/components/BatchShareModal.vue
+++ b/webapp/src/components/BatchShareModal.vue
@@ -1,0 +1,159 @@
+<template>
+  <form class="modal-enclosure" data-testid="batch-share-form" @submit.prevent="submitForm">
+    <Modal :model-value="modelValue" @update:model-value="handleClose">
+      <template #header> Share Items</template>
+      <template #body>
+        <div class="form-row">
+          <div class="form-group col-md-12">
+            <label for="items-selected" class="col-form-label">Items Selected:</label>
+            <div id="items-selected" class="dynamic-input">
+              <FormattedItemName
+                v-for="(item, index) in itemsSelected"
+                :key="index"
+                :item_id="item.item_id"
+                :item-type="item.type"
+                enable-click
+              />
+            </div>
+          </div>
+        </div>
+
+        <div class="alert alert-info">
+          <small>
+            <font-awesome-icon icon="info-circle" class="mr-1" />
+            Select people and/or groups to add to these items. Existing permissions will be
+            preserved.
+          </small>
+        </div>
+
+        <div class="form-row">
+          <div class="col-md-6 form-group">
+            <label id="creatorsLabel">Add creators <br />(read/write access):</label>
+            <UserSelect v-model="newCreators" aria-labelledby="creatorsLabel" multiple />
+          </div>
+          <div class="col-md-6 form-group">
+            <label id="groupsLabel"
+              >Add groups <br />
+              (read-only access):</label
+            >
+            <GroupSelect v-model="newGroups" aria-labelledby="groupsLabel" multiple />
+          </div>
+        </div>
+
+        <div v-if="newCreators.length === 0 && newGroups.length === 0" class="alert alert-warning">
+          <small>
+            <font-awesome-icon icon="exclamation-triangle" class="mr-1" />
+            Please select at least one person or group to add.
+          </small>
+        </div>
+      </template>
+    </Modal>
+  </form>
+</template>
+
+<script>
+import Modal from "@/components/Modal.vue";
+import FormattedItemName from "@/components/FormattedItemName";
+import UserSelect from "@/components/UserSelect.vue";
+import GroupSelect from "@/components/GroupSelect.vue";
+
+import {
+  fetchItemPermissions,
+  updateItemPermissions,
+  getSampleList,
+  getStartingMaterialList,
+  getEquipmentList,
+} from "@/server_fetch_utils";
+
+export default {
+  name: "BatchShareModal",
+  components: {
+    Modal,
+    FormattedItemName,
+    UserSelect,
+    GroupSelect,
+  },
+  props: {
+    modelValue: Boolean,
+    itemsSelected: {
+      type: Array,
+      required: true,
+    },
+  },
+  emits: ["update:modelValue", "itemsUpdated"],
+  data() {
+    return {
+      newCreators: [],
+      newGroups: [],
+    };
+  },
+  methods: {
+    async submitForm() {
+      if (this.newCreators.length === 0 && this.newGroups.length === 0) {
+        return;
+      }
+
+      try {
+        const refcodes = this.itemsSelected.map((item) => item.refcode);
+
+        for (const refcode of refcodes) {
+          const { creators: currentCreators, groups: currentGroups } =
+            await fetchItemPermissions(refcode);
+
+          const currentCreatorIds = currentCreators.map((c) => c.immutable_id || c._id);
+          const creatorsToAdd = this.newCreators.filter(
+            (c) => !currentCreatorIds.includes(c.immutable_id),
+          );
+
+          const currentGroupIds = currentGroups.map((g) => g.immutable_id || g._id);
+          const groupsToAdd = this.newGroups.filter(
+            (g) => !currentGroupIds.includes(g.immutable_id),
+          );
+
+          if (creatorsToAdd.length > 0 || groupsToAdd.length > 0) {
+            const mergedCreators = [...currentCreators, ...creatorsToAdd];
+            const mergedGroups = [...currentGroups, ...groupsToAdd];
+
+            await updateItemPermissions(refcode, mergedCreators, mergedGroups);
+          }
+        }
+
+        this.$emit("itemsUpdated");
+
+        if (this.itemsSelected.some((item) => item.type === "samples" || item.type === "cells")) {
+          getSampleList();
+        } else if (this.itemsSelected.some((item) => item.type === "starting_materials")) {
+          getStartingMaterialList();
+        } else if (this.itemsSelected.some((item) => item.type === "equipment")) {
+          getEquipmentList();
+        }
+
+        console.log("Items shared successfully.");
+
+        this.handleClose();
+      } catch (error) {
+        console.error("Error sharing items:", error);
+      }
+    },
+
+    handleClose() {
+      this.newCreators = [];
+      this.newGroups = [];
+      this.$emit("update:modelValue", false);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.dynamic-input {
+  display: flex;
+  flex-wrap: wrap;
+  border: 1px solid #ced4da;
+  padding: 0.375rem 0.75rem;
+  border-radius: 0.25rem;
+  max-width: 100%;
+  box-sizing: border-box;
+  gap: 0.2em;
+}
+</style>

--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -54,6 +54,7 @@
           @open-create-collection-modal="createCollectionModalIsOpen = true"
           @open-create-equipment-modal="createEquipmentModalIsOpen = true"
           @open-add-to-collection-modal="addToCollectionModalIsOpen = true"
+          @open-batch-share-modal="batchShareModalIsOpen = true"
           @delete-selected-items="deleteSelectedItems"
           @remove-selected-items-from-collection="removeSelectedItemsFromCollection"
           @reset-table="handleResetTable"
@@ -339,6 +340,11 @@
     :items-selected="itemsSelected"
     @items-updated="handleItemsUpdated"
   />
+  <BatchShareModal
+    v-model="batchShareModalIsOpen"
+    :items-selected="itemsSelected"
+    @items-updated="handleItemsUpdated"
+  />
 </template>
 
 <script>
@@ -349,6 +355,7 @@ import QRScannerModal from "@/components/QRScannerModal";
 import CreateCollectionModal from "@/components/CreateCollectionModal";
 import CreateEquipmentModal from "@/components/CreateEquipmentModal";
 import AddToCollectionModal from "@/components/AddToCollectionModal";
+import BatchShareModal from "@/components/BatchShareModal";
 
 import { INVENTORY_TABLE_TYPES, EDITABLE_INVENTORY } from "@/resources.js";
 
@@ -387,6 +394,7 @@ export default {
     CreateCollectionModal,
     CreateEquipmentModal,
     AddToCollectionModal,
+    BatchShareModal,
     DataTable,
     MultiSelect,
     Column,
@@ -445,6 +453,7 @@ export default {
       createCollectionModalIsOpen: false,
       createEquipmentModalIsOpen: false,
       addToCollectionModalIsOpen: false,
+      batchShareModalIsOpen: false,
       isSampleFetchError: false,
       itemsSelected: [],
       allSelected: false,

--- a/webapp/src/components/DynamicDataTableButtons.vue
+++ b/webapp/src/components/DynamicDataTableButtons.vue
@@ -149,6 +149,14 @@
             Remove from collection
           </a>
           <a
+            v-if="dataType !== 'collections' && dataType !== 'collectionItems'"
+            data-testid="batch-share-button"
+            class="dropdown-item"
+            @click="handleBatchShare"
+          >
+            Batch share
+          </a>
+          <a
             v-if="dataType !== 'collectionItems'"
             data-testid="delete-selected-button"
             class="dropdown-item"
@@ -231,6 +239,7 @@ export default {
     "open-create-collection-modal",
     "open-create-equipment-modal",
     "open-add-to-collection-modal",
+    "open-batch-share-modal",
     "delete-selected-items",
     "update:filters",
     "update:selected-columns",
@@ -339,6 +348,10 @@ export default {
       if (confirmed) {
         this.$emit("reset-table");
       }
+    },
+    handleBatchShare() {
+      this.$emit("open-batch-share-modal");
+      this.isSelectedDropdownVisible = false;
     },
   },
 };

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -1371,3 +1371,19 @@ export async function compareItemVersions(refcode, baseVersion, targetVersion) {
       throw error;
     });
 }
+
+export async function fetchItemPermissions(refcode) {
+  let url = `${API_URL}/items/${refcode}`;
+
+  return fetch_get(url)
+    .then((response_json) => {
+      return {
+        creators: response_json.item_data.creators || [],
+        groups: response_json.item_data.groups || [],
+      };
+    })
+    .catch((error) => {
+      console.error(`Error fetching permissions for ${refcode}:`, error);
+      throw error;
+    });
+}

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -833,6 +833,22 @@ export function updateItemPermissions(refcode, creators = null, groups = null) {
   );
 }
 
+export function appendItemPermissions(refcode, creators = null, groups = null) {
+  console.log("appendItemPermissions called with", refcode, creators, groups);
+
+  const payload = { creators: creators, groups: groups };
+
+  return fetch_put(`${API_URL}/items/${refcode}/permissions`, payload).then(
+    function (response_json) {
+      if (response_json.status === "success") {
+        return response_json;
+      } else {
+        throw new Error(response_json.message);
+      }
+    },
+  );
+}
+
 export function saveItem(item_id) {
   var item_data = store.state.all_item_data[item_id];
 
@@ -1368,22 +1384,6 @@ export async function compareItemVersions(refcode, baseVersion, targetVersion) {
         title: "Version Comparison Failed",
         message: `Error comparing versions for ${refcode}: ${error}`,
       });
-      throw error;
-    });
-}
-
-export async function fetchItemPermissions(refcode) {
-  let url = `${API_URL}/items/${refcode}`;
-
-  return fetch_get(url)
-    .then((response_json) => {
-      return {
-        creators: response_json.item_data.creators || [],
-        groups: response_json.item_data.groups || [],
-      };
-    })
-    .catch((error) => {
-      console.error(`Error fetching permissions for ${refcode}:`, error);
       throw error;
     });
 }


### PR DESCRIPTION
Closes #1523

Adds a "Share with people/groups" option to the checkbox dropdown menu in data tables. Users can select multiple items and batch-add creators (read/write) and groups (read-only) while preserving existing permissions.

## Implementation:

**Backend:**
- Refactored permissions logic into `_process_item_permissions` helper function
- `PATCH /items/<refcode>/permissions` - Replace mode (existing behavior)
- `PUT /items/<refcode>/permissions` - Append mode (new)
- Server-side concatenation eliminates need to fetch full items
- Returns `"No changes needed"` when permissions already exist

**Frontend:**
- New `BatchShareModal` component with user/group selectors
- `appendItemPermissions()` utility function for PUT requests
- Handles batch operations with informative logging

**Tests:**
- Added tests for append mode with creators and groups
- Verified no duplicate permissions
- Tested PATCH vs PUT behavior
- Validated base owner preservation
- Error handling for invalid IDs

**Current limitation:** This implementation only supports adding collaborators. Batch removal could be added in a future PR if needed.