### PR TITLE
Adding "substance" information to samples

### DIFF
--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -3,6 +3,49 @@
   "description": "A model for representing an experimental sample.",
   "type": "object",
   "properties": {
+    "chemform": {
+      "title": "Chemform",
+      "example": [
+        "Na3P",
+        "Na<sub>3</sub>P",
+        "LiNiO2@C",
+        "Na3+xP",
+        "LiNi1/3Co0.1Mn0.1O2"
+      ],
+      "type": "string"
+    },
+    "smiles": {
+      "title": "Smiles",
+      "aliases": [
+        "SMILES",
+        "smiles_representation"
+      ],
+      "type": "string"
+    },
+    "inchi": {
+      "title": "Inchi",
+      "type": "string"
+    },
+    "inchi_key": {
+      "title": "Inchi Key",
+      "type": "string"
+    },
+    "GHS_codes": {
+      "title": "Ghs H-Codes",
+      "examples": [
+        "H224",
+        "H303, H316, H319"
+      ],
+      "type": "string"
+    },
+    "molar_mass": {
+      "title": "Molecular Weight",
+      "type": "number"
+    },
+    "CAS": {
+      "title": "Substance Cas",
+      "type": "string"
+    },
     "synthesis_constituents": {
       "title": "Synthesis Constituents",
       "default": [],
@@ -156,14 +199,6 @@
           "$ref": "#/definitions/ItemStatus"
         }
       ]
-    },
-    "chemform": {
-      "title": "Chemform",
-      "example": [
-        "Na3P",
-        "LiNiO2@C"
-      ],
-      "type": "string"
     }
   },
   "required": [

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -3,6 +3,49 @@
   "description": "A model for representing an experimental sample, based on the connection\nwith cheminventory.net, which mixes container-level and substance-level\ninformation.",
   "type": "object",
   "properties": {
+    "chemform": {
+      "title": "Chemform",
+      "example": [
+        "Na3P",
+        "Na<sub>3</sub>P",
+        "LiNiO2@C",
+        "Na3+xP",
+        "LiNi1/3Co0.1Mn0.1O2"
+      ],
+      "type": "string"
+    },
+    "smiles": {
+      "title": "Smiles",
+      "aliases": [
+        "SMILES",
+        "smiles_representation"
+      ],
+      "type": "string"
+    },
+    "inchi": {
+      "title": "Inchi",
+      "type": "string"
+    },
+    "inchi_key": {
+      "title": "Inchi Key",
+      "type": "string"
+    },
+    "GHS_codes": {
+      "title": "Ghs H-Codes",
+      "examples": [
+        "H224",
+        "H303, H316, H319"
+      ],
+      "type": "string"
+    },
+    "molar_mass": {
+      "title": "Molecular Weight",
+      "type": "number"
+    },
+    "CAS": {
+      "title": "Substance Cas",
+      "type": "string"
+    },
     "synthesis_constituents": {
       "title": "Synthesis Constituents",
       "default": [],
@@ -166,10 +209,6 @@
       "type": "string",
       "format": "date-time"
     },
-    "CAS": {
-      "title": "Substance Cas",
-      "type": "string"
-    },
     "chemical_purity": {
       "title": "Chemical Purity",
       "type": "string"
@@ -178,32 +217,12 @@
       "title": "Full %",
       "type": "string"
     },
-    "GHS_codes": {
-      "title": "Ghs H-Codes",
-      "examples": [
-        "H224",
-        "H303, H316, H319"
-      ],
-      "type": "string"
-    },
     "size": {
       "title": "Container Size",
       "type": "string"
     },
     "size_unit": {
       "title": "Unit",
-      "type": "string"
-    },
-    "chemform": {
-      "title": "Molecular Formula",
-      "type": "string"
-    },
-    "molar_mass": {
-      "title": "Molecular Weight",
-      "type": "number"
-    },
-    "smiles_representation": {
-      "title": "Smiles",
       "type": "string"
     },
     "supplier": {

--- a/pydatalab/src/pydatalab/models/samples.py
+++ b/pydatalab/src/pydatalab/models/samples.py
@@ -1,17 +1,14 @@
 from pydantic import Field
 
 from pydatalab.models.items import Item
-from pydatalab.models.traits import HasSynthesisInfo
+from pydatalab.models.traits import HasSubstanceInfo, HasSynthesisInfo
 from pydatalab.models.utils import SampleStatus
 
 
-class Sample(Item, HasSynthesisInfo):
+class Sample(Item, HasSynthesisInfo, HasSubstanceInfo):
     """A model for representing an experimental sample."""
 
     type: str = Field("samples", const="samples", pattern="^samples$")
-
-    chemform: str | None = Field(example=["Na3P", "LiNiO2@C"])
-    """A string representation of the chemical formula or composition associated with this sample."""
 
     status: SampleStatus = Field(default=SampleStatus.ACTIVE)
     """The status of the sample, indicating its current state."""

--- a/pydatalab/src/pydatalab/models/starting_materials.py
+++ b/pydatalab/src/pydatalab/models/starting_materials.py
@@ -1,11 +1,11 @@
-from pydantic import Field, validator
+from pydantic import Field
 
 from pydatalab.models.items import Item
-from pydatalab.models.traits import HasSynthesisInfo
+from pydatalab.models.traits import HasSubstanceInfo, HasSynthesisInfo
 from pydatalab.models.utils import IsoformatDateTime, StartingMaterialsStatus
 
 
-class StartingMaterial(Item, HasSynthesisInfo):
+class StartingMaterial(Item, HasSynthesisInfo, HasSubstanceInfo):
     """A model for representing an experimental sample, based on the connection
     with cheminventory.net, which mixes container-level and substance-level
     information.
@@ -27,20 +27,11 @@ class StartingMaterial(Item, HasSynthesisInfo):
     date_opened: IsoformatDateTime | None = Field(alias="Date opened")
     """The date the item was opened"""
 
-    CAS: str | None = Field(alias="Substance CAS")
-    """The CAS Registry Number for the substance described by this entry."""
-
     chemical_purity: str | None = Field(alias="Chemical purity")
     """The chemical purity of this container with regards to the defined substance."""
 
     full_percent: str | None = Field(alias="Full %")
     """The amount of the defined substance remaining in the container, expressed as a percentage."""
-
-    GHS_codes: str | None = Field(
-        alias="GHS H-codes",
-        examples=["H224", "H303, H316, H319"],
-    )
-    """A string describing any GHS hazard codes associated with this item. See https://pubchem.ncbi.nlm.nih.gov/ghs/ for code definitions."""
 
     name: str | None = Field(alias="Container Name")
     """The name of the substance in the container."""
@@ -50,15 +41,6 @@ class StartingMaterial(Item, HasSynthesisInfo):
 
     size_unit: str | None = Field(alias="Unit")
     """Units for the 'size' field."""
-
-    chemform: str | None = Field(alias="Molecular Formula")
-    """A string representation of the chemical formula associated with this sample."""
-
-    molar_mass: float | None = Field(alias="Molecular Weight")
-    """Mass per formula unit, in g/mol."""
-
-    smiles_representation: str | None = Field(alias="SMILES")
-    """A SMILES string representation of a chemical structure associated with this substance."""
 
     supplier: str | None = Field(alias="Supplier")
     """Supplier or manufacturer of the chemical."""
@@ -71,15 +53,3 @@ class StartingMaterial(Item, HasSynthesisInfo):
 
     status: StartingMaterialsStatus = Field(default=StartingMaterialsStatus.AVAILABLE)
     """The status of the starting materials, indicating its current state."""
-
-    @validator("molar_mass")
-    def add_molar_mass(cls, v, values):
-        from periodictable import formula
-
-        if v is None and values.get("chemform"):
-            try:
-                return formula(values.get("chemform")).mass
-            except Exception:
-                return None
-
-        return v

--- a/pydatalab/src/pydatalab/models/traits.py
+++ b/pydatalab/src/pydatalab/models/traits.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic import BaseModel, Field, root_validator
+from pydantic import BaseModel, Field, root_validator, validator
 
 from pydatalab.models.blocks import DataBlockResponse
 from pydatalab.models.people import Group, Person
@@ -151,12 +151,48 @@ class HasSynthesisInfo(BaseModel):
         return values
 
 
-class HasChemInfo:
-    smile: str | None = Field(None)
+class HasSubstanceInfo(BaseModel):
+    """Trait mixin for models that have substance information."""
+
+    chemform: str | None = Field(
+        example=["Na3P", "Na<sub>3</sub>P", "LiNiO2@C", "Na3+xP", "LiNi1/3Co0.1Mn0.1O2"],
+    )
+    """A string representation of the chemical formula or composition associated with this sample.
+
+    The representation is relatively free-form; clients are expected parse and interpret HTML markup for subscripts
+    and accept unicode characters for greek letters.
+
+    """
+
+    smiles: str | None = Field(None, aliases=["SMILES", "smiles_representation"])
     """A SMILES string representation of the chemical structure associated with this sample."""
+
     inchi: str | None = Field(None)
-    """An InChI string representation of the chemical structure associated with this sample."""
+    """An International Chemical Identifier (InChI) string representation of chemicals/molecules associated with this sample."""
+
     inchi_key: str | None = Field(None)
-    """An InChI key representation of the chemical structure associated with this sample."""
-    """A unique key derived from the InChI string."""
-    chemform: str | None = Field(None)
+    """A unique key derived from the InChI."""
+
+    GHS_codes: str | None = Field(
+        alias="GHS H-codes",
+        examples=["H224", "H303, H316, H319"],
+    )
+    """A string describing any GHS hazard codes associated with this item. See https://pubchem.ncbi.nlm.nih.gov/ghs/ for code definitions."""
+
+    molar_mass: float | None = Field(alias="Molecular Weight")
+    """Mass per formula unit, in g/mol."""
+
+    CAS: str | None = Field(alias="Substance CAS")
+    """The CAS Registry Number for the substance described by this entry."""
+
+    @validator("molar_mass")
+    def add_molar_mass(cls, v, values):
+        from periodictable import formula
+
+        if v is None and values.get("chemform"):
+            try:
+                return formula(values.get("chemform")).mass
+            except Exception:
+                return None
+
+        return v

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -121,6 +121,10 @@ def get_starting_materials():
                         "supplier": 1,
                         "location": 1,
                         "status": 1,
+                        "GHS_codes": 1,
+                        "smiles": 1,
+                        "molar_mass": 1,
+                        "CAS": 1,
                     }
                 },
                 {
@@ -249,6 +253,10 @@ def get_samples_summary(match: dict | None = None, project: dict | None = None) 
         "item_id": 1,
         "name": 1,
         "chemform": 1,
+        "GHS_codes": 1,
+        "smiles": 1,
+        "molar_mass": 1,
+        "CAS": 1,
         "nblocks": {"$size": "$display_order"},
         "nfiles": {"$size": "$file_ObjectIds"},
         "characteristic_chemical_formula": 1,

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -65,6 +65,9 @@ def test_new_sample_with_automatically_generated_id(client, user_id):
         "type": "samples",
         "synthesis_description": "2 parts hydrogen were added to 1 part oxygen",
         "creator_ids": [user_id],
+        "CAS": "7732-18-5",
+        "inchi_key": "XLYOFNOQVPJJNP-UHFFFAOYSA-N",
+        "smiles": "O",
     }
 
     request_json = dict(
@@ -83,6 +86,7 @@ def test_new_sample_with_automatically_generated_id(client, user_id):
     assert response.status_code == 200
     assert response.json["status"] == "success"
     assert response.json["item_data"]["refcode"].split(":")[1] == created_item_id
+    assert response.json["item_data"]["molar_mass"] == 18.01528
 
     for key in new_sample_data:
         if isinstance(v := new_sample_data[key], datetime.datetime):


### PR DESCRIPTION
This PR adds the `HasSubstanceInfo` trait for use in items that have chemical information to attach to them. The model follows roughly what we already had for starting materials, with a few expansions, but all of this should be discussed before merging.

Previously, it also had some UI prototyping, which now lives in a different PR: #1728 

The component is currently vibe-coded to give a custom collapsible view that shows, when provided, the "best" guess of the substance:
- If SMILES/Inchi/Inchikey are provided, it renders a molecular structure (currently using pubchem)
- If a chemical formula is provided, show that
- If hazard codes are provided, show pictograms
etc.

When not editing, these are nicely rendered in a compact component. The "edit" mode is then just the normal input string boxes:

Edit mode (kinda gross):
<img width="915" height="949" alt="2026-01-15-143154_915x949_scrot" src="https://github.com/user-attachments/assets/05e70e87-e589-41c6-903a-51ce81d1506f" />

View mode (not too bad)
<img width="549" height="252" alt="2026-01-15-143147_549x252_scrot" src="https://github.com/user-attachments/assets/6425804d-f4d9-45ae-9fdd-2f11ceee0763" />

It would be really nice to have a "small" mode of the view component, which we can maybe use in the item table to do a hover row -> show chemical info lookup.