### PR TITLE
Add 'sudo' mode for admins that allows them to restrict their admin powers

### DIFF
--- a/pydatalab/tests/server/test_item_graph.py
+++ b/pydatalab/tests/server/test_item_graph.py
@@ -100,7 +100,8 @@ def test_single_starting_material(admin_client, client):
     assert len(graph["edges"]) == 4
 
     # Check for bug where this behaviour was inconsistent between admin and non-admin users
-    graph = admin_client.get("/item-graph/great-grandchild").json
+    # Admin needs ?sudo=1 to see items not created by them (super-user mode)
+    graph = admin_client.get("/item-graph/great-grandchild?sudo=1").json
     assert len(graph["nodes"]) == 2
     assert len(graph["edges"]) == 1
 
@@ -116,7 +117,7 @@ def test_single_starting_material(admin_client, client):
         "/new-sample/", json={"new_sample_data": json.loads(admin_great_great_grandchild.json())}
     )
 
-    graph = admin_client.get("/item-graph/great-grandchild").json
+    graph = admin_client.get("/item-graph/great-grandchild?sudo=1").json
     assert len(graph["nodes"]) == 3
     assert len(graph["edges"]) == 2
 
@@ -139,7 +140,7 @@ def test_single_starting_material(admin_client, client):
     client_collection_graph = client.get("/item-graph?collection_id=test-collection").json
     assert client_collection_graph["status"] == "error"
 
-    collection_graph = admin_client.get("/item-graph?collection_id=test-collection").json
+    collection_graph = admin_client.get("/item-graph?collection_id=test-collection&sudo=1").json
     assert len(collection_graph["nodes"]) == 1
     assert len(collection_graph["edges"]) == 0
 
@@ -147,6 +148,8 @@ def test_single_starting_material(admin_client, client):
     assert len(graph["nodes"]) == 2
     assert len(graph["edges"]) == 1
 
-    admin_graph = admin_client.get("/item-graph/great-grandchild?hide_collections=false").json
+    admin_graph = admin_client.get(
+        "/item-graph/great-grandchild?hide_collections=false&sudo=1"
+    ).json
     assert len(admin_graph["nodes"]) == 4
     assert len(admin_graph["edges"]) == 3

--- a/pydatalab/tests/server/test_permissions.py
+++ b/pydatalab/tests/server/test_permissions.py
@@ -399,6 +399,7 @@ def test_append_permissions_preserves_base_owner(client, another_user_id):
     assert len(creator_ids_final) == 2
     assert creator_ids_final[0] == original_owner_id
 
+
 def test_admin_super_user_mode(admin_client, client):
     """Test that admins must opt-in to super-user mode with ?sudo=1 for GET requests.
 

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -254,7 +254,8 @@ def test_item_regex_search(
     user, query, expected_result_ids, real_mongo_client, client, admin_client, insert_example_items
 ):
     if user == "admin":
-        response = admin_client.get(f"/search-items/?{query}")
+        # Admin needs ?sudo=1 to see all items (super-user mode)
+        response = admin_client.get(f"/search-items/?{query}&sudo=1")
     else:
         response = client.get(f"/search-items/?{query}")
 

--- a/webapp/cypress/e2e/editPage.cy.js
+++ b/webapp/cypress/e2e/editPage.cy.js
@@ -270,13 +270,13 @@ describe("Edit Page", () => {
     cy.get('[data-testid="search-input"]').type("editable_sample");
     cy.findByText("editable_sample").click();
 
-    cy.findByText("Upload files...").click();
+    cy.findByText("Upload files").click();
     cy.get(".uppy-Dashboard-AddFiles-title").should("contain.text", "Drop files here,");
     cy.get(".uppy-Dashboard-AddFiles-title").should("contain.text", "browse files");
     cy.get(".uppy-Dashboard-AddFiles-title").should("contain.text", "or import from:");
     cy.get("body").type("{esc}");
 
-    cy.findByText("Add files from server...").click();
+    cy.findByText("Add files from server").click();
     cy.findByText("Select files to add").should("exist");
   });
 

--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -520,6 +520,9 @@ export default {
     page() {
       return this.$store.state.datatablePaginationSettings[this.dataType].page;
     },
+    adminSuperUserMode() {
+      return this.$store.getters.isAdminSuperUserModeActive;
+    },
     uniqueCreators() {
       return Array.from(
         new Map(

--- a/webapp/src/components/DynamicDataTableButtons.vue
+++ b/webapp/src/components/DynamicDataTableButtons.vue
@@ -24,6 +24,8 @@
           v-if="dataType === 'samples'"
           data-testid="add-item-button"
           class="btn btn-default ml-2"
+          :disabled="adminSuperUserMode"
+          :title="adminSuperUserMode ? 'Disabled in super-user mode' : ''"
           @click="$emit('open-create-item-modal')"
         >
           Add an item
@@ -32,6 +34,8 @@
           v-if="dataType === 'samples'"
           data-testid="batch-item-button"
           class="btn btn-default ml-2"
+          :disabled="adminSuperUserMode"
+          :title="adminSuperUserMode ? 'Disabled in super-user mode' : ''"
           @click="$emit('open-batch-create-item-modal')"
         >
           Add batch of items
@@ -253,6 +257,11 @@ export default {
       isDeletingItems: false,
       itemCount: 0,
     };
+  },
+  computed: {
+    adminSuperUserMode() {
+      return this.$store.getters.isAdminSuperUserModeActive;
+    },
   },
   watch: {
     itemsSelected(newVal) {

--- a/webapp/src/components/FileList.vue
+++ b/webapp/src/components/FileList.vue
@@ -58,20 +58,17 @@
             }})
           </span>
         </div>
-      </div>
-      <div class="row">
-        <button id="uppy-trigger" class="btn btn-default btn-sm mb-3 ml-4" type="button">
-          <font-awesome-icon class="upload-icon" icon="file" fixed-width />
-          Upload files...</button
-        ><!-- Surrounding divs so that buttons  don't become full-width in the card -->
-        <button
-          class="btn btn-default btn-sm mb-3 ml-2"
-          type="button"
-          @click="setFileSelectModalOpen"
-        >
-          <font-awesome-icon class="remote-upload-icon" icon="cloud-upload-alt" fixed-width />
-          Add files from server...
-        </button>
+        <div class="row buttons">
+          <div class="btn-group" role="group">
+            <button id="uppy-trigger" class="btn btn-default btn-sm" type="button">
+              <font-awesome-icon class="upload-icon" icon="file" fixed-width /> Upload files
+            </button>
+            <button class="btn btn-default btn-sm" type="button" @click="setFileSelectModalOpen">
+              <font-awesome-icon class="remote-upload-icon" icon="cloud-upload-alt" fixed-width />
+              Add files from server
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -154,9 +151,13 @@ export default {
 .unlink-icon,
 .upload-icon,
 .remote-upload-icon {
-  margin-left: 0.4rem;
+  margin-left: 0rem;
   color: #888;
   font-size: small;
+}
+
+.btn-group {
+  margin-top: 0.5rem;
 }
 
 #filearea {

--- a/webapp/src/components/FileList.vue
+++ b/webapp/src/components/FileList.vue
@@ -7,7 +7,7 @@
           <a @click="deleteFile($event, file_id)">
             <font-awesome-icon icon="times" fixed-width class="delete-file-button" />
           </a>
-          <a class="filelink" target="_blank" :href="`${$API_URL}/files/${file_id}/${file.name}`">
+          <a class="filelink" target="_blank" :href="getFileUrl(file_id, file.name)">
             {{ file.name }}
           </a>
           <span v-if="getFileSize(file)" class="file-size">
@@ -99,7 +99,16 @@ export default {
       serverFileModalIsOpen: false,
     };
   },
+  computed: {
+    adminSuperUserMode() {
+      return this.$store.state.adminSuperUserMode;
+    },
+  },
   methods: {
+    getFileUrl(file_id, filename) {
+      const baseUrl = `${this.$API_URL}/files/${file_id}/${filename}`;
+      return this.adminSuperUserMode ? `${baseUrl}?sudo=1` : baseUrl;
+    },
     formatDistance,
     getFileSize(file) {
       return file.size;

--- a/webapp/src/components/FileList.vue
+++ b/webapp/src/components/FileList.vue
@@ -101,7 +101,7 @@ export default {
   },
   computed: {
     adminSuperUserMode() {
-      return this.$store.state.adminSuperUserMode;
+      return this.$store.getters.isAdminSuperUserModeActive;
     },
   },
   methods: {

--- a/webapp/src/components/LoginDetails.vue
+++ b/webapp/src/components/LoginDetails.vue
@@ -4,6 +4,7 @@
       <button
         id="userDropdown"
         class="btn dropdown-toggle border"
+        :class="{ 'super-user-active': adminSuperUserMode }"
         type="button"
         aria-haspopup="true"
         aria-expanded="false"
@@ -17,6 +18,7 @@
       <div
         v-show="isUserDropdownVisible"
         class="dropdown-menu"
+        :class="{ 'super-user-active': adminSuperUserMode }"
         style="display: block"
         aria-labelledby="UserDropdown"
       >
@@ -102,6 +104,9 @@ export default {
     hasUnverifiedUser() {
       return this.$store.getters.getHasUnverifiedUser;
     },
+    adminSuperUserMode() {
+      return this.$store.getters.isAdminSuperUserModeActive;
+    },
   },
   watch: {
     modelValue(newValue) {
@@ -146,5 +151,25 @@ export default {
 
 .user-display-name {
   font-weight: bold;
+}
+
+#userDropdown:hover,
+#userDropdown:focus {
+  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+}
+
+.super-user-active {
+  border-color: #a52a2a !important;
+}
+
+#userDropdown.super-user-active:hover,
+#userDropdown.super-user-active:focus {
+  border-color: #a52a2a !important;
+  box-shadow: 0 0 0 0.2rem rgba(165, 42, 42, 0.25) !important;
+}
+
+.dropdown-menu.super-user-active {
+  border-color: #a52a2a;
+  min-width: auto;
 }
 </style>

--- a/webapp/src/components/Navbar.vue
+++ b/webapp/src/components/Navbar.vue
@@ -33,8 +33,21 @@
     >
   </div>
   <div v-if="!isLoggedIn" class="container">
-    <div class="alert alert-info col-md-6 col-lg-4 text-center mx-auto">
-      Please login to view or create items.
+    <div class="alert alert-info col-md-6 col-lg-4 text-center mx-auto info-banner">
+      <div class="info-banner-text">
+        <font-awesome-icon icon="info-circle" fixed-width /> Please login to view or create items.
+      </div>
+    </div>
+  </div>
+  <div v-if="adminSuperUserMode" class="container">
+    <div class="alert alert-warning col-md-8 col-lg-8 text-center mx-auto super-user-banner">
+      <div class="super-user-banner-text">
+        <font-awesome-icon icon="exclamation-triangle" fixed-width /> Super-user mode is currently
+        active. You have read access to all items.
+        <div>
+          <a href="#" class="disable-link" @click.prevent="disableSuperUserMode">(disable)</a>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -60,6 +73,15 @@ export default {
     isLoggedIn() {
       return Boolean(this.$store.state.currentUserDisplayName);
     },
+    adminSuperUserMode() {
+      return this.$store.getters.isAdminSuperUserModeActive;
+    },
+  },
+  methods: {
+    disableSuperUserMode() {
+      this.$store.commit("setAdminSuperUserMode", false);
+      window.location.reload();
+    },
   },
 };
 </script>
@@ -77,5 +99,52 @@ export default {
 a > .logo-banner:hover {
   filter: alpha(opacity=40);
   opacity: 0.4;
+}
+
+.info-banner {
+  background-color: white;
+  border-color: #007bff;
+  color: #004085;
+  background: repeating-linear-gradient(
+    45deg,
+    #004085,
+    #004085 1px,
+    transparent 1px,
+    transparent 10px
+  );
+}
+
+.info-banner-text {
+  background-color: white;
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+}
+
+.super-user-banner {
+  background-color: white;
+  background: repeating-linear-gradient(
+    45deg,
+    #a52a2a,
+    #a52a2a 1px,
+    transparent 1px,
+    transparent 10px
+  );
+  border-color: #a52a2a;
+  color: #721c24;
+}
+
+.super-user-banner-text {
+  background-color: white;
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+}
+
+.super-user-banner .disable-link {
+  color: #721c24;
+  text-decoration: underline;
+}
+
+.super-user-banner .disable-link:hover {
+  color: #721c24;
 }
 </style>

--- a/webapp/src/components/UserDropdown.vue
+++ b/webapp/src/components/UserDropdown.vue
@@ -14,6 +14,19 @@
       <span v-if="hasUnverifiedUser" class="notification-wrapper"><NotificationDot /></span>
     </router-link>
   </span>
+  <span v-if="user.role === 'admin'" class="dropdown-item super-user-toggle">
+    <div class="form-check form-switch">
+      <input
+        id="superUserModeToggle"
+        class="form-check-input"
+        type="checkbox"
+        role="switch"
+        :checked="adminSuperUserMode"
+        @change="toggleSuperUserMode"
+      />
+      <label class="form-check-label" for="superUserModeToggle">Super-user mode</label>
+    </div>
+  </span>
   <a
     type="button"
     class="dropdown-item btn login btn-link"
@@ -52,12 +65,21 @@ export default {
     hasUnverifiedUser() {
       return this.$store.getters.getHasUnverifiedUser;
     },
+    adminSuperUserMode() {
+      return this.$store.state.adminSuperUserMode;
+    },
   },
   watch: {
     editAccountSettingIsOpen: function (val) {
       if (!val) {
         this.$emit("update:modelValue", false);
       }
+    },
+  },
+  methods: {
+    toggleSuperUserMode(event) {
+      this.$store.commit("setAdminSuperUserMode", event.target.checked);
+      window.location.reload();
     },
   },
 };
@@ -77,5 +99,13 @@ export default {
   display: inline-block;
   margin-left: 0.25rem;
   vertical-align: middle;
+}
+
+.super-user-toggle {
+  padding: 0.5rem 1rem;
+}
+
+.super-user-toggle .form-check-label {
+  cursor: pointer;
 }
 </style>

--- a/webapp/src/components/UserDropdown.vue
+++ b/webapp/src/components/UserDropdown.vue
@@ -8,25 +8,27 @@
     <font-awesome-icon icon="cog" /> &nbsp;&nbsp;Account settings
     <span v-if="isUnverified" class="notification-wrapper"><NotificationDot /></span>
   </a>
-  <span v-if="user.role === 'admin'">
-    <router-link to="/admin" class="dropdown-item btn login btn-link" aria-label="Administration">
+  <div v-if="user.role === 'admin'" class="dropdown-item admin-row">
+    <router-link to="/admin" class="btn login btn-link admin-link" aria-label="Administration">
       <font-awesome-icon icon="users-cog" /> &nbsp;Administration
       <span v-if="hasUnverifiedUser" class="notification-wrapper"><NotificationDot /></span>
     </router-link>
-  </span>
-  <span v-if="user.role === 'admin'" class="dropdown-item super-user-toggle">
-    <div class="form-check form-switch">
-      <input
-        id="superUserModeToggle"
-        class="form-check-input"
-        type="checkbox"
-        role="switch"
-        :checked="adminSuperUserMode"
-        @change="toggleSuperUserMode"
-      />
-      <label class="form-check-label" for="superUserModeToggle">Super-user mode</label>
-    </div>
-  </span>
+    <StyledTooltip :delay="300">
+      <template #anchor>
+        <div class="custom-control custom-switch super-user-toggle" @click.stop>
+          <input
+            id="superUserModeToggle"
+            type="checkbox"
+            class="custom-control-input"
+            :checked="adminSuperUserMode"
+            @change="toggleSuperUserMode"
+          />
+          <label class="custom-control-label" for="superUserModeToggle"></label>
+        </div>
+      </template>
+      <template #content> Super-user mode: enables read access to all items </template>
+    </StyledTooltip>
+  </div>
   <a
     type="button"
     class="dropdown-item btn login btn-link"
@@ -40,12 +42,14 @@
 <script>
 import EditAccountSettingsModal from "@/components/EditAccountSettingsModal.vue";
 import NotificationDot from "@/components/NotificationDot.vue";
+import StyledTooltip from "@/components/StyledTooltip.vue";
 import { API_URL } from "@/resources.js";
 
 export default {
   components: {
     EditAccountSettingsModal,
     NotificationDot,
+    StyledTooltip,
   },
   props: {
     modelValue: Boolean,
@@ -101,11 +105,39 @@ export default {
   vertical-align: middle;
 }
 
-.super-user-toggle {
-  padding: 0.5rem 1rem;
+.admin-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
-.super-user-toggle .form-check-label {
+.admin-row .admin-link {
+  padding: 0;
+  flex-grow: 1;
+  text-decoration: none;
+  color: inherit;
+}
+
+.admin-row .admin-link:hover {
+  text-decoration: none;
+}
+
+.super-user-toggle {
+  margin-left: 1rem;
+  padding-left: 2.25rem;
+}
+
+.super-user-toggle .custom-control-label {
   cursor: pointer;
+}
+
+/* Brick red styling for super-user mode toggle when checked */
+.super-user-toggle .custom-control-input:checked ~ .custom-control-label::before {
+  background-color: #a52a2a;
+  border-color: #a52a2a;
+}
+
+.super-user-toggle .custom-control-input:checked ~ .custom-control-label::after {
+  background-color: #fff;
 }
 </style>

--- a/webapp/src/components/UserDropdown.vue
+++ b/webapp/src/components/UserDropdown.vue
@@ -70,7 +70,7 @@ export default {
       return this.$store.getters.getHasUnverifiedUser;
     },
     adminSuperUserMode() {
-      return this.$store.state.adminSuperUserMode;
+      return this.$store.getters.isAdminSuperUserModeActive;
     },
   },
   watch: {

--- a/webapp/src/components/datablocks/MediaBlock.vue
+++ b/webapp/src/components/datablocks/MediaBlock.vue
@@ -72,7 +72,7 @@ export default {
       return this.$store.state.blocksInfos["media"];
     },
     adminSuperUserMode() {
-      return this.$store.state.adminSuperUserMode;
+      return this.$store.getters.isAdminSuperUserModeActive;
     },
     media_url() {
       // If the API has already base64 encoded the image, then use it,
@@ -80,7 +80,10 @@ export default {
       if ((b64_encoding != null && b64_encoding[this.file_id]) || null != null) {
         return `data:image/png;base64,${b64_encoding[this.file_id]}`;
       }
-      const baseUrl = `${API_URL}/files/${this.file_id}/${this.lookup_file_field("name", this.file_id)}`;
+      const baseUrl = `${API_URL}/files/${this.file_id}/${this.lookup_file_field(
+        "name",
+        this.file_id,
+      )}`;
       return this.adminSuperUserMode ? `${baseUrl}?sudo=1` : baseUrl;
     },
     isPhoto() {

--- a/webapp/src/components/datablocks/MediaBlock.vue
+++ b/webapp/src/components/datablocks/MediaBlock.vue
@@ -71,13 +71,17 @@ export default {
     blockInfo() {
       return this.$store.state.blocksInfos["media"];
     },
+    adminSuperUserMode() {
+      return this.$store.state.adminSuperUserMode;
+    },
     media_url() {
       // If the API has already base64 encoded the image, then use it,
       let b64_encoding = this.block_data["b64_encoded_image"] || null;
       if ((b64_encoding != null && b64_encoding[this.file_id]) || null != null) {
         return `data:image/png;base64,${b64_encoding[this.file_id]}`;
       }
-      return `${API_URL}/files/${this.file_id}/${this.lookup_file_field("name", this.file_id)}`;
+      const baseUrl = `${API_URL}/files/${this.file_id}/${this.lookup_file_field("name", this.file_id)}`;
+      return this.adminSuperUserMode ? `${baseUrl}?sudo=1` : baseUrl;
     },
     isPhoto() {
       let extension = this.lookup_file_field("extension", this.file_id);

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -548,7 +548,7 @@ export async function getCurrentUser() {
       store.commit("setCurrentUserInfoLoading", false);
       store.state.currentUserInfoLoaded = true;
       currentUserPromise = null;
-      sessionStorage.removeItem("adminSuperUserMode");
+      store.commit("setAdminSuperUserMode", false);
       return null;
     });
 
@@ -558,7 +558,7 @@ export async function getCurrentUser() {
 export function invalidateCurrentUserCache() {
   currentUserCache = null;
   currentUserPromise = null;
-  sessionStorage.removeItem("adminSuperUserMode");
+  store.commit("setAdminSuperUserMode", false);
 }
 
 export async function requestMagicLink(email_address) {

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -126,6 +126,13 @@ function fetch_delete(url, body) {
  * @throws {Error} If file exceeds size limit or fetch fails
  */
 export async function fetch_file(url, maxSizeBytes = 100 * 1024 * 1024) {
+  // If admin super-user mode is enabled, append sudo=1
+  if (store.state.adminSuperUserMode) {
+    const urlObj = url instanceof URL ? url : new URL(url, window.location.origin);
+    urlObj.searchParams.set("sudo", "1");
+    url = urlObj.toString();
+  }
+
   const requestOptions = {
     method: "GET",
     headers: construct_headers(),

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -64,6 +64,13 @@ export function construct_headers(additional_headers = null) {
 
 // eslint-disable-next-line no-unused-vars
 function fetch_get(url) {
+  // If admin super-user mode is enabled, append sudo=1
+  if (store.state.adminSuperUserMode) {
+    const urlObj = url instanceof URL ? url : new URL(url, window.location.origin);
+    urlObj.searchParams.set("sudo", "1");
+    url = urlObj.toString();
+  }
+
   const requestOptions = {
     method: "GET",
     headers: construct_headers(),
@@ -512,6 +519,7 @@ export async function getCurrentUser() {
   if (currentUserCache !== null) {
     store.commit("setDisplayName", currentUserCache.display_name);
     store.commit("setCurrentUserID", currentUserCache.immutable_id);
+    store.commit("setCurrentUserRole", currentUserCache.role);
     store.commit("setIsUnverified", currentUserCache.account_status === "unverified");
     return currentUserCache;
   }
@@ -528,6 +536,7 @@ export async function getCurrentUser() {
         currentUserCache = response;
         store.commit("setDisplayName", response.display_name);
         store.commit("setCurrentUserID", response.immutable_id);
+        store.commit("setCurrentUserRole", response.role);
         store.commit("setIsUnverified", response.account_status === "unverified");
         store.commit("setCurrentUserInfoLoading", false);
         store.state.currentUserInfoLoaded = true;

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -65,7 +65,7 @@ export function construct_headers(additional_headers = null) {
 // eslint-disable-next-line no-unused-vars
 function fetch_get(url) {
   // If admin super-user mode is enabled, append sudo=1
-  if (store.state.adminSuperUserMode) {
+  if (store.getters.isAdminSuperUserModeActive) {
     const urlObj = url instanceof URL ? url : new URL(url, window.location.origin);
     urlObj.searchParams.set("sudo", "1");
     url = urlObj.toString();
@@ -134,7 +134,7 @@ function fetch_delete(url, body) {
  */
 export async function fetch_file(url, maxSizeBytes = 100 * 1024 * 1024) {
   // If admin super-user mode is enabled, append sudo=1
-  if (store.state.adminSuperUserMode) {
+  if (store.getters.isAdminSuperUserModeActive) {
     const urlObj = url instanceof URL ? url : new URL(url, window.location.origin);
     urlObj.searchParams.set("sudo", "1");
     url = urlObj.toString();
@@ -548,6 +548,7 @@ export async function getCurrentUser() {
       store.commit("setCurrentUserInfoLoading", false);
       store.state.currentUserInfoLoaded = true;
       currentUserPromise = null;
+      sessionStorage.removeItem("adminSuperUserMode");
       return null;
     });
 
@@ -557,6 +558,7 @@ export async function getCurrentUser() {
 export function invalidateCurrentUserCache() {
   currentUserCache = null;
   currentUserPromise = null;
+  sessionStorage.removeItem("adminSuperUserMode");
 }
 
 export async function requestMagicLink(email_address) {

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -38,6 +38,7 @@ export default createStore({
     blocksInfos: {},
     currentUserIsUnverified: false,
     hasUnverifiedUser: false,
+    adminSuperUserMode: sessionStorage.getItem("adminSuperUserMode") === "true", // Toggle state for admin super-user (sudo) mode
     datatablePaginationSettings: {
       samples: {
         page: 0,
@@ -363,6 +364,10 @@ export default createStore({
     },
     updateHasUnverified(state, hasUnverified) {
       state.hasUnverifiedUser = hasUnverified;
+    },
+    setAdminSuperUserMode(state, enabled) {
+      state.adminSuperUserMode = enabled;
+      sessionStorage.setItem("adminSuperUserMode", enabled);
     },
     setRows(state, { type, rows }) {
       state.datatablePaginationSettings[type].rows = rows;

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -31,6 +31,7 @@ export default createStore({
     fileSelectModalIsOpen: false,
     currentUserDisplayName: null,
     currentUserID: null,
+    currentUserRole: null,
     currentUserInfoLoading: false,
     currentUserInfoLoaded: false,
     currentUserInfoPromise: null,
@@ -90,6 +91,9 @@ export default createStore({
     },
     setCurrentUserID(state, userID) {
       state.currentUserID = userID;
+    },
+    setCurrentUserRole(state, role) {
+      state.currentUserRole = role;
     },
     setIsUnverified(state, isUnverified) {
       state.currentUserIsUnverified = isUnverified;
@@ -430,6 +434,14 @@ export default createStore({
       // userId can be a user ID string or null/undefined for combined activity
       const cacheKey = userId || "combined";
       return state.userActivityCache[cacheKey];
+    },
+    isAdminSuperUserModeActive(state) {
+      // Super-user mode is only active if: flag is set, user is logged in, and user is an admin
+      return (
+        state.adminSuperUserMode &&
+        state.currentUserDisplayName !== null &&
+        state.currentUserRole === "admin"
+      );
     },
   },
   actions: {

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -39,7 +39,7 @@ export default createStore({
     blocksInfos: {},
     currentUserIsUnverified: false,
     hasUnverifiedUser: false,
-    adminSuperUserMode: sessionStorage.getItem("adminSuperUserMode") === "true", // Toggle state for admin super-user (sudo) mode
+    adminSuperUserMode: false,
     datatablePaginationSettings: {
       samples: {
         page: 0,
@@ -371,7 +371,11 @@ export default createStore({
     },
     setAdminSuperUserMode(state, enabled) {
       state.adminSuperUserMode = enabled;
-      sessionStorage.setItem("adminSuperUserMode", enabled);
+      if (enabled) {
+        sessionStorage.setItem("adminSuperUserMode", enabled);
+      } else {
+        sessionStorage.removeItem("adminSuperUserMode");
+      }
     },
     setRows(state, { type, rows }) {
       state.datatablePaginationSettings[type].rows = rows;
@@ -435,13 +439,9 @@ export default createStore({
       const cacheKey = userId || "combined";
       return state.userActivityCache[cacheKey];
     },
-    isAdminSuperUserModeActive(state) {
+    isAdminSuperUserModeActive() {
       // Super-user mode is only active if: flag is set, user is logged in, and user is an admin
-      return (
-        state.adminSuperUserMode &&
-        state.currentUserDisplayName !== null &&
-        state.currentUserRole === "admin"
-      );
+      return sessionStorage.getItem("adminSuperUserMode");
     },
   },
   actions: {


### PR DESCRIPTION
This PR adds the `sudo=1` flag to many GET endpoints (primarily for items and files) to allow admins to request elevated permissions (currently the default). It then adds a UI toggle for this, that allows them to only pull items that are directly shared with them (via groups or creators) so that they can also operate as a normal user.