### PR TITLE
Show locations where present in item select

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -449,6 +449,7 @@ def search_items():
                 "chemform": 1,
                 "refcode": 1,
                 "status": 1,
+                "location": 1,
             }
         }
     )

--- a/webapp/src/components/FormattedItemName.vue
+++ b/webapp/src/components/FormattedItemName.vue
@@ -11,7 +11,8 @@
       {{ item_id }}
     </span>
     {{ shortenedName }}
-    <span v-if="chemform && chemform != ' '"> [ <ChemicalFormula :formula="chemform" /> ] </span>
+    <span v-if="chemform && chemform != ''"> [ <ChemicalFormula :formula="chemform" /> ] </span>
+    <span v-if="location && location != ''"> ({{ location }}) </span>
   </span>
   <span v-else>
     <font-awesome-icon v-if="selecting" :icon="['far', 'plus-square']" />
@@ -39,6 +40,10 @@ export default {
       default: "",
     },
     chemform: {
+      type: String,
+      default: "",
+    },
+    location: {
       type: String,
       default: "",
     },

--- a/webapp/src/components/ItemSelect.vue
+++ b/webapp/src/components/ItemSelect.vue
@@ -16,7 +16,7 @@
       <span v-if="searching"> Sorry, no matches found. </span>
       <span v-else class="empty-search"> Type a search term... </span>
     </template>
-    <template #option="{ type, item_id, name, chemform, status }">
+    <template #option="{ type, item_id, name, chemform, status, location }">
       <span v-if="status != 'dummy'" class="item-status"
         ><FormattedItemStatus :status="status"
       /></span>
@@ -26,6 +26,7 @@
         :name="name"
         :selecting="true"
         :chemform="chemform"
+        :location="location"
         enable-modified-click
         :max-length="formattedItemNameMaxLength"
       />
@@ -116,6 +117,7 @@ export default {
         item_id: "",
         name: newOption,
         type: "none",
+        location: "",
         status: "dummy",
       };
     },


### PR DESCRIPTION
This helps disambiguate across e.g., shared chemical inventories.