### PR TITLE
Prevent repeated clicks on collection export button

### DIFF
--- a/webapp/src/components/ExportButton.vue
+++ b/webapp/src/components/ExportButton.vue
@@ -68,6 +68,13 @@ export default {
         }
 
         const taskId = response.task_id;
+
+        DialogService.alert({
+          title: "Export in Progress",
+          message: `Your ${this.exportType} is being exported. This may take a few moments. You'll be notified when it's ready to download.`,
+          type: "info",
+        });
+
         this.pollExportStatus(taskId);
       } catch (error) {
         console.error("Export failed:", error);
@@ -90,10 +97,11 @@ export default {
             clearInterval(this.pollInterval);
             this.downloadExport(taskId);
             this.isExporting = false;
+            DialogService.closeCurrentDialog(true);
             DialogService.alert({
               title: "Export Complete",
               message: `Your ${this.exportType} has been exported successfully.`,
-              type: "info",
+              type: "success",
             });
           } else if (status.status === "error") {
             clearInterval(this.pollInterval);

--- a/webapp/src/components/SampleGraphExportModal.vue
+++ b/webapp/src/components/SampleGraphExportModal.vue
@@ -277,6 +277,12 @@ export default {
         if (this.exportOnlyThisItem) {
           const response = await startItemExport(this.itemId);
           const taskId = response.task_id;
+          DialogService.alert({
+            title: "Export in Progress",
+            message:
+              "Your item is being exported. This may take a few moments. You'll be notified when it's ready to download.",
+            type: "info",
+          });
           this.pollExportStatus(taskId);
           return;
         }
@@ -322,6 +328,13 @@ export default {
         });
         const taskId = response.task_id;
 
+        DialogService.alert({
+          title: "Export in Progress",
+          message:
+            "Your items are being exported. This may take a few moments. You'll be notified when it's ready to download.",
+          type: "info",
+        });
+
         this.pollExportStatus(taskId);
       } catch (error) {
         console.error("Export failed:", error);
@@ -343,11 +356,13 @@ export default {
             this.downloadExport(taskId);
             this.isExporting = false;
             this.isModalOpen = false;
+            DialogService.closeCurrentDialog(true);
+
             DialogService.alert({
               title: "Export Complete",
               message:
                 "Your items have been exported successfully and the download should begin shortly.",
-              type: "info",
+              type: "success",
             });
           } else if (status.status === "error") {
             clearInterval(this.pollInterval);


### PR DESCRIPTION
Closes #1547

**Changes:**
- Add "Export in Progress" dialog immediately when export starts
- Change completion dialog from info to success type
- Automatically close progress dialog before showing success dialog
- Only close progress dialog if one is currently displayed (prevents issues with fast exports)