### PR TITLE
Use slim Python 3.11 base image for API container

### DIFF
--- a/.docker/server_dockerfile
+++ b/.docker/server_dockerfile
@@ -1,7 +1,7 @@
 ARG UV_VERSION="0.9.21"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_image
 
-FROM python:3.10 AS api
+FROM python:3.11-slim-trixie AS api
 ARG TARGETARCH
 SHELL ["/bin/bash", "--login", "-c"]
 
@@ -9,7 +9,7 @@ SHELL ["/bin/bash", "--login", "-c"]
 ENV GIT_LFS_SKIP_SMUDGE=1
 
 # Install system dependencies
-RUN apt update && apt install -y gnupg curl tree mdbtools && apt clean
+RUN apt update && apt install -y git gnupg curl tree mdbtools && apt clean
 
 # Install MongoDB tools in the official way
 WORKDIR /opt
@@ -28,7 +28,7 @@ ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
     UV_PYTHON_DOWNLOADS=never \
     UV_PROJECT_ENVIRONMENT=/opt/.venv \
-    UV_PYTHON=python3.10
+    UV_PYTHON=python3.11
 
 # Used to fake the version of the package in cases where datalab is only
 # available as a git submodule or worktree


### PR DESCRIPTION
This PR simply changes our base image from `python:3.10` to `python:3.11-slim-trixie` for smaller images and better version management (plus bumping Python version to the highest we support).