### PR TITLE
Fix manager sharing issue

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/admin.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/admin.py
@@ -188,7 +188,7 @@ def update_user_managers(user_id):
                     }
                 ), 400
 
-            manager_object_ids.append(str(manager_oid))
+            manager_object_ids.append(manager_oid)
 
     update_result = flask_mongo.db.users.update_one(
         {"_id": ObjectId(user_id)}, {"$set": {"managers": manager_object_ids}}


### PR DESCRIPTION
This PR primarily closes #1543 by being more careful around string/ObjectId insertion in the database for managers. It also:

- Improves upon the manager cycle checker to allow for branching cycles (via BFS) and adds an upper bound halting criteria
- Adds tests for manager permissions