### PR TITLE
Add group-based inventory separation for equipment and starting materials

### DIFF
--- a/pydatalab/src/pydatalab/permissions.py
+++ b/pydatalab/src/pydatalab/permissions.py
@@ -183,6 +183,15 @@ def _get_base_permissions(
             {"creator_ids": {"$exists": False}},
         ]
     }
+
+    # Define permission for inventory items with no groups (accessible to all)
+    null_group_perm = {
+        "$or": [
+            {"group_ids": {"$size": 0}},
+            {"group_ids": {"$exists": False}},
+        ]
+    }
+
     if current_user.is_authenticated and current_user.person is not None:
         # find managed users under the given user (can later be expanded to groups)
         managed_users = list(
@@ -212,18 +221,21 @@ def _get_base_permissions(
         user_perm: dict[str, Any] = {"$or": user_perm_conditions}
 
         if user_only:
-            # TODO: remove this hack when permissions are refactored. Currently starting_materials and equipment
-            # are a special case that should be group editable, so even when the route has asked to only edit this
-            # user's stuff, we can also let starting materials and equipment through.
-
-            # If we are trying to delete, then make sure they cannot delete items that do not match their user
             if deleting:
                 return user_perm
-
-            user_perm = {"$or": [user_perm, {"type": {"$in": ["starting_materials", "equipment"]}}]}
-            return user_perm
-
-        return {"$or": [user_perm, null_perm]}
+            else:
+                inventory_types_perm = {
+                    "$and": [
+                        {"type": {"$in": ["starting_materials", "equipment"]}},
+                        null_group_perm,
+                    ]
+                }
+                return {"$or": [user_perm, inventory_types_perm]}
+        else:
+            inventory_types_perm = {
+                "$and": [{"type": {"$in": ["starting_materials", "equipment"]}}, null_group_perm]
+            }
+            return {"$or": [user_perm, null_perm, inventory_types_perm]}
 
     elif user_only:
         return {"_id": -1}

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -70,6 +70,7 @@ def get_equipment_summary():
                 {
                     "$match": {
                         "type": "equipment",
+                        **get_default_permissions(user_only=False),
                     }
                 },
                 {"$project": _project},
@@ -497,6 +498,49 @@ def search_items():
         else:
             pipeline.insert(0, {"$match": {"type": {"$in": types}}})
 
+    if current_user.is_authenticated and current_user.person is not None:
+        user_group_ids = []
+        if current_user.person.groups:
+            user_group_ids = [group.immutable_id for group in current_user.person.groups]
+
+        if user_group_ids:
+            pipeline.append(
+                {
+                    "$addFields": {
+                        "group_priority": {
+                            "$cond": {
+                                "if": {
+                                    "$or": [
+                                        {"$eq": [{"$size": {"$ifNull": ["$group_ids", []]}}, 0]},
+                                        {
+                                            "$gt": [
+                                                {
+                                                    "$size": {
+                                                        "$setIntersection": [
+                                                            "$group_ids",
+                                                            user_group_ids,
+                                                        ]
+                                                    }
+                                                },
+                                                0,
+                                            ]
+                                        },
+                                    ]
+                                },
+                                "then": 1,
+                                "else": 0,
+                            }
+                        }
+                    }
+                }
+            )
+
+            if any(stage.get("$sort") for stage in pipeline):
+                pipeline = [stage for stage in pipeline if "$sort" not in stage]
+                pipeline.append({"$sort": {"group_priority": -1, "score": {"$meta": "textScore"}}})
+            else:
+                pipeline.append({"$sort": {"group_priority": -1}})
+
     pipeline.append({"$limit": nresults})
     pipeline.append(
         {
@@ -622,10 +666,13 @@ def _create_sample(
     new_sample = sample_dict.copy()
 
     if type_ in ACCESSIBLE_TYPES:
-        # starting_materials and equipment are open to all in the deploment at this point,
-        # so no creators are assigned
         new_sample["creator_ids"] = []
         new_sample["creators"] = []
+
+        if sample_dict.get("groups"):
+            new_sample["group_ids"] = []
+            for g in sample_dict["groups"]:
+                new_sample["group_ids"].append(ObjectId(g["immutable_id"]))
 
     elif CONFIG.TESTING and not current_user.is_authenticated:
         # Set fake ID to ObjectId("000000000000000000000000") so a dummy user can be created
@@ -637,6 +684,7 @@ def _create_sample(
             }
         ]
     else:
+        # For non-inventory items (samples, cells), handle creators and groups normally
         new_sample["creator_ids"] = [current_user.person.immutable_id]
         new_sample["creators"] = [
             {
@@ -644,6 +692,16 @@ def _create_sample(
                 "gravatar_hash": current_user.person.gravatar_hash,
             }
         ]
+
+        # Check for initialised sharing options, e.g., groups and other creators
+        if sample_dict.get("creators"):
+            for c in sample_dict["creators"]:
+                new_sample["creator_ids"].append(ObjectId(c["immutable_id"]))
+
+        if sample_dict.get("groups"):
+            new_sample["group_ids"] = []
+            for g in sample_dict["groups"]:
+                new_sample["group_ids"].append(ObjectId(g["immutable_id"]))
 
     # Check for initialised sharing options, e.g., groups and other creators
     if sample_dict.get("creators"):

--- a/webapp/src/components/EquipmentInformation.vue
+++ b/webapp/src/components/EquipmentInformation.vue
@@ -57,15 +57,18 @@
       </div>
     </div>
     <div class="form-row">
-      <div class="form-group col-md-8">
+      <div class="form-group col-md-5">
         <label for="equip-contact" class="mr-2">Contact information</label>
         <input id="equip-contact" v-model="Contact" class="form-control" />
       </div>
-      <div class="form-group col-md-3 col-sm-3 col-6 pb-3">
+      <div class="form-group col-md-3 pb-3">
         <ToggleableItemStatusFormGroup
           v-model="Status"
           :possible-item-statuses="possibleItemStatuses"
         />
+      </div>
+      <div class="form-group col-md-4 pb-3">
+        <ToggleableGroupsFormGroup v-model="ItemGroups" :refcode="Refcode" />
       </div>
     </div>
     <label id="equip-description-label" class="mr-2">Description</label>
@@ -89,6 +92,7 @@ import CollectionList from "@/components/CollectionList";
 import FormattedRefcode from "@/components/FormattedRefcode";
 import Creators from "@/components/Creators";
 import ToggleableItemStatusFormGroup from "@/components/ToggleableItemStatusFormGroup";
+import ToggleableGroupsFormGroup from "@/components/ToggleableGroupsFormGroup";
 
 export default {
   components: {
@@ -99,6 +103,7 @@ export default {
     FormattedRefcode,
     Creators,
     ToggleableItemStatusFormGroup,
+    ToggleableGroupsFormGroup,
   },
   props: {
     item_id: { type: String, required: true },
@@ -125,6 +130,7 @@ export default {
     EquipmentDate: createComputedSetterForItemField("date"),
     SerialNos: createComputedSetterForItemField("serial_numbers"),
     Maintainers: createComputedSetterForItemField("creators"),
+    ItemGroups: createComputedSetterForItemField("groups"),
     Contact: createComputedSetterForItemField("contact"),
     Status: createComputedSetterForItemField("status"),
     schema() {

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -45,7 +45,10 @@
           </div>
         </div>
         <div class="form-row">
-          <div class="form-group col-lg-12 col-sm-12">
+          <div class="form-group col-md-6 pb-3">
+            <ToggleableGroupsFormGroup v-model="ItemGroups" :refcode="Refcode" />
+          </div>
+          <div class="form-group col-lg-6 col-sm-6">
             <label for="startmat-location">Location</label>
             <AutoComplete
               v-model="Location"
@@ -59,7 +62,7 @@
           </div>
         </div>
         <div class="form-row">
-          <div class="form-group col-lg-3 col-sm-4">
+          <div class="form-group col-lg-4 col-sm-4">
             <label for="startmat-supplier">Supplier</label>
             <AutoComplete
               v-model="Supplier"
@@ -71,20 +74,20 @@
               @complete="filterSuppliers"
             />
           </div>
-          <div class="form-group col-lg-3 col-sm-4">
+          <div class="form-group col-lg-4 col-sm-4">
             <label for="startmat-purity">Chemical purity</label>
             <StyledInput id="startmat-purity" v-model="ChemicalPurity" :readonly="!isEditable" />
           </div>
-        </div>
-        <div class="form-row">
-          <div class="form-group col-lg-3 col-sm-3 col-6">
+          <div class="form-group col-lg-4 col-sm-4">
             <label for="startmat-cas">CAS</label>
             <a v-if="CAS" :href="'https://commonchemistry.cas.org/detail?cas_rn=' + CAS"
               ><font-awesome-icon icon="search" class="fixed-width ml-2"
             /></a>
             <StyledInput id="startmat-cas" v-model="CAS" :readonly="!isEditable" />
           </div>
-          <div class="form-group col-lg-3 col-sm-3 col-6">
+        </div>
+        <div class="form-row">
+          <div class="form-group col-lg-6 col-sm-6">
             <label for="startmat-date-opened">Date opened</label>
             <StyledInput
               id="startmat-date-opened"
@@ -126,6 +129,7 @@ import ChemFormulaInput from "@/components/ChemFormulaInput";
 import TableOfContents from "@/components/TableOfContents";
 import ToggleableCollectionFormGroup from "@/components/ToggleableCollectionFormGroup";
 import ToggleableItemStatusFormGroup from "@/components/ToggleableItemStatusFormGroup";
+import ToggleableGroupsFormGroup from "@/components/ToggleableGroupsFormGroup";
 import FormattedRefcode from "@/components/FormattedRefcode";
 import FormattedBarCode from "@/components/FormattedBarcode";
 import StyledInput from "@/components/StyledInput";
@@ -147,6 +151,7 @@ export default {
     TiptapInline,
     ToggleableCollectionFormGroup,
     ToggleableItemStatusFormGroup,
+    ToggleableGroupsFormGroup,
     TableOfContents,
     FormattedRefcode,
     FormattedBarCode,
@@ -183,6 +188,7 @@ export default {
     Location: createComputedSetterForItemField("location"),
     ItemDescription: createComputedSetterForItemField("description"),
     Collections: createComputedSetterForItemField("collections"),
+    ItemGroups: createComputedSetterForItemField("groups"),
     Refcode: createComputedSetterForItemField("refcode"),
     Status: createComputedSetterForItemField("status"),
     schema() {


### PR DESCRIPTION
Implements #1551

### Changes
- **Backend**: Apply group permissions to equipment/starting_materials endpoints
- **Frontend**: Add group selection to CreateEquipmentModal
- **Frontend**: Add ToggleableGroupsFormGroup to inventory edit pages

### Behavior
- Items with no groups → accessible to all users
- Items with groups → accessible only to group members

### Questions

- Is it the expected behavior that a user can share items with groups they are not a member of?
- “Maintainers” column in the equipment datatable is currently empty because the /equipment/ endpoints do not perform the MongoDB $lookup to populate creators and groups objects from their IDs. Is this intentional, or should these endpoints include the lookup?
