### PR TITLE
Add sharing API and UI for collections

### DIFF
--- a/pydatalab/src/pydatalab/permissions.py
+++ b/pydatalab/src/pydatalab/permissions.py
@@ -144,24 +144,13 @@ def check_access_token(refcode: str, token: str | None = None) -> bool:
         return False
 
 
-def get_default_permissions(
+def _get_base_permissions(
     user_only: bool = True, deleting: bool = False, elevate_permissions: bool = False
 ) -> dict[str, Any]:
-    """Return the MongoDB query terms corresponding to the current user.
-
-    Will return open permissions if a) the `CONFIG.TESTING` parameter is `True`,
-    or b) if the current user is registered as an admin and has opted into super-user
-    mode via `?sudo=1` (for GET requests) or is performing a write operation.
-
-    Parameters:
-        user_only: Whether to exclude items that also have no attached user (`False`),
-            i.e., public items. This should be set to `False` when reading (and wanting
-            to return public items), but left as `True` when modifying or removing items.
-        elevate_permissions: Whether to elevate this query's permissions, i.e., in the case
-            that an item-specific access token has been provided elsewhere.
-
+    """Build the MongoDB permission filter without collection-inheritance —
+    i.e., based purely on `creator_ids`/`group_ids` and the various admin/
+    testing/access-token short-circuits.
     """
-
     if CONFIG.TESTING:
         return {}
 
@@ -240,3 +229,63 @@ def get_default_permissions(
         return {"_id": -1}
 
     return null_perm
+
+
+def get_default_permissions(
+    user_only: bool = True,
+    deleting: bool = False,
+    elevate_permissions: bool = False,
+    inherit_from_collections: bool = True,
+) -> dict[str, Any]:
+    """Return the MongoDB query terms corresponding to the current user.
+
+    Will return open permissions if a) the `CONFIG.TESTING` parameter is `True`,
+    or b) if the current user is registered as an admin and has opted into super-user
+    mode via `?sudo=1` (for GET requests) or is performing a write operation.
+
+    For read paths (`user_only=False`), the filter is by default widened to
+    include any document whose `relationships` link it to a collection the
+    current user can read — i.e., items inherit read access from collections
+    they are members of. Write paths (`user_only=True`) never inherit;
+    collection membership grants read but not edit/delete on member items.
+
+    Parameters:
+        user_only: Whether to exclude items that also have no attached user (`False`),
+            i.e., public items. This should be set to `False` when reading (and wanting
+            to return public items), but left as `True` when modifying or removing items.
+        elevate_permissions: Whether to elevate this query's permissions, i.e., in the case
+            that an item-specific access token has been provided elsewhere.
+        inherit_from_collections: Whether read access should be inherited from
+            collections the user can read. Set this to `False` for endpoints
+            that should only show items the user directly owns or is a member
+            of (e.g., a "My samples" listing) — the user can still discover
+            collection-shared items by navigating into the collection. Has
+            no effect when `user_only=True`.
+
+    """
+    base = _get_base_permissions(
+        user_only=user_only, deleting=deleting, elevate_permissions=elevate_permissions
+    )
+    # Inheritance is read-only, and unnecessary when the base already
+    # short-circuits to a fully-open or fully-closed filter.
+    if user_only or not inherit_from_collections or base == {} or base == {"_id": -1}:
+        return base
+
+    collection_ids = [
+        doc["_id"]
+        for doc in flask_mongo.db.collections.find(
+            _get_base_permissions(user_only=False), {"_id": 1}
+        )
+    ]
+    if not collection_ids:
+        return base
+
+    inheritance = {
+        "relationships": {
+            "$elemMatch": {"type": "collections", "immutable_id": {"$in": collection_ids}}
+        }
+    }
+
+    if "$or" in base and len(base) == 1:
+        return {"$or": [*base["$or"], inheritance]}
+    return {"$or": [base, inheritance]}

--- a/pydatalab/src/pydatalab/routes/v0_1/collections.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/collections.py
@@ -26,7 +26,7 @@ def _(): ...
 def get_collections():
     collections = flask_mongo.db.collections.aggregate(
         [
-            {"$match": get_default_permissions(user_only=True)},
+            {"$match": get_default_permissions(user_only=False)},
             {"$lookup": creators_lookup()},
             {"$lookup": groups_lookup()},
             {"$project": {"_id": 0}},
@@ -44,7 +44,7 @@ def get_collection(collection_id):
             {
                 "$match": {
                     "collection_id": collection_id,
-                    **get_default_permissions(user_only=True),
+                    **get_default_permissions(user_only=False),
                 }
             },
             {"$lookup": creators_lookup()},
@@ -168,7 +168,7 @@ def create_collection():
         )
 
     result: InsertOneResult = flask_mongo.db.collections.insert_one(
-        data_model.dict(exclude={"creators"})
+        data_model.dict(exclude={"creators", "groups"})
     )
     if not result.acknowledged:
         return (
@@ -248,7 +248,15 @@ def save_collection(collection_id):
         )
 
     # These keys should not be updated here and cannot be modified by the user through this endpoint
-    for k in ("_id", "file_ObjectIds", "creators", "creator_ids", "collection_id"):
+    for k in (
+        "_id",
+        "file_ObjectIds",
+        "creators",
+        "creator_ids",
+        "collection_id",
+        "groups",
+        "group_ids",
+    ):
         if k in updated_data:
             del updated_data[k]
 
@@ -512,7 +520,7 @@ def search_collections():
     if not query:
         return jsonify({"status": "error", "message": "No query provided."}), 400
 
-    permissions = get_default_permissions(user_only=True)
+    permissions = get_default_permissions(user_only=False)
     pipeline = build_search_pipeline(query, COLLECTIONS_FTS_FIELDS, permissions)
     pipeline.append({"$limit": nresults})
 

--- a/pydatalab/src/pydatalab/routes/v0_1/collections.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/collections.py
@@ -8,14 +8,11 @@ from pydantic import ValidationError
 from pymongo.results import InsertOneResult, UpdateResult
 
 from pydatalab.config import CONFIG
-from pydatalab.logger import logged_route
+from pydatalab.logger import LOGGER, logged_route
 from pydatalab.models.collections import Collection
 from pydatalab.mongo import COLLECTIONS_FTS_FIELDS, build_search_pipeline, flask_mongo
 from pydatalab.permissions import active_users_or_get_only, get_default_permissions
-from pydatalab.routes.v0_1.items import (
-    creators_lookup,
-    get_items_summary,
-)
+from pydatalab.routes.v0_1.items import creators_lookup, get_items_summary, groups_lookup
 
 COLLECTIONS = Blueprint("collections", __name__)
 
@@ -31,6 +28,7 @@ def get_collections():
         [
             {"$match": get_default_permissions(user_only=True)},
             {"$lookup": creators_lookup()},
+            {"$lookup": groups_lookup()},
             {"$project": {"_id": 0}},
             {"$sort": {"_id": -1}},
         ]
@@ -50,6 +48,7 @@ def get_collection(collection_id):
                 }
             },
             {"$lookup": creators_lookup()},
+            {"$lookup": groups_lookup()},
             {"$sort": {"_id": -1}},
         ]
     )
@@ -125,6 +124,19 @@ def create_collection():
                 "gravatar_hash": current_user.person.gravatar_hash,
             }
         ]
+
+    if data.get("additional_creators"):
+        for c in data["additional_creators"]:
+            creator_id = c.get("_id") or c.get("immutable_id")
+            if creator_id:
+                data["creator_ids"].append(ObjectId(creator_id))
+
+    if data.get("groups"):
+        data["group_ids"] = []
+        for g in data["groups"]:
+            group_id = g.get("_id") or g.get("immutable_id")
+            if group_id:
+                data["group_ids"].append(ObjectId(group_id))
 
     # check to make sure that item_id isn't taken already
     if flask_mongo.db.collections.find_one({"collection_id": data["collection_id"]}):
@@ -285,6 +297,146 @@ def save_collection(collection_id):
         )
 
     return jsonify(status="success"), 200
+
+
+@COLLECTIONS.route("/collections/<collection_id>/permissions", methods=["PATCH"])
+def update_collection_permissions(collection_id: str):
+    """Update the permissions of a collection with the given collection_id."""
+    request_json = request.get_json()
+    creator_ids: list[ObjectId] = []
+    group_ids: list[ObjectId] = []
+
+    current_collection = flask_mongo.db.collections.find_one(
+        {"collection_id": collection_id, **get_default_permissions(user_only=True)},
+        {"_id": 1, "creator_ids": 1, "group_ids": 1},
+    )  # type: ignore
+
+    if not current_collection:
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": f"No valid collection found with the given {collection_id=}.",
+                }
+            ),
+            401,
+        )
+
+    current_creator_ids = current_collection["creator_ids"]
+
+    creators_requested = False
+    groups_requested = False
+
+    if "creators" in request_json and request_json["creators"] is not None:
+        creators_requested = True
+        new_creators = request_json["creators"]
+        if not isinstance(new_creators, list):
+            raise RuntimeError("Invalid creators list provided in request.")
+
+        creator_ids = [
+            ObjectId(creator.get("immutable_id", None))
+            for creator in request_json["creators"]
+            if creator.get("immutable_id", None) is not None
+        ]
+
+    if "groups" in request_json and request_json["groups"] is not None:
+        groups_requested = True
+        new_groups = request_json["groups"]
+        if not isinstance(new_groups, list):
+            raise RuntimeError("Invalid groups list provided in request.")
+
+        group_ids = [
+            ObjectId(group.get("immutable_id", None))
+            for group in request_json["groups"]
+            if group.get("immutable_id", None) is not None
+        ]
+
+    if not groups_requested and not creators_requested:
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": "No valid creator or group IDs found in the request.",
+                }
+            ),
+            400,
+        )
+
+    if creator_ids:
+        found_creator_ids = [
+            d for d in flask_mongo.db.users.find({"_id": {"$in": creator_ids}}, {"_id": 1})
+        ]  # type: ignore
+        if len(found_creator_ids) != len(creator_ids):
+            return (
+                jsonify(
+                    {
+                        "status": "error",
+                        "message": "One or more creator IDs not found in the database.",
+                    }
+                ),
+                400,
+            )
+
+    if group_ids:
+        found_group_ids = [
+            d for d in flask_mongo.db.groups.find({"_id": {"$in": group_ids}}, {"_id": 1})
+        ]  # type: ignore
+        if len(found_group_ids) != len(group_ids):
+            return (
+                jsonify(
+                    {
+                        "status": "error",
+                        "message": "One or more group IDs not found in the database.",
+                    }
+                ),
+                400,
+            )
+
+    if creator_ids and creators_requested:
+        current_user_id = current_user.person.immutable_id
+        try:
+            creator_ids.remove(current_user_id)
+        except ValueError:
+            pass
+        creator_ids.insert(0, current_user_id)
+
+        if current_creator_ids:
+            base_owner = current_creator_ids[0]
+            try:
+                creator_ids.remove(base_owner)
+            except ValueError:
+                pass
+            creator_ids.insert(0, base_owner)
+
+    LOGGER.warning(
+        "Setting permissions for collection %s to %s (creators) / %s (groups)",
+        collection_id,
+        creator_ids,
+        group_ids,
+    )
+
+    set_op = {}
+    if creators_requested:
+        set_op["creator_ids"] = creator_ids
+    if groups_requested:
+        set_op["group_ids"] = group_ids
+
+    LOGGER.debug("Updating collection %s with set op: %s", collection_id, set_op)
+
+    result = flask_mongo.db.collections.update_one(
+        {"collection_id": collection_id, **get_default_permissions(user_only=True)},
+        {"$set": set_op},
+    )
+
+    if result.matched_count != 1:
+        return jsonify(
+            {
+                "status": "error",
+                "message": "Failed to update permissions: collection not found or insufficient permissions.",
+            }
+        ), 400
+
+    return jsonify({"status": "success"}), 200
 
 
 @COLLECTIONS.route("/collections/<collection_id>", methods=["DELETE"])

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -88,7 +88,7 @@ def get_starting_materials():
                 {
                     "$match": {
                         "type": "starting_materials",
-                        **get_default_permissions(user_only=False),
+                        **get_default_permissions(user_only=False, inherit_from_collections=False),
                     }
                 },
                 {
@@ -215,7 +215,7 @@ def get_samples_summary(match: dict | None = None, project: dict | None = None) 
     """
     if not match:
         match = {}
-    match.update(get_default_permissions(user_only=False))
+    match.update(get_default_permissions(user_only=False, inherit_from_collections=False))
     match["type"] = {"$in": ["samples", "cells"]}
 
     _project = {

--- a/pydatalab/tests/server/test_permissions.py
+++ b/pydatalab/tests/server/test_permissions.py
@@ -445,3 +445,158 @@ def test_admin_super_user_mode(admin_client, client):
     # Admin can still PATCH/DELETE user's item without ?sudo=1 (non-GET methods unaffected)
     response = admin_client.patch(f"/items/{user_refcode}/permissions", json={"creators": []})
     assert response.status_code == 200
+
+
+def test_collection_permissions_update(admin_client, client, user_id, another_client):
+    """Admin creates a collection, shares it with a normal user via the
+    `/collections/<id>/permissions` endpoint, and verifies that the user can
+    then access it (whilst a third user still cannot)."""
+
+    collection_id = "shared-collection"
+    response = admin_client.put(
+        "/collections",
+        json={
+            "data": {
+                "collection_id": collection_id,
+                "title": "Shared collection",
+                "type": "collections",
+            }
+        },
+    )
+    assert response.status_code == 201, response.json
+
+    # Normal user cannot see it yet
+    assert client.get(f"/collections/{collection_id}").status_code == 404
+    # And it does not show up in their listing
+    listing = client.get("/collections").json["data"]
+    assert all(c["collection_id"] != collection_id for c in listing)
+
+    # Admin shares the collection with the normal user
+    response = admin_client.patch(
+        f"/collections/{collection_id}/permissions",
+        json={"creators": [{"immutable_id": str(user_id)}]},
+    )
+    assert response.status_code == 200, response.json
+
+    # Normal user can now access it
+    response = client.get(f"/collections/{collection_id}")
+    assert response.status_code == 200, response.json
+    assert response.json["data"]["collection_id"] == collection_id
+
+    # And it now appears in their listing
+    listing = client.get("/collections").json["data"]
+    assert any(c["collection_id"] == collection_id for c in listing)
+
+    # A third user without permission still cannot see it, nor does it show
+    # up in their listing
+    assert another_client.get(f"/collections/{collection_id}").status_code == 404
+    listing = another_client.get("/collections").json["data"]
+    assert all(c["collection_id"] != collection_id for c in listing)
+
+    # A non-permitted user cannot grant themselves access
+    response = another_client.patch(
+        f"/collections/{collection_id}/permissions",
+        json={"creators": [{"immutable_id": str(user_id)}]},
+    )
+    assert response.status_code != 200
+
+
+def test_collection_create_with_inlined_groups(admin_client, database, group_id):
+    """Creating a collection with an inlined `groups` payload (as the frontend
+    sends) should populate `group_ids` in the stored document, but should NOT
+    persist the inlined `groups` field — that is reserved for the read-time
+    `$lookup` join."""
+
+    collection_id = "collection-with-inlined-groups"
+    response = admin_client.put(
+        "/collections",
+        json={
+            "data": {
+                "collection_id": collection_id,
+                "title": "Collection with inlined groups",
+                "type": "collections",
+                "groups": [{"immutable_id": str(group_id)}],
+            }
+        },
+    )
+    assert response.status_code == 201, response.json
+
+    stored = database.collections.find_one({"collection_id": collection_id})
+    assert stored is not None
+    assert stored.get("group_ids") == [group_id]
+    # The inlined `groups` payload from the request must not be persisted —
+    # otherwise the read-time $lookup is shadowed by stale data.
+    assert "groups" not in stored or stored["groups"] is None
+
+
+def test_collection_visible_via_group_membership(admin_client, client, another_client, group_id):
+    """A collection shared with a group should be visible (both via the
+    listing and the detail endpoint) to all members of that group, not just
+    direct creators."""
+
+    collection_id = "group-shared-collection"
+    response = admin_client.put(
+        "/collections",
+        json={
+            "data": {
+                "collection_id": collection_id,
+                "title": "Group-shared collection",
+                "type": "collections",
+                "groups": [{"immutable_id": str(group_id)}],
+            }
+        },
+    )
+    assert response.status_code == 201, response.json
+
+    # Both group members can see it on the detail endpoint
+    assert client.get(f"/collections/{collection_id}").status_code == 200
+    assert another_client.get(f"/collections/{collection_id}").status_code == 200
+
+    # And, crucially, it must show up on the listing endpoint — the listing
+    # match must not be constrained to user_only permissions, otherwise
+    # group-shared collections never appear.
+    for c in (client, another_client):
+        listing = c.get("/collections").json["data"]
+        assert any(entry["collection_id"] == collection_id for entry in listing), (
+            f"group-shared collection missing from /collections listing for {c}"
+        )
+
+
+def test_collection_permissions_update_via_group(admin_client, client, another_client, group_id):
+    """Admin creates a collection, then shares it with a group via the
+    `/collections/<id>/permissions` endpoint, and verifies that members of
+    that group can access it (both detail and listing)."""
+
+    collection_id = "group-shared-via-patch"
+    response = admin_client.put(
+        "/collections",
+        json={
+            "data": {
+                "collection_id": collection_id,
+                "title": "Group-shared via PATCH",
+                "type": "collections",
+            }
+        },
+    )
+    assert response.status_code == 201, response.json
+
+    # Group members cannot see it yet
+    assert client.get(f"/collections/{collection_id}").status_code == 404
+    listing = client.get("/collections").json["data"]
+    assert all(c["collection_id"] != collection_id for c in listing)
+
+    # Admin shares the collection with the group
+    response = admin_client.patch(
+        f"/collections/{collection_id}/permissions",
+        json={"groups": [{"immutable_id": str(group_id)}]},
+    )
+    assert response.status_code == 200, response.json
+
+    # Both group members now have access via detail and listing
+    for c in (client, another_client):
+        response = c.get(f"/collections/{collection_id}")
+        assert response.status_code == 200, response.json
+        assert response.json["data"]["collection_id"] == collection_id
+
+        listing = c.get("/collections").json["data"]
+        assert any(entry["collection_id"] == collection_id for entry in listing)

--- a/pydatalab/tests/server/test_permissions.py
+++ b/pydatalab/tests/server/test_permissions.py
@@ -600,3 +600,128 @@ def test_collection_permissions_update_via_group(admin_client, client, another_c
 
         listing = c.get("/collections").json["data"]
         assert any(entry["collection_id"] == collection_id for entry in listing)
+
+
+def test_item_inherits_collection_read_access(admin_client, client, another_client, group_id):
+    """An item that is a member of a collection should be readable by anyone
+    who can read the collection, even if they are not directly named on the
+    item's `creator_ids` / `group_ids`. Write access does NOT inherit."""
+
+    item_id = "inherited-access-sample"
+    collection_id = "collection-with-inherited-item"
+
+    response = admin_client.post("/new-sample/", json={"type": "samples", "item_id": item_id})
+    assert response.status_code == 201, response.json
+    refcode = response.json["sample_list_entry"]["refcode"]
+
+    # Normal users cannot see it before the collection share
+    assert client.get(f"/items/{refcode}").status_code == 404
+    assert another_client.get(f"/items/{refcode}").status_code == 404
+
+    response = admin_client.put(
+        "/collections",
+        json={
+            "data": {
+                "collection_id": collection_id,
+                "title": "Collection that grants access",
+                "type": "collections",
+                "groups": [{"immutable_id": str(group_id)}],
+                "starting_members": [{"item_id": item_id}],
+            }
+        },
+    )
+    assert response.status_code == 201, response.json
+
+    # Group members can now read the item via inherited access
+    for c in (client, another_client):
+        response = c.get(f"/items/{refcode}")
+        assert response.status_code == 200, response.json
+        assert response.json["item_data"]["item_id"] == item_id
+
+    # But the item does NOT show up in their default /samples/ listing —
+    # that view is intentionally restricted to items the user directly owns
+    # or has been shared on. Collection-shared items are discoverable by
+    # navigating into the collection itself.
+    for c in (client, another_client):
+        listing = c.get("/samples/").json["samples"]
+        assert all(entry["item_id"] != item_id for entry in listing), (
+            f"inherited item should not appear in default /samples/ listing for {c}"
+        )
+
+    # But write access is NOT inherited
+    response = client.post(
+        "/save-item/", json={"item_id": item_id, "data": {"description": "hijack"}}
+    )
+    assert response.status_code != 200, response.json
+
+    response = client.post("/delete-sample/", json={"item_id": item_id})
+    assert response.status_code != 200, response.json
+
+
+def test_item_loses_inherited_access_when_removed_from_collection(
+    admin_client, client, group_id, database
+):
+    """Removing an item from a collection should revoke the inherited read access."""
+
+    item_id = "soon-to-be-removed-item"
+    collection_id = "collection-revoking-access"
+
+    response = admin_client.post("/new-sample/", json={"type": "samples", "item_id": item_id})
+    assert response.status_code == 201
+    refcode = response.json["sample_list_entry"]["refcode"]
+
+    response = admin_client.put(
+        "/collections",
+        json={
+            "data": {
+                "collection_id": collection_id,
+                "title": "Revoking collection",
+                "type": "collections",
+                "groups": [{"immutable_id": str(group_id)}],
+                "starting_members": [{"item_id": item_id}],
+            }
+        },
+    )
+    assert response.status_code == 201
+
+    assert client.get(f"/items/{refcode}").status_code == 200
+
+    database.items.update_one(
+        {"item_id": item_id},
+        {"$pull": {"relationships": {"type": "collections"}}},
+    )
+
+    assert client.get(f"/items/{refcode}").status_code == 404
+
+
+def test_item_loses_inherited_access_when_collection_unshared(admin_client, client, group_id):
+    """Revoking the group share on the collection should revoke inherited
+    access to its member items."""
+
+    item_id = "item-via-unshared-collection"
+    collection_id = "collection-to-unshare"
+
+    response = admin_client.post("/new-sample/", json={"type": "samples", "item_id": item_id})
+    assert response.status_code == 201
+    refcode = response.json["sample_list_entry"]["refcode"]
+
+    response = admin_client.put(
+        "/collections",
+        json={
+            "data": {
+                "collection_id": collection_id,
+                "title": "About to be unshared",
+                "type": "collections",
+                "groups": [{"immutable_id": str(group_id)}],
+                "starting_members": [{"item_id": item_id}],
+            }
+        },
+    )
+    assert response.status_code == 201
+
+    assert client.get(f"/items/{refcode}").status_code == 200
+
+    response = admin_client.patch(f"/collections/{collection_id}/permissions", json={"groups": []})
+    assert response.status_code == 200
+
+    assert client.get(f"/items/{refcode}").status_code == 404

--- a/webapp/src/components/CollectionInformation.vue
+++ b/webapp/src/components/CollectionInformation.vue
@@ -16,11 +16,17 @@
             </div>
           </div>
           <div class="form-row">
-            <div class="form-group col">
-              <label id="creators" class="mr-2">Creators</label>
-              <div>
-                <Creators :creators="CollectionCreators" aria-labelledby="creators" />
-              </div>
+            <div class="form-group col-md-6">
+              <ToggleableCreatorsFormGroup
+                v-model="CollectionCreators"
+                :collection-id="collection_id"
+              />
+            </div>
+            <div class="form-group col-md-6">
+              <ToggleableGroupsFormGroup
+                v-model="CollectionGroups"
+                :collection-id="collection_id"
+              />
             </div>
           </div>
         </div>
@@ -69,6 +75,8 @@ import CollectionRelationshipVisualization from "@/components/CollectionRelation
 import DynamicDataTable from "@/components/DynamicDataTable";
 import FormattedItemStatus from "@/components/FormattedItemStatus.vue";
 import ExportButton from "@/components/ExportButton";
+import ToggleableCreatorsFormGroup from "@/components/ToggleableCreatorsFormGroup";
+import ToggleableGroupsFormGroup from "@/components/ToggleableGroupsFormGroup";
 
 export default {
   components: {
@@ -78,6 +86,8 @@ export default {
     DynamicDataTable,
     FormattedItemStatus,
     ExportButton,
+    ToggleableCreatorsFormGroup,
+    ToggleableGroupsFormGroup,
   },
   props: {
     collection_id: {
@@ -131,8 +141,13 @@ export default {
     Title: createComputedSetterForCollectionField("title"),
     Name: createComputedSetterForCollectionField("name"),
     CollectionCreators: createComputedSetterForCollectionField("creators"),
+    CollectionGroups: createComputedSetterForCollectionField("groups"),
     children() {
       return this.$store.state.all_collection_children[this.collection_id] || [];
+    },
+    collectionRefcode() {
+      const collection = this.$store.state.all_collection_data[this.collection_id];
+      return collection?.refcode || null;
     },
   },
   created() {

--- a/webapp/src/components/CreateCollectionModal.vue
+++ b/webapp/src/components/CreateCollectionModal.vue
@@ -38,6 +38,24 @@
             />
           </div>
         </div>
+        <div class="form-row">
+          <div class="col-md-6 form-group">
+            <label id="shareWithGroupsLabel">(Optional) Share with groups:</label>
+            <GroupSelect
+              v-model="shareWithGroups"
+              aria-labelledby="shareWithGroupsLabel"
+              multiple
+            />
+          </div>
+          <div class="col-md-6 form-group">
+            <label id="additionalCreatorsLabel">(Optional) Additional creators:</label>
+            <UserSelect
+              v-model="additionalCreators"
+              aria-labelledby="additionalCreatorsLabel"
+              multiple
+            />
+          </div>
+        </div>
       </template>
     </Modal>
   </form>
@@ -48,6 +66,8 @@ import { DialogService } from "@/services/DialogService";
 
 import Modal from "@/components/Modal.vue";
 import ItemSelect from "@/components/ItemSelect.vue";
+import GroupSelect from "@/components/GroupSelect.vue";
+import UserSelect from "@/components/UserSelect.vue";
 import { createNewCollection } from "@/server_fetch_utils.js";
 import { validateEntryID } from "@/field_utils.js";
 
@@ -56,6 +76,8 @@ export default {
   components: {
     Modal,
     ItemSelect,
+    GroupSelect,
+    UserSelect,
   },
   props: {
     modelValue: Boolean,
@@ -68,6 +90,8 @@ export default {
       selectedCollectionToCopy: null,
       startingMembers: [],
       takenCollectionIds: [],
+      shareWithGroups: [],
+      additionalCreators: [],
     };
   },
   computed: {
@@ -86,15 +110,27 @@ export default {
   },
   methods: {
     async submitForm() {
-      await createNewCollection(this.collection_id, this.title, {
-        starting_members: this.startingMembers,
-      })
+      console.log("new collection form submit triggered");
+
+      const groupsData = this.shareWithGroups.length > 0 ? this.shareWithGroups : null;
+      const additionalCreatorsData =
+        this.additionalCreators.length > 0 ? this.additionalCreators : null;
+
+      await createNewCollection(
+        this.collection_id,
+        this.title,
+        this.startingMembers,
+        groupsData,
+        additionalCreatorsData,
+      )
         .then(() => {
           this.$emit("update:modelValue", false); // close this modal
           // Disable scroll now that items are added to the top by default
           // document.getElementById(this.item_id).scrollIntoView({ behavior: "smooth" });
           this.collection_id = null;
           this.title = null;
+          this.shareWithGroups = [];
+          this.additionalCreators = [];
         })
         .catch((error) => {
           let id_error = false;

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -312,18 +312,28 @@ export function createNewSamples(
   });
 }
 
-export function createNewCollection(collection_id, title = "", startingData = {}, copyFrom = null) {
+export async function createNewCollection(
+  collection_id,
+  title,
+  startingMembers,
+  groups = null,
+  additionalCreators = null,
+) {
+  const starting_members_json = startingMembers
+    ? startingMembers.map((x) => ({ item_id: x.item_id, type: x.type }))
+    : [];
+
   return fetch_put(`${API_URL}/collections`, {
-    copy_from_collection_id: copyFrom,
     data: {
       collection_id: collection_id,
       title: title,
-      type: "collections",
-      ...startingData,
+      starting_members: starting_members_json,
+      groups: groups,
+      additional_creators: additionalCreators,
     },
   }).then(function (response_json) {
-    store.commit("prependToCollectionList", response_json.data);
-    return "success";
+    store.commit("addCollectionToCollectionList", response_json.data);
+    return response_json;
   });
 }
 
@@ -931,6 +941,31 @@ export function appendItemPermissions(refcode, creators = null, groups = null) {
       }
     },
   );
+}
+
+export function updateCollectionPermissions(collection_id, creators = null, groups = null) {
+  console.log("updateCollectionPermissions called with", collection_id, creators, groups);
+
+  const payload = { creators: creators, groups: groups };
+
+  return fetch_patch(`${API_URL}/collections/${collection_id}/permissions`, payload)
+    .then(function (response_json) {
+      if (response_json.status === "error") {
+        DialogService.error({
+          title: "Permission update failed",
+          message: `Failed to update permissions for collection ${collection_id}: ${response_json.message}`,
+        });
+        throw new Error(response_json.message);
+      }
+      return response_json;
+    })
+    .catch((error) => {
+      DialogService.error({
+        title: "Collection Permissions Update Failed",
+        message: `Error updating collection permissions: ${error}`,
+      });
+      throw error;
+    });
 }
 
 export function saveItem(item_id) {

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -298,7 +298,11 @@ export default createStore({
       //requires the following fields in payload:
       // item_id, block_data
       Object.assign(state.all_collection_data[payload.collection_id], payload.block_data);
-      state.saved_status_collections[payload.collection_id] = false;
+      if (payload.block_data.creators || payload.block_data.groups) {
+        return;
+      } else {
+        state.saved_status_collections[payload.collection_id] = false;
+      }
     },
     setItemSaved(state, payload) {
       // requires the following fields in payload:


### PR DESCRIPTION
Closes #1524

**Changes:**
- Add permission editors to collection edit page
- Add group/creator selectors to collection creation modal
- Add PATCH `/collections/<id>/permissions` endpoint
- Include groups lookup in collection GET requests

Collections now support the same permission system as items, with groups providing read-only access and creators having read-write access.

When a user has access to a collection as a creator or via group membership, they also get read access to the items within.