### PR TITLE
Improve error handling for block updates

### DIFF
--- a/webapp/src/components/FileMultiSelectDropdown.vue
+++ b/webapp/src/components/FileMultiSelectDropdown.vue
@@ -330,7 +330,9 @@ export default {
           this.item_id,
           this.block_id,
           this.$store.state.all_item_data[this.item_id]["blocks_obj"][this.block_id],
-        );
+        ).catch((error) => {
+          console.error("Error updating block:", error);
+        });
       }
     },
     checkFileList() {

--- a/webapp/src/components/FileSelectDropdown.vue
+++ b/webapp/src/components/FileSelectDropdown.vue
@@ -97,7 +97,9 @@ export default {
           this.item_id,
           this.block_id,
           this.$store.state.all_item_data[this.item_id]["blocks_obj"][this.block_id],
-        );
+        ).catch((error) => {
+          console.error("Error updating block:", error);
+        });
       }
     },
     checkFileList() {

--- a/webapp/src/components/datablocks/BokehBlock.vue
+++ b/webapp/src/components/datablocks/BokehBlock.vue
@@ -64,7 +64,9 @@ export default {
 
   methods: {
     updateBlock() {
-      updateBlockFromServer(this.item_id, this.block_id, this.block);
+      updateBlockFromServer(this.item_id, this.block_id, this.block).catch((error) => {
+        console.error("Error updating block:", error);
+      });
     },
   },
 };

--- a/webapp/src/components/datablocks/ChatBlock.vue
+++ b/webapp/src/components/datablocks/ChatBlock.vue
@@ -177,6 +177,9 @@ export default {
         .then(() => {
           this.prompt = "";
         })
+        .catch((error) => {
+          console.error("Error updating block:", error);
+        })
         .finally(() => {
           this.isLoading = false;
         });

--- a/webapp/src/components/datablocks/CycleBlock.vue
+++ b/webapp/src/components/datablocks/CycleBlock.vue
@@ -456,10 +456,14 @@ export default {
         this.item_id,
         this.block_id,
         this.$store.state.all_item_data[this.item_id]["blocks_obj"][this.block_id],
-      ).then(() => {
-        this.bokehPlotLimitedWidth = this.derivative_mode != "dQ/dV";
-        this.isReplotButtonDisplayed = false;
-      });
+      )
+        .then(() => {
+          this.bokehPlotLimitedWidth = this.derivative_mode != "dQ/dV";
+          this.isReplotButtonDisplayed = false;
+        })
+        .catch((error) => {
+          console.error("Error updating block:", error);
+        });
     },
   },
 };

--- a/webapp/src/components/datablocks/DataBlockBase.vue
+++ b/webapp/src/components/datablocks/DataBlockBase.vue
@@ -218,7 +218,9 @@ export default {
   },
   methods: {
     async updateBlock() {
-      await updateBlockFromServer(this.item_id, this.block_id, this.block);
+      await updateBlockFromServer(this.item_id, this.block_id, this.block).catch((error) => {
+        console.error("Error updating block:", error);
+      });
     },
     async handleBokehEvent(event) {
       // Only handle events for this specific block
@@ -233,7 +235,9 @@ export default {
         this.block_id,
         this.$store.state.all_item_data[this.item_id]["blocks_obj"][this.block_id],
         event.detail,
-      );
+      ).catch((error) => {
+        console.error("Error updating block:", error);
+      });
     },
     async deleteThisBlock() {
       const confirmed = await DialogService.confirm({

--- a/webapp/src/components/datablocks/NMRBlock.vue
+++ b/webapp/src/components/datablocks/NMRBlock.vue
@@ -156,7 +156,9 @@ export default {
         this.item_id,
         this.block_id,
         this.$store.state.all_item_data[this.item_id]["blocks_obj"][this.block_id],
-      );
+      ).catch((error) => {
+        console.error("Error updating block:", error);
+      });
     },
   },
 };

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -805,10 +805,16 @@ export async function updateBlockFromServer(item_id, block_id, block_data, event
     .catch((error) => {
       // The block component renders errors, so no need to make a dialog here.
       store.commit("setBlockNotUpdating", block_id);
-      if (error && !error.includes("Invalid block type")) {
+
+      const errorMessage = error?.message || String(error);
+
+      if (errorMessage.includes("Invalid block type")) {
         // Do not set any error message for NotImplemented as this will be handled elsewhere
-        store.commit("setBlockError", { block_id, error: error });
+        return;
       }
+
+      store.commit("setBlockError", { block_id, error: errorMessage });
+      throw error;
     });
 }
 

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -458,7 +458,11 @@ export default {
         // update each block asynchronously
         this.item_data.display_order.forEach((block_id) => {
           console.log(`calling update on block ${block_id}`);
-          updateBlockFromServer(this.item_id, block_id, this.item_data.blocks_obj[block_id]);
+          updateBlockFromServer(this.item_id, block_id, this.item_data.blocks_obj[block_id]).catch(
+            (error) => {
+              console.error(`Error updating block ${block_id}:`, error);
+            },
+          );
         });
         this.blocksLoaded = true;
         this.setLastModified();


### PR DESCRIPTION
Closes #1488

### Changes
- Modified `updateBlockFromServer` to propagate errors instead of silently failing
- Added `.catch()` handlers in all components calling `updateBlockFromServer` to prevent uncaught errors
- Errors are now properly displayed to users while being logged to console
