### PR TITLE
Lock down `/info/stats` endpoint and make about section optional

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/info.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/info.py
@@ -112,6 +112,7 @@ def get_info():
 
 
 @INFO.route("/info/stats", methods=["GET"])
+@active_users_or_get_only
 def get_stats():
     """Returns a dictionary of counts of each entry type in the deployment"""
 

--- a/webapp/src/components/StatisticsTable.vue
+++ b/webapp/src/components/StatisticsTable.vue
@@ -1,5 +1,6 @@
 <template>
   <div v-if="counts" class="mx-auto">
+    <h5 v-if="title">{{ title }}</h5>
     <table>
       <tbody>
         <tr>
@@ -22,6 +23,13 @@ import { getStats } from "@/server_fetch_utils.js";
 import { itemTypes } from "@/resources.js";
 
 export default {
+  props: {
+    title: {
+      type: String,
+      default: null,
+      required: false,
+    },
+  },
   data() {
     return {
       counts: null,
@@ -29,9 +37,7 @@ export default {
     };
   },
   async mounted() {
-    console.log(this.counts);
     this.counts = await getStats();
-    console.log(this.counts);
   },
 };
 </script>

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -268,7 +268,11 @@ export async function getStats() {
       return response_json.counts;
     })
     .catch((error) => {
-      throw error;
+      if (error === "UNAUTHORIZED") {
+        return null;
+      } else {
+        throw error;
+      }
     });
 }
 

--- a/webapp/src/views/About.vue
+++ b/webapp/src/views/About.vue
@@ -18,10 +18,7 @@
           >.
         </p>
 
-        <h5>Deployment stats:</h5>
-        <div class="mx-auto" style="width: 80%">
-          <StatisticsTable />
-        </div>
+        <StatisticsTable :title="'Deployment stats:'" />
 
         <UserActivityGraph :combined="true" :title="'User activity:'" />
 


### PR DESCRIPTION
This PR adds login requirement to view the number of samples/cells in a deployment and hides the corresponding section in the about page when the user is not logged in.