### PR TITLE
Table layout tweaks: partition button groups, increase width and combine table settings

### DIFF
--- a/pydatalab/src/pydatalab/bokeh_plots.py
+++ b/pydatalab/src/pydatalab/bokeh_plots.py
@@ -299,7 +299,7 @@ def selectable_axes_plot(
 
     p = figure(
         sizing_mode="scale_width",
-        aspect_ratio=kwargs.pop("aspect_ratio", 1.5),
+        aspect_ratio=kwargs.pop("aspect_ratio", 2),
         x_axis_label=x_axis_label,
         y_axis_label=y_axis_label,
         tools=TOOLS,

--- a/webapp/src/components/DynamicDataTableButtons.vue
+++ b/webapp/src/components/DynamicDataTableButtons.vue
@@ -18,99 +18,97 @@
       </div>
     </div>
 
-    <div class="d-flex justify-content-between align-items-center">
-      <div class="button-left">
+    <div class="button-bar">
+      <div v-if="dataType === 'samples'" class="btn-action-group">
         <button
-          v-if="dataType === 'samples'"
           data-testid="add-item-button"
-          class="btn btn-default ml-2"
+          class="btn btn-default btn-action"
           @click="$emit('open-create-item-modal')"
         >
           Add an item
         </button>
         <button
-          v-if="dataType === 'samples'"
           data-testid="batch-item-button"
-          class="btn btn-default ml-2"
+          class="btn btn-default btn-action"
           @click="$emit('open-batch-create-item-modal')"
         >
           Add batch of items
         </button>
         <button
-          v-if="dataType === 'samples'"
           data-testid="scan-qr-button"
-          class="btn btn-default ml-2"
+          class="btn btn-default btn-action"
           aria-label="Scan QR code"
           title="Scan QR code"
           @click="$emit('open-qr-scanner-modal')"
         >
-          <font-awesome-icon icon="qrcode" />
-        </button>
-        <button
-          v-if="dataType === 'collections'"
-          data-testid="add-collection-button"
-          class="btn btn-default ml-2"
-          @click="$emit('open-create-collection-modal')"
-        >
-          Create new collection
-        </button>
-        <button
-          v-if="dataType === 'startingMaterials' && editableInventory"
-          data-testid="add-starting-material-button"
-          class="btn btn-default ml-2"
-          @click="$emit('open-create-item-modal')"
-        >
-          Add a starting material
-        </button>
-        <button
-          v-if="dataType === 'equipment'"
-          data-testid="add-equipment-button"
-          class="btn btn-default ml-2"
-          @click="$emit('open-create-equipment-modal')"
-        >
-          Add an item
+          <font-awesome-icon icon="qrcode" /> Scan QR code
         </button>
       </div>
+      <button
+        v-if="dataType === 'collections'"
+        data-testid="add-collection-button"
+        class="btn btn-default"
+        @click="$emit('open-create-collection-modal')"
+      >
+        Create new collection
+      </button>
+      <button
+        v-if="dataType === 'startingMaterials' && editableInventory"
+        data-testid="add-starting-material-button"
+        class="btn btn-default"
+        @click="$emit('open-create-item-modal')"
+      >
+        Add a starting material
+      </button>
+      <button
+        v-if="dataType === 'equipment'"
+        data-testid="add-equipment-button"
+        class="btn btn-default"
+        @click="$emit('open-create-equipment-modal')"
+      >
+        Add an item
+      </button>
 
-      <div class="button-right d-flex">
-        <MultiSelect
-          :model-value="selectedColumns"
-          :options="availableColumns"
-          :option-label="columnLabel"
-          placeholder="Select column(s) to display"
-          display="chip"
-          @update:model-value="$emit('update:selected-columns', $event)"
-        >
-          <template #value="{ value }">
-            <span v-if="value && value.length == availableColumns.length" class="text-gray-400"
-              >All columns displayed</span
-            >
-            <span v-else>{{ value.length }} columns displayed</span>
-          </template>
-        </MultiSelect>
+      <div class="button-bar-spacer"></div>
 
-        <IconField class="ml-2">
-          <InputIcon>
-            <font-awesome-icon icon="search" />
-          </InputIcon>
-          <InputText
-            v-model="localFilters.global.value"
-            data-testid="search-input"
-            class="search-input"
-            placeholder="Search"
-          />
-        </IconField>
+      <MultiSelect
+        :model-value="selectedColumns"
+        :options="availableColumns"
+        :option-label="columnLabel"
+        placeholder="Select column(s) to display"
+        display="chip"
+        class="column-select"
+        @update:model-value="$emit('update:selected-columns', $event)"
+      >
+        <template #value="{ value }">
+          <span v-if="value && value.length == availableColumns.length" class="text-gray-400"
+            >All columns displayed</span
+          >
+          <span v-else>{{ value.length }} columns displayed</span>
+        </template>
+      </MultiSelect>
 
-        <button
-          data-testid="reset-table-button"
-          class="btn btn-default ml-2"
-          aria-label="Reset table"
-          title="Reset table"
-          @click="resetTable"
-        >
-          <font-awesome-icon icon="redo" />
-        </button>
-      </div>
+      <IconField class="search-field">
+        <InputIcon>
+          <font-awesome-icon icon="search" />
+        </InputIcon>
+        <InputText
+          v-model="localFilters.global.value"
+          data-testid="search-input"
+          class="search-input"
+          placeholder="Search"
+        />
+      </IconField>
+
+      <button
+        data-testid="reset-table-button"
+        class="btn btn-default"
+        aria-label="Reset table"
+        title="Reset table"
+        @click="resetTable"
+      >
+        <font-awesome-icon icon="redo" />
+      </button>
     </div>
 
     <div v-if="itemsSelected.length > 0" class="d-flex justify-content-end align-items-center mt-2">
@@ -358,11 +356,59 @@ export default {
 </script>
 
 <style scoped>
+.button-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.btn-action-group {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.btn-action {
+  flex: 1;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.button-bar-spacer {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.column-select {
+  flex: 0 1 auto;
+  min-width: 120px;
+  max-width: 220px;
+}
+
+.column-select :deep(.p-multiselect) {
+  height: calc(1.5em + 0.75rem + 2px);
+  align-items: center;
+}
+
+.search-field {
+  flex: 0 1 auto;
+  min-width: 100px;
+  max-width: 200px;
+}
+
+.search-field :deep(.p-inputtext) {
+  height: calc(1.5em + 0.75rem + 2px);
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
 .search-input {
   height: calc(1.5em + 0.75rem + 2px);
   padding: 0.375rem 0.75rem;
   font-size: 1rem;
   line-height: 1.5;
   border-radius: 0.25rem;
+  width: 100%;
 }
 </style>

--- a/webapp/src/components/DynamicDataTableButtons.vue
+++ b/webapp/src/components/DynamicDataTableButtons.vue
@@ -71,44 +71,63 @@
 
       <div class="button-bar-spacer"></div>
 
-      <MultiSelect
-        :model-value="selectedColumns"
-        :options="availableColumns"
-        :option-label="columnLabel"
-        placeholder="Select column(s) to display"
-        display="chip"
-        class="column-select"
-        @update:model-value="$emit('update:selected-columns', $event)"
-      >
-        <template #value="{ value }">
-          <span v-if="value && value.length == availableColumns.length" class="text-gray-400"
-            >All columns displayed</span
+      <div class="search-settings-group">
+        <IconField class="search-field">
+          <InputIcon>
+            <font-awesome-icon icon="search" />
+          </InputIcon>
+          <InputText
+            v-model="localFilters.global.value"
+            data-testid="search-input"
+            class="search-input"
+            placeholder="Search"
+          />
+        </IconField>
+
+        <div class="dropdown">
+          <button
+            data-testid="table-settings-button"
+            class="btn btn-default"
+            type="button"
+            aria-label="Table settings"
+            title="Table settings"
+            aria-haspopup="true"
+            :aria-expanded="isSettingsDropdownVisible"
+            @click="isSettingsDropdownVisible = !isSettingsDropdownVisible"
           >
-          <span v-else>{{ value.length }} columns displayed</span>
-        </template>
-      </MultiSelect>
-
-      <IconField class="search-field">
-        <InputIcon>
-          <font-awesome-icon icon="search" />
-        </InputIcon>
-        <InputText
-          v-model="localFilters.global.value"
-          data-testid="search-input"
-          class="search-input"
-          placeholder="Search"
-        />
-      </IconField>
-
-      <button
-        data-testid="reset-table-button"
-        class="btn btn-default"
-        aria-label="Reset table"
-        title="Reset table"
-        @click="resetTable"
-      >
-        <font-awesome-icon icon="redo" />
-      </button>
+            <font-awesome-icon icon="cog" />
+          </button>
+          <div
+            v-show="isSettingsDropdownVisible"
+            class="dropdown-menu dropdown-menu-right settings-dropdown"
+            style="display: block"
+          >
+            <div class="dropdown-item-text">
+              <label class="mb-1 font-weight-bold">Columns</label>
+              <MultiSelect
+                :model-value="selectedColumns"
+                :options="availableColumns"
+                :option-label="columnLabel"
+                placeholder="Select column(s) to display"
+                display="chip"
+                class="column-select-dropdown"
+                @update:model-value="$emit('update:selected-columns', $event)"
+              >
+                <template #value="{ value }">
+                  <span v-if="value && value.length == availableColumns.length" class="text-muted"
+                    >All columns</span
+                  >
+                  <span v-else>{{ value.length }} columns</span>
+                </template>
+              </MultiSelect>
+            </div>
+            <div class="dropdown-divider"></div>
+            <a data-testid="reset-table-button" class="dropdown-item" @click="resetTable">
+              <font-awesome-icon icon="redo" class="mr-2" /> Reset table settings
+            </a>
+          </div>
+        </div>
+      </div>
     </div>
 
     <div v-if="itemsSelected.length > 0" class="d-flex justify-content-end align-items-center mt-2">
@@ -248,6 +267,7 @@ export default {
     return {
       localFilters: { ...this.filters },
       isSelectedDropdownVisible: false,
+      isSettingsDropdownVisible: false,
       isDeletingItems: false,
       itemCount: 0,
     };
@@ -337,6 +357,7 @@ export default {
       return option.label || option.header || option.field;
     },
     async resetTable() {
+      this.isSettingsDropdownVisible = false;
       const confirmed = await DialogService.confirm({
         title: "Confirm reset",
         message:
@@ -379,20 +400,16 @@ export default {
   min-width: 0;
 }
 
-.column-select {
+.search-settings-group {
+  display: flex;
+  gap: 0.5rem;
   flex: 0 1 auto;
-  min-width: 120px;
-  max-width: 220px;
-}
-
-.column-select :deep(.p-multiselect) {
-  height: calc(1.5em + 0.75rem + 2px);
-  align-items: center;
+  min-width: 0;
 }
 
 .search-field {
-  flex: 0 1 auto;
-  min-width: 100px;
+  flex: 1 1 80px;
+  min-width: 80px;
   max-width: 200px;
 }
 
@@ -409,6 +426,19 @@ export default {
   font-size: 1rem;
   line-height: 1.5;
   border-radius: 0.25rem;
+  width: 100%;
+}
+
+.settings-dropdown {
+  min-width: 220px;
+  padding: 0.5rem 0;
+}
+
+.dropdown-item-text {
+  padding: 0.5rem 1rem;
+}
+
+.column-select-dropdown {
   width: 100%;
 }
 </style>

--- a/webapp/src/views/Collections.vue
+++ b/webapp/src/views/Collections.vue
@@ -1,11 +1,9 @@
 <template>
   <Navbar />
 
-  <div id="tableContainer" class="container">
-    <div class="row">
-      <div class="col-sm-12 mx-auto">
-        <CollectionTable />
-      </div>
+  <div id="tableContainer" class="container-fluid">
+    <div class="w-100 px-5 mx-auto">
+      <CollectionTable />
     </div>
   </div>
 </template>

--- a/webapp/src/views/Equipment.vue
+++ b/webapp/src/views/Equipment.vue
@@ -1,11 +1,9 @@
 <template>
   <Navbar />
 
-  <div id="tableContainer" class="container">
-    <div class="row">
-      <div class="col-sm-12 mx-auto">
-        <EquipmentTable />
-      </div>
+  <div id="tableContainer" class="container-fluid">
+    <div class="w-100 px-5 mx-auto">
+      <EquipmentTable />
     </div>
   </div>
 </template>

--- a/webapp/src/views/Samples.vue
+++ b/webapp/src/views/Samples.vue
@@ -1,11 +1,9 @@
 <template>
   <Navbar />
 
-  <div id="tableContainer" class="container">
-    <div class="row">
-      <div class="col-sm-12 mx-auto">
-        <SampleTable />
-      </div>
+  <div id="tableContainer" class="container-fluid">
+    <div class="w-100 px-5 mx-auto">
+      <SampleTable />
     </div>
   </div>
 </template>

--- a/webapp/src/views/StartingMaterials.vue
+++ b/webapp/src/views/StartingMaterials.vue
@@ -1,11 +1,9 @@
 <template>
   <Navbar />
 
-  <div id="tableContainer" class="container">
-    <div class="row">
-      <div class="col-sm-12 mx-auto">
-        <StartingMaterialTable />
-      </div>
+  <div id="tableContainer" class="container-fluid">
+    <div class="w-100 px-5 mx-auto">
+      <StartingMaterialTable />
     </div>
   </div>
 </template>


### PR DESCRIPTION
Supersedes #1441. Updates the dynamic data table to:

- better group buttons into flexes
- increase table width by default
- combine table settings (column selector and reset button) into settings dropdown.

<details><summary>Before (1920x1080)</summary>
<img width="1920" height="1221" alt="image" src="https://github.com/user-attachments/assets/a9d9ca6c-2ee5-4f9e-9f62-31052170cb5d" /></details>

<details><summary>Before (narrow):</summary>
<img width="762" height="1457" alt="image" src="https://github.com/user-attachments/assets/f9d39f7f-db0e-4c85-a652-ce3d24d50dd9" /></details>


<details><summary>After (1920x1080):</summary>
<img width="1920" height="1217" alt="image" src="https://github.com/user-attachments/assets/296846a9-d156-4ee3-986b-3f11f3b0859f" /></details>

<details><summary>After (narrow):</summary>
<img width="748" height="1263" alt="image" src="https://github.com/user-attachments/assets/80be325b-2bee-4c9c-affe-5451571b7c4e" /></details>
