### PR TITLE
Migrate admin tables to PrimeVue with bulk operations

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/admin.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/admin.py
@@ -85,6 +85,21 @@ def get_users():
             {
                 "$lookup": {
                     "from": "groups",
+                    "let": {"group_ids": "$group_ids"},
+                    "pipeline": [
+                        {"$match": {"$expr": {"$in": ["$_id", {"$ifNull": ["$$group_ids", []]}]}}},
+                        {"$addFields": {"__order": {"$indexOfArray": ["$$group_ids", "$_id"]}}},
+                        {"$sort": {"__order": 1}},
+                        {"$project": {"_id": 1, "display_name": 1}},
+                    ],
+                    "as": "groups",
+                },
+            },
+            {
+                "$lookup": {
+                    "from": "groups",
+                    # Users store groups as [{immutable_id: ObjectId}] subdocuments (unlike items which use a flat group_ids list),
+                    # so $map is needed to extract the ObjectIds before $in can match against groups._id.
                     "let": {
                         "group_ids": {
                             "$map": {
@@ -209,17 +224,6 @@ def update_user_managers(user_id):
                 return jsonify(
                     {"status": "error", "message": f"Manager with ID {manager_id} not found"}
                 ), 404
-
-            manager_role = flask_mongo.db.roles.find_one({"_id": manager_oid})
-            actual_role = manager_role.get("role", "user") if manager_role else "user"
-
-            if actual_role not in ["admin", "manager"]:
-                return jsonify(
-                    {
-                        "status": "error",
-                        "message": f"User {manager_id} cannot be assigned as a manager: only users with 'admin' or 'manager' role can manage other users (current role: {actual_role})",
-                    }
-                ), 400
 
             if check_manager_cycle(user_id, manager_id):
                 return jsonify(

--- a/pydatalab/src/pydatalab/routes/v0_1/admin.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/admin.py
@@ -85,19 +85,6 @@ def get_users():
             {
                 "$lookup": {
                     "from": "groups",
-                    "let": {"group_ids": "$group_ids"},
-                    "pipeline": [
-                        {"$match": {"$expr": {"$in": ["$_id", {"$ifNull": ["$$group_ids", []]}]}}},
-                        {"$addFields": {"__order": {"$indexOfArray": ["$$group_ids", "$_id"]}}},
-                        {"$sort": {"__order": 1}},
-                        {"$project": {"_id": 1, "display_name": 1}},
-                    ],
-                    "as": "groups",
-                },
-            },
-            {
-                "$lookup": {
-                    "from": "groups",
                     # Users store groups as [{immutable_id: ObjectId}] subdocuments (unlike items which use a flat group_ids list),
                     # so $map is needed to extract the ObjectIds before $in can match against groups._id.
                     "let": {

--- a/pydatalab/tests/server/test_manager_assignment.py
+++ b/pydatalab/tests/server/test_manager_assignment.py
@@ -10,8 +10,6 @@ def test_assign_manager_success(admin_client, real_mongo_client):
     user_2 = db.users.insert_one({"display_name": "User 2"})
     user_2_id = user_2.inserted_id
 
-    db.roles.insert_one({"_id": user_1.inserted_id, "role": "manager"})
-
     response = admin_client.patch(f"/users/{user_2_id}/managers", json={"managers": [user_1_id]})
 
     assert response.status_code == 200
@@ -20,7 +18,6 @@ def test_assign_manager_success(admin_client, real_mongo_client):
     assert user_1_id in updated_user["managers"]
 
     db.users.delete_many({"_id": {"$in": [user_1.inserted_id, user_2.inserted_id]}})
-    db.roles.delete_one({"_id": user_1.inserted_id})
 
 
 def test_assign_manager_requires_admin(client, real_mongo_client):
@@ -48,9 +45,6 @@ def test_assign_manager_prevents_direct_cycle(admin_client, real_mongo_client):
     user_2 = db.users.insert_one({"display_name": "User 2"})
     user_2_id = user_2.inserted_id
 
-    db.roles.insert_one({"_id": user_1.inserted_id, "role": "manager"})
-    db.roles.insert_one({"_id": user_2.inserted_id, "role": "manager"})
-
     response = admin_client.patch(f"/users/{user_2_id}/managers", json={"managers": [user_1_id]})
     assert response.status_code == 200
 
@@ -60,27 +54,22 @@ def test_assign_manager_prevents_direct_cycle(admin_client, real_mongo_client):
     assert "circular" in response.json["message"].lower()
 
     db.users.delete_many({"_id": {"$in": [user_1.inserted_id, user_2.inserted_id]}})
-    db.roles.delete_many({"_id": {"$in": [user_1.inserted_id, user_2.inserted_id]}})
 
 
 def test_manager_double_cycle(admin_client, real_mongo_client):
     db = real_mongo_client.get_database()
 
     user_1 = db.users.insert_one({"display_name": "User 1"})
-    db.roles.insert_one({"_id": user_1.inserted_id, "role": "manager"})
 
     user_1_id = user_1.inserted_id
 
     user_2 = db.users.insert_one({"display_name": "User 2"})
-    db.roles.insert_one({"_id": user_2.inserted_id, "role": "manager"})
     user_2_id = user_2.inserted_id
 
     user_3 = db.users.insert_one({"display_name": "User 3"})
-    db.roles.insert_one({"_id": user_3.inserted_id, "role": "manager"})
     user_3_id = user_3.inserted_id
 
     user_4 = db.users.insert_one({"display_name": "User 4"})
-    db.roles.insert_one({"_id": user_4.inserted_id, "role": "manager"})
     user_4_id = user_4.inserted_id
 
     # Check that the following hierarchy is forbidden:
@@ -119,41 +108,25 @@ def test_manager_double_cycle(admin_client, real_mongo_client):
             }
         }
     )
-    db.roles.delete_many(
-        {
-            "_id": {
-                "$in": [
-                    user_1.inserted_id,
-                    user_2.inserted_id,
-                    user_3.inserted_id,
-                    user_4.inserted_id,
-                ]
-            }
-        }
-    )
 
 
 def test_manager_double_cycle_inverse(admin_client, real_mongo_client):
     db = real_mongo_client.get_database()
 
     user_1 = db.users.insert_one({"display_name": "User 1"})
-    db.roles.insert_one({"_id": user_1.inserted_id, "role": "manager"})
+
     user_1_id = str(user_1.inserted_id)
 
     user_2 = db.users.insert_one({"display_name": "User 2"})
-    db.roles.insert_one({"_id": user_2.inserted_id, "role": "manager"})
     user_2_id = str(user_2.inserted_id)
 
     user_3 = db.users.insert_one({"display_name": "User 3"})
-    db.roles.insert_one({"_id": user_3.inserted_id, "role": "manager"})
     user_3_id = str(user_3.inserted_id)
 
     user_4 = db.users.insert_one({"display_name": "User 4"})
-    db.roles.insert_one({"_id": user_4.inserted_id, "role": "manager"})
     user_4_id = str(user_4.inserted_id)
 
     user_5 = db.users.insert_one({"display_name": "User 5"})
-    db.roles.insert_one({"_id": user_5.inserted_id, "role": "manager"})
     user_5_id = str(user_5.inserted_id)
 
     # Similar to the above, check that the following hierarchy is forbidden:
@@ -193,9 +166,6 @@ def test_assign_manager_prevents_deep_cycle(admin_client, real_mongo_client):
     user_3 = db.users.insert_one({"display_name": "User 3"})
     user_3_id = str(user_3.inserted_id)
 
-    for uid in [user_1.inserted_id, user_2.inserted_id, user_3.inserted_id]:
-        db.roles.insert_one({"_id": uid, "role": "manager"})
-
     admin_client.patch(f"/users/{user_2_id}/managers", json={"managers": [user_1_id]})
     admin_client.patch(f"/users/{user_3_id}/managers", json={"managers": [user_2_id]})
 
@@ -205,9 +175,6 @@ def test_assign_manager_prevents_deep_cycle(admin_client, real_mongo_client):
     assert "circular" in response.json["message"].lower()
 
     db.users.delete_many(
-        {"_id": {"$in": [user_1.inserted_id, user_2.inserted_id, user_3.inserted_id]}}
-    )
-    db.roles.delete_many(
         {"_id": {"$in": [user_1.inserted_id, user_2.inserted_id, user_3.inserted_id]}}
     )
 
@@ -224,9 +191,6 @@ def test_assign_manager_allows_hierarchy(admin_client, real_mongo_client):
     user_3 = db.users.insert_one({"display_name": "User 3"})
     user_3_id = str(user_3.inserted_id)
 
-    for uid in [user_1.inserted_id, user_2.inserted_id]:
-        db.roles.insert_one({"_id": uid, "role": "manager"})
-
     response = admin_client.patch(f"/users/{user_2_id}/managers", json={"managers": [user_1_id]})
     assert response.status_code == 200
 
@@ -236,7 +200,6 @@ def test_assign_manager_allows_hierarchy(admin_client, real_mongo_client):
     db.users.delete_many(
         {"_id": {"$in": [user_1.inserted_id, user_2.inserted_id, user_3.inserted_id]}}
     )
-    db.roles.delete_many({"_id": {"$in": [user_1.inserted_id, user_2.inserted_id]}})
 
 
 def test_remove_manager_assignment(admin_client, real_mongo_client):
@@ -248,8 +211,6 @@ def test_remove_manager_assignment(admin_client, real_mongo_client):
     user_2 = db.users.insert_one({"display_name": "User 2", "managers": [user_1_id]})
     user_2_id = str(user_2.inserted_id)
 
-    db.roles.insert_one({"_id": user_1.inserted_id, "role": "manager"})
-
     response = admin_client.patch(f"/users/{user_2_id}/managers", json={"managers": []})
 
     assert response.status_code == 200
@@ -258,7 +219,6 @@ def test_remove_manager_assignment(admin_client, real_mongo_client):
     assert updated_user["managers"] == []
 
     db.users.delete_many({"_id": {"$in": [user_1.inserted_id, user_2.inserted_id]}})
-    db.roles.delete_one({"_id": user_1.inserted_id})
 
 
 def test_assign_nonexistent_manager(admin_client, real_mongo_client):
@@ -297,8 +257,6 @@ def test_manager_can_see_managed_user_items(admin_client, real_mongo_client, use
     user_1 = db.users.insert_one({"display_name": "User 1"})
     user_1_id = str(user_1.inserted_id)
 
-    db.roles.insert_one({"_id": user_1.inserted_id, "role": "manager"})
-
     response = admin_client.patch(f"/users/{str(user_id)}/managers", json={"managers": [user_1_id]})
     assert response.status_code == 200
 
@@ -317,7 +275,6 @@ def test_manager_can_see_managed_user_items(admin_client, real_mongo_client, use
     assert response.status_code == 200
 
     db.users.delete_one({"_id": user_1.inserted_id})
-    db.roles.delete_one({"_id": user_1.inserted_id})
 
 
 def test_manager_cycle_infinite_loop(admin_client, real_mongo_client):
@@ -326,8 +283,7 @@ def test_manager_cycle_infinite_loop(admin_client, real_mongo_client):
 
     user_docs = [{"display_name": f"User {i}"} for i in range(1, 100)]
     ids = db.users.insert_many(user_docs)
-    for inserted_id in ids.inserted_ids:
-        db.roles.insert_one({"_id": inserted_id, "role": "manager"})
+
     for i in range(len(ids.inserted_ids) - 1):
         resp = admin_client.patch(
             f"/users/{str(ids.inserted_ids[i + 1])}/managers",

--- a/pydatalab/tests/server/test_permissions.py
+++ b/pydatalab/tests/server/test_permissions.py
@@ -143,9 +143,6 @@ def test_manager_permissions(
     assert response.status_code == 201
     refcode = response.json["sample_list_entry"]["refcode"]
 
-    db = real_mongo_client.get_database()
-    db.roles.update_one({"_id": another_user_id}, {"$set": {"role": "manager"}}, upsert=True)
-
     # Add manager to the original user
     response = admin_client.patch(
         f"/users/{user_id}/managers", json={"managers": [str(another_user_id)]}
@@ -173,8 +170,6 @@ def test_manager_permissions(
 
     # Also removes read access
     assert another_client.get(f"/items/{refcode}").status_code == 404
-
-    db.roles.update_one({"_id": another_user_id}, {"$set": {"role": "user"}})
 
 
 def test_group_permissions(client, another_client, user_id, another_user_id, group_id):

--- a/webapp/cypress/component/CollectionTableTest.cy.jsx
+++ b/webapp/cypress/component/CollectionTableTest.cy.jsx
@@ -1,4 +1,6 @@
 import CollectionTable from "@/components/CollectionTable.vue";
+import UserBubble from "@/components/UserBubble.vue";
+import StyledTooltip from "@/components/StyledTooltip.vue";
 import PrimeVue from "primevue/config";
 import { createStore } from "vuex";
 
@@ -36,6 +38,10 @@ describe("CollectionTable Component Tests", () => {
     cy.mount(CollectionTable, {
       global: {
         plugins: [store, PrimeVue],
+        components: {
+          UserBubble,
+          StyledTooltip,
+        },
       },
     });
   });

--- a/webapp/cypress/component/EquipmentTableTest.cy.jsx
+++ b/webapp/cypress/component/EquipmentTableTest.cy.jsx
@@ -1,4 +1,6 @@
 import EquipmentTable from "@/components/EquipmentTable.vue";
+import UserBubble from "@/components/UserBubble.vue";
+import StyledTooltip from "@/components/StyledTooltip.vue";
 import PrimeVue from "primevue/config";
 import { createStore } from "vuex";
 
@@ -52,6 +54,10 @@ describe("EquipmentTable Component Tests", () => {
               IsoDatetimeToDate,
             },
           },
+        },
+        components: {
+          UserBubble,
+          StyledTooltip,
         },
       },
     });

--- a/webapp/cypress/component/SampleTableTest.cy.jsx
+++ b/webapp/cypress/component/SampleTableTest.cy.jsx
@@ -1,4 +1,6 @@
 import SampleTable from "@/components/SampleTable.vue";
+import UserBubble from "@/components/UserBubble.vue";
+import StyledTooltip from "@/components/StyledTooltip.vue";
 import PrimeVue from "primevue/config";
 import { createStore } from "vuex";
 
@@ -132,6 +134,10 @@ describe("SampleTable Component Tests", () => {
               IsoDatetimeToDate,
             },
           },
+        },
+        components: {
+          UserBubble,
+          StyledTooltip,
         },
       },
     });

--- a/webapp/src/components/BulkAddToGroupModal.vue
+++ b/webapp/src/components/BulkAddToGroupModal.vue
@@ -1,0 +1,148 @@
+<template>
+  <form class="modal-enclosure" data-testid="bulk-add-to-group-form" @submit.prevent="submitForm">
+    <Modal :model-value="modelValue" :disable-submit="!isValid" @update:model-value="handleClose">
+      <template #header> Add Users to Group </template>
+
+      <template #body>
+        <div v-if="modelValue">
+          <div class="alert alert-info">
+            <small>
+              <font-awesome-icon icon="info-circle" class="mr-1" />
+              Select a group to add the {{ selectedUsers.length }} selected user(s) to.
+            </small>
+          </div>
+
+          <div class="form-row">
+            <div class="form-group col-md-12">
+              <label for="selected-users" class="col-form-label font-weight-bold"
+                >Users Selected ({{ selectedUsers.length }}):</label
+              >
+              <div id="selected-users" class="selected-users-list">
+                <div
+                  v-for="(user, index) in selectedUsers"
+                  :key="index"
+                  class="user-item d-flex align-items-center mb-2"
+                >
+                  <UserBubble :creator="user" :size="32" />
+                  <span class="ml-2">{{ user.display_name }}</span>
+                  <span class="ml-auto">
+                    <RoleBadge :role="user.role" />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-row">
+            <div class="form-group col-md-12">
+              <label for="group-select" class="col-form-label font-weight-bold">Group:</label>
+              <GroupSelect
+                v-model="selectedGroups"
+                :minimum-options="1"
+                aria-labelledby="group-select"
+              />
+              <div
+                v-if="showValidation && selectedGroups.length === 0"
+                class="invalid-feedback d-block"
+              >
+                Please select a group.
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
+    </Modal>
+  </form>
+</template>
+
+<script>
+import Modal from "@/components/Modal.vue";
+import RoleBadge from "@/components/RoleBadge.vue";
+import UserBubble from "@/components/UserBubble.vue";
+import GroupSelect from "@/components/GroupSelect.vue";
+import { DialogService } from "@/services/DialogService";
+
+export default {
+  name: "BulkAddToGroupModal",
+  components: {
+    Modal,
+    RoleBadge,
+    UserBubble,
+    GroupSelect,
+  },
+  props: {
+    modelValue: Boolean,
+    selectedUsers: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  emits: ["update:modelValue", "group-selected"],
+  data() {
+    return {
+      selectedGroups: [],
+      showValidation: false,
+    };
+  },
+  computed: {
+    isValid() {
+      return this.selectedGroups.length > 0;
+    },
+  },
+  methods: {
+    submitForm() {
+      this.showValidation = true;
+
+      if (!this.isValid) {
+        DialogService.error({
+          title: "Invalid Selection",
+          message: "Please select at least one group.",
+        });
+        return;
+      }
+
+      this.$emit("group-selected", this.selectedGroups);
+      this.resetForm();
+      this.$emit("update:modelValue", false);
+    },
+    handleClose(value) {
+      if (!value) {
+        this.resetForm();
+      }
+      this.$emit("update:modelValue", value);
+    },
+    resetForm() {
+      this.selectedGroups = [];
+      this.showValidation = false;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.selected-users-list {
+  max-height: 300px;
+  overflow-y: auto;
+  padding: 1rem;
+  background-color: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 0.25rem;
+}
+
+.user-item {
+  padding: 0.5rem;
+  background-color: white;
+  border-radius: 0.25rem;
+  border: 1px solid #e9ecef;
+}
+
+.modal-enclosure :deep(.modal-content) {
+  max-height: 90vh;
+  overflow: auto;
+  scroll-behavior: smooth;
+}
+
+.invalid-feedback.d-block {
+  display: block !important;
+}
+</style>

--- a/webapp/src/components/BulkChangeManagersModal.vue
+++ b/webapp/src/components/BulkChangeManagersModal.vue
@@ -1,0 +1,222 @@
+<template>
+  <form
+    class="modal-enclosure"
+    data-testid="bulk-change-managers-form"
+    @submit.prevent="submitForm"
+  >
+    <Modal :model-value="modelValue" :disable-submit="!isValid" @update:model-value="handleClose">
+      <template #header> Change User Managers </template>
+
+      <template #body>
+        <div v-if="modelValue">
+          <div class="alert alert-info">
+            <small>
+              <font-awesome-icon icon="info-circle" class="mr-1" />
+              Select managers for the {{ selectedUsers.length }} selected user(s).
+            </small>
+          </div>
+
+          <div class="form-row">
+            <div class="form-group col-md-12">
+              <label for="selected-users" class="col-form-label font-weight-bold"
+                >Users Selected ({{ selectedUsers.length }}):</label
+              >
+              <div id="selected-users" class="selected-users-list">
+                <div
+                  v-for="(user, index) in selectedUsers"
+                  :key="index"
+                  class="user-item d-flex align-items-center mb-2"
+                >
+                  <UserBubble :creator="user" :size="32" />
+                  <span class="ml-2">{{ user.display_name }}</span>
+                  <span class="ml-auto">
+                    <RoleBadge :role="user.role" />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-row">
+            <div class="form-group col-md-12">
+              <label for="managers-select" class="col-form-label font-weight-bold">Managers:</label>
+              <vSelect
+                v-model="selectedManagers"
+                :options="potentialManagers"
+                label="display_name"
+                multiple
+                placeholder="Select managers..."
+                class="managers-select"
+                :taggable="false"
+                :push-tags="false"
+                :create-option="() => null"
+                @update:model-value="handleManagersUpdate"
+              >
+                <template #option="option">
+                  <div class="d-flex align-items-center">
+                    <UserBubble :creator="option" :size="20" />
+                    <span class="ml-2">{{ option.display_name }}</span>
+                    <span class="ml-auto"><RoleBadge :role="option.role" /></span>
+                  </div>
+                </template>
+                <template #selected-option="option">
+                  <div class="d-flex align-items-center">
+                    <UserBubble :creator="option" :size="18" />
+                    <span class="ml-2 small">{{ option.display_name }}</span>
+                  </div>
+                </template>
+              </vSelect>
+            </div>
+          </div>
+        </div>
+      </template>
+    </Modal>
+  </form>
+</template>
+
+<script>
+import { DialogService } from "@/services/DialogService";
+
+import Modal from "@/components/Modal.vue";
+import RoleBadge from "@/components/RoleBadge.vue";
+import UserBubble from "@/components/UserBubble.vue";
+import vSelect from "vue-select";
+
+export default {
+  name: "BulkChangeManagersModal",
+  components: {
+    Modal,
+    RoleBadge,
+    UserBubble,
+    vSelect,
+  },
+  props: {
+    modelValue: Boolean,
+    selectedUsers: {
+      type: Array,
+      default: () => [],
+    },
+    allUsers: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  emits: ["update:modelValue", "managers-selected"],
+  data() {
+    return {
+      selectedManagers: [],
+    };
+  },
+  computed: {
+    potentialManagers() {
+      const selectedUserIds = this.selectedUsers.map((u) => u.immutable_id);
+      return this.allUsers.filter(
+        (u) =>
+          !selectedUserIds.includes(u.immutable_id) && (u.role === "admin" || u.role === "manager"),
+      );
+    },
+    isValid() {
+      return (
+        this.selectedManagers.length > 0 &&
+        this.selectedManagers.every((m) => m && typeof m === "object" && m.immutable_id)
+      );
+    },
+  },
+  methods: {
+    handleManagersUpdate(value) {
+      const validManagers = (value || []).filter(
+        (m) =>
+          m &&
+          typeof m === "object" &&
+          m.immutable_id &&
+          this.potentialManagers.some((pm) => pm.immutable_id === m.immutable_id),
+      );
+
+      if (validManagers.length !== (value || []).length) {
+        this.$nextTick(() => {
+          this.selectedManagers = validManagers;
+        });
+      } else {
+        this.selectedManagers = validManagers;
+      }
+    },
+    handleSearchBlur() {
+      this.selectedManagers = this.selectedManagers.filter(
+        (m) => m && typeof m === "object" && m.immutable_id,
+      );
+    },
+    submitForm() {
+      const validManagers = this.selectedManagers.filter(
+        (m) =>
+          m &&
+          typeof m === "object" &&
+          m.immutable_id &&
+          this.potentialManagers.some((pm) => pm.immutable_id === m.immutable_id),
+      );
+
+      if (validManagers.length === 0 && this.selectedManagers.length > 0) {
+        DialogService.error({
+          title: "Invalid Selection",
+          message: "No valid managers selected. Please choose from the dropdown list.",
+        });
+        this.selectedManagers = [];
+        return;
+      }
+
+      if (validManagers.length !== this.selectedManagers.length) {
+        DialogService.error({
+          title: "Invalid Selection",
+          message: "Some invalid entries were removed. Please verify your selection.",
+        });
+        this.selectedManagers = validManagers;
+        return;
+      }
+
+      this.$emit("managers-selected", validManagers);
+      this.resetForm();
+      this.$emit("update:modelValue", false);
+    },
+    handleClose(value) {
+      if (!value) {
+        this.resetForm();
+      }
+      this.$emit("update:modelValue", value);
+    },
+    resetForm() {
+      this.selectedManagers = [];
+    },
+  },
+};
+</script>
+
+<style scoped>
+.selected-users-list {
+  max-height: 300px;
+  overflow-y: auto;
+  padding: 1rem;
+  background-color: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 0.25rem;
+}
+
+.user-item {
+  padding: 0.5rem;
+  background-color: white;
+  border-radius: 0.25rem;
+  border: 1px solid #e9ecef;
+}
+
+.managers-select {
+  width: 100%;
+}
+
+.managers-select :deep(.vs__dropdown-menu) {
+  z-index: 9999;
+}
+
+.modal-enclosure :deep(.modal-content) {
+  max-height: 90vh;
+  overflow: auto;
+  scroll-behavior: smooth;
+}
+</style>

--- a/webapp/src/components/BulkChangeRoleModal.vue
+++ b/webapp/src/components/BulkChangeRoleModal.vue
@@ -1,0 +1,168 @@
+<template>
+  <form class="modal-enclosure" data-testid="bulk-change-role-form" @submit.prevent="submitForm">
+    <Modal
+      :model-value="modelValue"
+      :disable-submit="!selectedRole"
+      @update:model-value="handleClose"
+    >
+      <template #header> Change User Roles </template>
+
+      <template #body>
+        <div v-if="modelValue">
+          <div class="alert alert-info">
+            <small>
+              <font-awesome-icon icon="info-circle" class="mr-1" />
+              Select a new role for the {{ selectedUsers.length }} selected user(s).
+            </small>
+          </div>
+
+          <div class="form-row">
+            <div class="form-group col-md-12">
+              <label for="selected-users" class="col-form-label font-weight-bold"
+                >Users Selected ({{ selectedUsers.length }}):</label
+              >
+              <div id="selected-users" class="selected-users-list">
+                <div
+                  v-for="(user, index) in selectedUsers"
+                  :key="index"
+                  class="user-item d-flex align-items-center mb-2"
+                >
+                  <UserBubble :creator="user" :size="32" />
+                  <span class="ml-2">{{ user.display_name }}</span>
+                  <span class="ml-auto">
+                    <RoleBadge :role="user.role" />
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-row">
+            <div class="form-group col-md-12">
+              <label for="role-select" class="col-form-label font-weight-bold">New Role:</label>
+              <vSelect
+                v-model="selectedRole"
+                :options="roleOptions"
+                :clearable="false"
+                :searchable="false"
+                placeholder="Select a role..."
+                class="role-select"
+                :class="{ 'is-invalid': showValidation && !selectedRole }"
+              >
+                <template #option="option">
+                  <RoleBadge :role="option.label" />
+                </template>
+                <template #selected-option="option">
+                  <RoleBadge :role="option.label" />
+                </template>
+              </vSelect>
+              <div v-if="showValidation && !selectedRole" class="invalid-feedback d-block">
+                Please select a role.
+              </div>
+            </div>
+          </div>
+
+          <div v-if="selectedRole === 'admin'" class="alert alert-warning">
+            <small>
+              <font-awesome-icon icon="exclamation-triangle" class="mr-1" />
+              <strong>Warning:</strong> You are about to grant admin privileges to
+              {{ selectedUsers.length }} user(s). Admins have full access to all system features.
+            </small>
+          </div>
+        </div>
+      </template>
+    </Modal>
+  </form>
+</template>
+
+<script>
+import Modal from "@/components/Modal.vue";
+import RoleBadge from "@/components/RoleBadge.vue";
+import UserBubble from "@/components/UserBubble.vue";
+import vSelect from "vue-select";
+
+export default {
+  name: "BulkChangeRoleModal",
+  components: {
+    Modal,
+    RoleBadge,
+    UserBubble,
+    vSelect,
+  },
+  props: {
+    modelValue: Boolean,
+    selectedUsers: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  emits: ["update:modelValue", "role-selected"],
+  data() {
+    return {
+      selectedRole: null,
+      roleOptions: ["user", "admin", "manager"],
+      showValidation: false,
+    };
+  },
+  methods: {
+    submitForm() {
+      this.showValidation = true;
+
+      if (!this.selectedRole) {
+        return;
+      }
+
+      this.$emit("role-selected", this.selectedRole);
+
+      this.resetForm();
+      this.$emit("update:modelValue", false);
+    },
+    handleClose(value) {
+      if (!value) {
+        this.resetForm();
+      }
+      this.$emit("update:modelValue", value);
+    },
+    resetForm() {
+      this.selectedRole = null;
+      this.showValidation = false;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.selected-users-list {
+  max-height: 300px;
+  overflow-y: auto;
+  padding: 1rem;
+  background-color: #f8f9fa;
+  border: 1px solid #dee2e6;
+  border-radius: 0.25rem;
+}
+
+.user-item {
+  padding: 0.5rem;
+  background-color: white;
+  border-radius: 0.25rem;
+  border: 1px solid #e9ecef;
+}
+
+.role-select {
+  width: 100%;
+}
+
+.role-select :deep(.vs__dropdown-menu) {
+  z-index: 9999;
+}
+
+.modal-enclosure :deep(.modal-content) {
+  max-height: 90vh;
+  overflow: auto;
+  scroll-behavior: smooth;
+}
+
+.invalid-feedback.d-block {
+  display: block !important;
+}
+</style>

--- a/webapp/src/components/Creators.vue
+++ b/webapp/src/components/Creators.vue
@@ -36,6 +36,7 @@ export default {
     FormattedGroupName,
     GroupsIconCounter,
   },
+
   props: {
     creators: {
       type: Array,
@@ -61,6 +62,7 @@ export default {
       default: () => [],
     },
   },
+
   data() {
     return {};
   },
@@ -69,6 +71,20 @@ export default {
       if (this.groups.length === 0) return "";
       if (this.groups.length === 1) return this.groups[0].display_name;
       return `${this.groups.length} groups`;
+    },
+  },
+  watch: {
+    groups: {
+      immediate: true,
+      handler(val) {
+        console.log("Creators component - groups prop:", val);
+      },
+    },
+    creators: {
+      immediate: true,
+      handler(val) {
+        console.log("Creators component - creators prop:", val);
+      },
     },
   },
 };

--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -46,6 +46,7 @@
           :available-columns="availableColumns"
           :selected-columns="selectedColumns"
           :collection-id="collectionId"
+          :all-users="allUsersForBulk"
           @update:filters="updateFilters"
           @update:selected-columns="onToggleColumns"
           @open-create-item-modal="createItemModalIsOpen = true"
@@ -58,6 +59,7 @@
           @delete-selected-items="deleteSelectedItems"
           @remove-selected-items-from-collection="removeSelectedItemsFromCollection"
           @reset-table="handleResetTable"
+          @users-data-changed="$emit('users-data-changed')"
         />
       </template>
       <template #loading>
@@ -453,7 +455,7 @@ export default {
       default: null,
     },
   },
-  emits: ["remove-selected-items-from-collection"],
+  emits: ["remove-selected-items-from-collection", "users-data-changed"],
   data() {
     return {
       createItemModalIsOpen: false,
@@ -622,6 +624,18 @@ export default {
     },
     availableColumns() {
       return this.columns.map((col) => ({ ...col }));
+    },
+    allUsersForBulk() {
+      if (this.dataType !== "users" || !this.data || this.data.length === 0) {
+        return [];
+      }
+      return this.data[0]?.allUsers || [];
+    },
+    availableGroupsForBulk() {
+      if (this.dataType !== "users") {
+        return [];
+      }
+      return this.$store.state.groups_list || [];
     },
   },
   created() {

--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -313,6 +313,81 @@
           </div>
         </template>
 
+        <template
+          v-else-if="dataType === 'users' && column.filter && column.field === 'account_status'"
+          #filter
+        >
+          <Select
+            v-model="filters[column.field].constraints[0].value"
+            :options="uniqueStatuses"
+            placeholder="Any"
+            class="p-column-filter"
+            show-clear
+          >
+            <template #option="slotProps">
+              <UserStatusCell :status="slotProps.option" />
+            </template>
+            <template #value="slotProps">
+              <UserStatusCell v-if="slotProps.value" :status="slotProps.value" />
+              <span v-else>Any</span>
+            </template>
+          </Select>
+        </template>
+
+        <template
+          v-else-if="dataType === 'users' && column.filter && column.field === 'role'"
+          #filter
+        >
+          <Select
+            v-model="filters[column.field].constraints[0].value"
+            :options="uniqueRoles"
+            placeholder="Any"
+            class="p-column-filter"
+            show-clear
+          >
+            <template #option="slotProps">
+              <RoleBadge :role="slotProps.option" />
+            </template>
+            <template #value="slotProps">
+              <RoleBadge v-if="slotProps.value" :role="slotProps.value" />
+              <span v-else>Any</span>
+            </template>
+          </Select>
+        </template>
+
+        <template
+          v-else-if="dataType === 'users' && column.filter && column.field === 'groups'"
+          #filter
+        >
+          <MultiSelect
+            v-model="filters[column.field].constraints[0].value"
+            :options="uniqueUserGroups"
+            option-label="display_name"
+            placeholder="Any"
+            class="p-column-filter"
+            :max-selected-labels="1"
+            :filter="true"
+          >
+            <template #option="slotProps">
+              <div class="flex items-center">
+                <Creators :groups="[slotProps.option]" :creators="[]" :show-names="true" />
+              </div>
+            </template>
+            <template #value="slotProps">
+              <div v-if="slotProps.value && slotProps.value.length" class="flex flex-wrap gap-1">
+                <Creators
+                  v-for="group in slotProps.value"
+                  :key="group.immutable_id"
+                  :groups="[group]"
+                  :creators="[]"
+                  :show-names="false"
+                />
+              </div>
+              <span v-else>Any</span>
+            </template>
+          </MultiSelect>
+        </template>
+
         <template v-else-if="column.filter" #filter="{ filterModel }">
           <InputText
             v-model="filterModel.value"
@@ -379,6 +454,7 @@ import UserStatusCell from "@/components/UserStatusCell.vue";
 import UserRoleCell from "@/components/UserRoleCell.vue";
 import UserManagersCell from "@/components/UserManagersCell.vue";
 import UserActionsCell from "@/components/UserActionsCell.vue";
+import RoleBadge from "@/components/RoleBadge.vue";
 
 import { FilterMatchMode, FilterOperator, FilterService } from "@primevue/core/api";
 import DataTable from "primevue/datatable";
@@ -421,6 +497,7 @@ export default {
     UserRoleCell,
     UserManagersCell,
     UserActionsCell,
+    RoleBadge,
   },
   props: {
     columns: {
@@ -474,7 +551,6 @@ export default {
           operator: FilterOperator.AND,
           constraints: [{ value: null, matchMode: FilterMatchMode.CONTAINS }],
         },
-
         collection_id: {
           operator: FilterOperator.AND,
           constraints: [{ value: null, matchMode: FilterMatchMode.CONTAINS }],
@@ -510,6 +586,22 @@ export default {
         date: {
           operator: FilterOperator.AND,
           constraints: [{ value: null, matchMode: "dateRange" }],
+        },
+        display_name: {
+          operator: FilterOperator.AND,
+          constraints: [{ value: null, matchMode: FilterMatchMode.CONTAINS }],
+        },
+        account_status: {
+          operator: FilterOperator.OR,
+          constraints: [{ value: null, matchMode: "exactAccountStatusMatch" }],
+        },
+        role: {
+          operator: FilterOperator.OR,
+          constraints: [{ value: null, matchMode: "exactRoleMatch" }],
+        },
+        groups: {
+          operator: FilterOperator.AND,
+          constraints: [{ value: null, matchMode: "exactGroupMatch" }],
         },
       },
       filteredData: [],
@@ -605,6 +697,25 @@ export default {
       return Array.from(
         new Set(this.data.filter((item) => item.status).map((item) => item.status)),
       ).map((status) => ({ status }));
+    },
+    uniqueStatuses() {
+      if (this.dataType !== "users" || !this.data) return [];
+      return ["active", "unverified", "deactivated"];
+    },
+    uniqueRoles() {
+      if (this.dataType !== "users" || !this.data) return [];
+      return ["user", "admin", "manager"];
+    },
+    uniqueUserGroups() {
+      if (this.dataType !== "users" || !this.data) return [];
+      const allGroups = this.data.flatMap((user) => user.groups || []);
+      const uniqueGroupsMap = new Map();
+      allGroups.forEach((group) => {
+        if (group && group.immutable_id) {
+          uniqueGroupsMap.set(group.immutable_id, { ...group });
+        }
+      });
+      return Array.from(uniqueGroupsMap.values());
     },
     knownTypes() {
       // Grab the set of types stored under the item type key
@@ -825,6 +936,27 @@ export default {
       const endDate = new Date(filterValue[1]).setHours(0, 0, 0, 0);
       return itemDate >= startDate && itemDate <= endDate;
     });
+    FilterService.register("exactAccountStatusMatch", (value, filterValue) => {
+      if (!filterValue) return true;
+      return value === filterValue;
+    });
+
+    FilterService.register("exactRoleMatch", (value, filterValue) => {
+      if (!filterValue) return true;
+      return value === filterValue;
+    });
+    FilterService.register("exactGroupMatch", (value, filterValue) => {
+      if (!filterValue || (Array.isArray(filterValue) && filterValue.length === 0)) return true;
+      if (!value || !Array.isArray(value)) return false;
+
+      if (Array.isArray(filterValue)) {
+        return filterValue.some((f) =>
+          value.some((group) => String(group.immutable_id) === String(f.immutable_id)),
+        );
+      }
+
+      return value.some((group) => String(group.immutable_id) === String(filterValue.immutable_id));
+    });
   },
   methods: {
     getColumnMinWidth(column) {
@@ -949,9 +1081,10 @@ export default {
           collections: "collections",
         },
         Creators: {
-          creators: data.creators || [],
-          groups: data.groups || [],
-          showNames: data.creators?.length === 1,
+          showNames:
+            data.creators?.length === 1 ||
+            data.creatorsAndGroups?.filter((item) => item.type === "creator").length === 1,
+          showBubble: true,
         },
         FormattedItemStatus: {
           status: "status",
@@ -1009,8 +1142,14 @@ export default {
       });
 
       if (componentName === "Creators") {
-        props.creators = data.creators || [];
-        props.groups = data.groups || [];
+        if (data.creatorsAndGroups) {
+          props.creators = data.creatorsAndGroups.filter((item) => item.type === "creator");
+          props.groups = data.creatorsAndGroups.filter((item) => item.type === "group");
+        } else {
+          props.creators = data.creators || [];
+          props.groups = data.groups || [];
+        }
+        props.showBubble = props.showBubble !== undefined ? props.showBubble : true;
       }
 
       return props;

--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -566,6 +566,7 @@ import GroupsIconCounter from "@/components/GroupsIconCounter";
 
 import UserStatusCell from "@/components/UserStatusCell.vue";
 import UserRoleCell from "@/components/UserRoleCell.vue";
+import UserGroupsCell from "@/components/UserGroupsCell.vue";
 import UserManagersCell from "@/components/UserManagersCell.vue";
 import UserActionsCell from "@/components/UserActionsCell.vue";
 import RoleBadge from "@/components/RoleBadge.vue";
@@ -617,6 +618,7 @@ export default {
     Select,
     UserStatusCell,
     UserRoleCell,
+    UserGroupsCell,
     UserManagersCell,
     UserActionsCell,
     RoleBadge,
@@ -1318,7 +1320,8 @@ export default {
           allUsers: data.allUsers || [],
         },
         UserGroupsCell: {
-          groups: data.groups || [],
+          user: data,
+          allGroups: data.allGroups || [],
         },
         UserManagersCell: {
           user: data,

--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -28,7 +28,7 @@
       @state-restore="onStateRestore"
       @state-save="onStateSave"
       @filter="onFilter"
-      @row-click="goToEditPage"
+      @row-click="dataType !== 'users' ? goToEditPage : null"
       @row-select="null"
       @select-all-change="onSelectAllChange"
       @page="onPageChange"
@@ -373,6 +373,11 @@ import FormattedRefcode from "@/components/FormattedRefcode.vue";
 import FormattedGroupName from "./FormattedGroupName.vue";
 import GroupsIconCounter from "@/components/GroupsIconCounter";
 
+import UserStatusCell from "@/components/UserStatusCell.vue";
+import UserRoleCell from "@/components/UserRoleCell.vue";
+import UserManagersCell from "@/components/UserManagersCell.vue";
+import UserActionsCell from "@/components/UserActionsCell.vue";
+
 import { FilterMatchMode, FilterOperator, FilterService } from "@primevue/core/api";
 import DataTable from "primevue/datatable";
 import MultiSelect from "primevue/multiselect";
@@ -410,6 +415,10 @@ export default {
     GroupsIconCounter,
     DatePicker,
     Select,
+    UserStatusCell,
+    UserRoleCell,
+    UserManagersCell,
+    UserActionsCell,
   },
   props: {
     columns: {
@@ -940,6 +949,24 @@ export default {
         FilesIconCounter: {
           count: "nfiles",
         },
+        UserStatusCell: {
+          status: "account_status",
+        },
+        UserRoleCell: {
+          user: data,
+          allUsers: data.allUsers || [],
+        },
+        UserGroupsCell: {
+          groups: data.groups || [],
+        },
+        UserManagersCell: {
+          user: data,
+          allUsers: data.allUsers || [],
+        },
+        UserActionsCell: {
+          user: data,
+          allUsers: data.allUsers || [],
+        },
       };
 
       const config = propsConfig[componentName] || {};
@@ -955,6 +982,8 @@ export default {
           } else if (data[setting] !== undefined) {
             acc[prop] = data[setting];
           }
+        } else {
+          acc[prop] = setting;
         }
         return acc;
       }, {});

--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -60,6 +60,7 @@
           @remove-selected-items-from-collection="removeSelectedItemsFromCollection"
           @reset-table="handleResetTable"
           @users-data-changed="$emit('users-data-changed')"
+          @bulk-invalidate-tokens="handleItemsUpdated"
         />
       </template>
       <template #loading>
@@ -93,7 +94,10 @@
         :class="{ 'filter-active': isFilterActive(column.field) }"
         :style="{ minWidth: getColumnMinWidth(column) }"
         :filter-menu-class="
-          column.field === 'type' || column.field === 'status' || column.field === 'date'
+          column.field === 'type' ||
+          column.field === 'status' ||
+          column.field === 'date' ||
+          column.field === 'created_at'
             ? 'no-operator'
             : ''
         "
@@ -111,7 +115,10 @@
         <template v-if="column.body" #body="slotProps">
           <component :is="column.body" v-bind="getComponentProps(column.body, slotProps.data)" />
         </template>
-        <template v-else-if="column.field === 'date'" #body="slotProps">
+        <template
+          v-else-if="column.field === 'date' || column.field === 'created_at'"
+          #body="slotProps"
+        >
           {{ $filters.IsoDatetimeToDate(slotProps.data[column.field]) }}
         </template>
         <template v-else #body="slotProps">
@@ -388,6 +395,107 @@
           </MultiSelect>
         </template>
 
+        <template
+          v-else-if="dataType === 'tokens' && column.filter && column.field === 'active'"
+          #filter
+        >
+          <Select
+            v-model="filters[column.field].constraints[0].value"
+            :options="uniqueTokenStatuses"
+            option-value="active"
+            placeholder="Any"
+            class="p-column-filter"
+            show-clear
+          >
+            <template #option="slotProps">
+              <TokenStatusCell :active="slotProps.option.active" />
+            </template>
+            <template #value="slotProps">
+              <TokenStatusCell
+                v-if="slotProps.value !== null && slotProps.value !== undefined"
+                :active="slotProps.value"
+              />
+              <span v-else>Any</span>
+            </template>
+          </Select>
+        </template>
+
+        <template
+          v-else-if="dataType === 'tokens' && column.filter && column.field === 'item_type'"
+          #filter
+        >
+          <MultiSelect
+            v-model="filters[column.field].constraints[0].value"
+            :options="uniqueItemTypes"
+            option-label="item_type"
+            placeholder="Select item types"
+            class="d-flex w-full"
+            :filter="true"
+            @click.stop
+          >
+          </MultiSelect>
+        </template>
+
+        <template v-else-if="column.filter && column.field === 'created_at'" #filter>
+          <div class="date-filter-container">
+            <Select
+              v-model="dateFilterMode"
+              :options="dateFilterOptions"
+              option-label="label"
+              option-value="value"
+              class="mb-2 w-full"
+              @change="handleDateFilterModeChange('created_at')"
+            />
+            <DatePicker
+              v-model="filters['created_at'].constraints[0].value"
+              :selection-mode="dateFilterMode === 'range' ? 'range' : 'single'"
+              :manual-input="false"
+              date-format="yy-mm-dd"
+              placeholder="Select date"
+              class="w-full"
+              show-button-bar
+              @date-select="onDateRangeSelect"
+            />
+          </div>
+        </template>
+
+        <template
+          v-else-if="dataType === 'tokens' && column.filter && column.field === 'created_by_info'"
+          #filter
+        >
+          <MultiSelect
+            v-model="filters[column.field].constraints[0].value"
+            :options="uniqueTokenCreators"
+            option-label="display_name"
+            placeholder="Any"
+            class="d-flex w-full"
+            :filter="true"
+            @click.stop
+          >
+            <template #option="slotProps">
+              <div class="d-flex align-items-center">
+                <UserBubble :creator="slotProps.option" :size="24" />
+                <span class="ml-2">{{ slotProps.option.display_name }}</span>
+              </div>
+            </template>
+            <template #value="slotProps">
+              <div class="flex flex-wrap gap-2 items-center">
+                <template v-if="slotProps.value && slotProps.value.length">
+                  <span
+                    v-for="(option, index) in slotProps.value"
+                    :key="index"
+                    class="inline-flex items-center mr-2"
+                  >
+                    <UserBubble :creator="option" :size="20" />
+                    <span class="ml-1">{{ option.display_name }}</span>
+                  </span>
+                </template>
+                <span v-else class="text-gray-400">Any</span>
+              </div>
+            </template>
+          </MultiSelect>
+        </template>
+
         <template v-else-if="column.filter" #filter="{ filterModel }">
           <InputText
             v-model="filterModel.value"
@@ -456,6 +564,10 @@ import UserManagersCell from "@/components/UserManagersCell.vue";
 import UserActionsCell from "@/components/UserActionsCell.vue";
 import RoleBadge from "@/components/RoleBadge.vue";
 
+import TokenStatusCell from "@/components/TokenStatusCell.vue";
+import TokenActionsCell from "@/components/TokenActionsCell.vue";
+import TokenCreatedByCell from "@/components/TokenCreatedByCell.vue";
+
 import { FilterMatchMode, FilterOperator, FilterService } from "@primevue/core/api";
 import DataTable from "primevue/datatable";
 import MultiSelect from "primevue/multiselect";
@@ -498,6 +610,9 @@ export default {
     UserManagersCell,
     UserActionsCell,
     RoleBadge,
+    TokenStatusCell,
+    TokenActionsCell,
+    TokenCreatedByCell,
   },
   props: {
     columns: {
@@ -602,6 +717,26 @@ export default {
         groups: {
           operator: FilterOperator.AND,
           constraints: [{ value: null, matchMode: "exactGroupMatch" }],
+        },
+        active: {
+          operator: FilterOperator.OR,
+          constraints: [{ value: null, matchMode: "exactActiveMatch" }],
+        },
+        refcode: {
+          operator: FilterOperator.AND,
+          constraints: [{ value: null, matchMode: FilterMatchMode.CONTAINS }],
+        },
+        item_type: {
+          operator: FilterOperator.AND,
+          constraints: [{ value: null, matchMode: "exactItemTypeMatch" }],
+        },
+        created_at: {
+          operator: FilterOperator.AND,
+          constraints: [{ value: null, matchMode: "dateRange" }],
+        },
+        created_by_info: {
+          operator: FilterOperator.AND,
+          constraints: [{ value: null, matchMode: "exactCreatedByMatch" }],
         },
       },
       filteredData: [],
@@ -716,6 +851,30 @@ export default {
         }
       });
       return Array.from(uniqueGroupsMap.values());
+    },
+    uniqueTokenStatuses() {
+      if (this.dataType !== "tokens" || !this.data) return [];
+      return [
+        { active: true, label: "Active" },
+        { active: false, label: "Invalidated" },
+      ];
+    },
+    uniqueItemTypes() {
+      if (this.dataType !== "tokens" || !this.data) return [];
+      return Array.from(new Set(this.data.map((token) => token.item_type).filter(Boolean))).map(
+        (type) => ({ item_type: type }),
+      );
+    },
+    uniqueTokenCreators() {
+      if (this.dataType !== "tokens" || !this.data) return [];
+      return Array.from(
+        new Map(
+          this.data
+            .map((token) => token.created_by_info)
+            .filter(Boolean)
+            .map((creator) => [creator.immutable_id, creator]),
+        ).values(),
+      );
     },
     knownTypes() {
       // Grab the set of types stored under the item type key
@@ -957,6 +1116,34 @@ export default {
 
       return value.some((group) => String(group.immutable_id) === String(filterValue.immutable_id));
     });
+    FilterService.register("exactActiveMatch", (value, filterValue) => {
+      if (filterValue === null || filterValue === undefined) return true;
+      return value === filterValue;
+    });
+    FilterService.register("exactItemTypeMatch", (value, filterValue) => {
+      if (!filterValue || (Array.isArray(filterValue) && filterValue.length === 0)) {
+        return true;
+      }
+
+      if (Array.isArray(filterValue)) {
+        return filterValue.some((f) => f.item_type === value);
+      }
+
+      return filterValue.item_type === value;
+    });
+    FilterService.register("exactCreatedByMatch", (value, filterValue) => {
+      if (!filterValue || (Array.isArray(filterValue) && filterValue.length === 0)) {
+        return true;
+      }
+
+      if (!value) return false;
+
+      if (Array.isArray(filterValue)) {
+        return filterValue.some((f) => f.immutable_id === value.immutable_id);
+      }
+
+      return filterValue.immutable_id === value.immutable_id;
+    });
   },
   methods: {
     getColumnMinWidth(column) {
@@ -1113,6 +1300,16 @@ export default {
         UserActionsCell: {
           user: data,
           allUsers: data.allUsers || [],
+        },
+        TokenStatusCell: {
+          active: "active",
+        },
+        TokenActionsCell: {
+          token: data,
+          allTokens: data.allTokens || [],
+        },
+        TokenCreatedByCell: {
+          creator: "created_by_info",
         },
       };
 

--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -61,6 +61,7 @@
           @reset-table="handleResetTable"
           @users-data-changed="$emit('users-data-changed')"
           @bulk-invalidate-tokens="handleItemsUpdated"
+          @bulk-delete-groups="$emit('groups-data-changed')"
         />
       </template>
       <template #loading>
@@ -113,7 +114,12 @@
         </template>
 
         <template v-if="column.body" #body="slotProps">
-          <component :is="column.body" v-bind="getComponentProps(column.body, slotProps.data)" />
+          <component
+            :is="column.body"
+            v-bind="getComponentProps(column.body, slotProps.data)"
+            @edit-group="$emit('edit-group', $event)"
+            @group-deleted="$emit('group-deleted')"
+          />
         </template>
         <template
           v-else-if="column.field === 'date' || column.field === 'created_at'"
@@ -568,6 +574,10 @@ import TokenStatusCell from "@/components/TokenStatusCell.vue";
 import TokenActionsCell from "@/components/TokenActionsCell.vue";
 import TokenCreatedByCell from "@/components/TokenCreatedByCell.vue";
 
+import GroupIdCell from "@/components/GroupIdCell.vue";
+import GroupMembersCell from "@/components/GroupMembersCell.vue";
+import GroupActionsCell from "@/components/GroupActionsCell.vue";
+
 import { FilterMatchMode, FilterOperator, FilterService } from "@primevue/core/api";
 import DataTable from "primevue/datatable";
 import MultiSelect from "primevue/multiselect";
@@ -613,6 +623,9 @@ export default {
     TokenStatusCell,
     TokenActionsCell,
     TokenCreatedByCell,
+    GroupIdCell,
+    GroupMembersCell,
+    GroupActionsCell,
   },
   props: {
     columns: {
@@ -647,7 +660,13 @@ export default {
       default: null,
     },
   },
-  emits: ["remove-selected-items-from-collection", "users-data-changed"],
+  emits: [
+    "remove-selected-items-from-collection",
+    "users-data-changed",
+    "edit-group",
+    "group-deleted",
+    "groups-data-changed",
+  ],
   data() {
     return {
       createItemModalIsOpen: false,
@@ -737,6 +756,14 @@ export default {
         created_by_info: {
           operator: FilterOperator.AND,
           constraints: [{ value: null, matchMode: "exactCreatedByMatch" }],
+        },
+        group_id: {
+          operator: FilterOperator.AND,
+          constraints: [{ value: null, matchMode: FilterMatchMode.CONTAINS }],
+        },
+        description: {
+          operator: FilterOperator.AND,
+          constraints: [{ value: null, matchMode: FilterMatchMode.CONTAINS }],
         },
       },
       filteredData: [],
@@ -1310,6 +1337,16 @@ export default {
         },
         TokenCreatedByCell: {
           creator: "created_by_info",
+        },
+        GroupIdCell: {
+          groupId: "group_id",
+        },
+        GroupMembersCell: {
+          members: "members",
+        },
+        GroupActionsCell: {
+          group: data,
+          allGroups: data.allGroups || [],
         },
       };
 

--- a/webapp/src/components/DynamicDataTableButtons.vue
+++ b/webapp/src/components/DynamicDataTableButtons.vue
@@ -166,7 +166,7 @@
           aria-labelledby="dropdownMenuButton"
         >
           <a
-            v-if="!['collections', 'collectionItems', 'users'].includes(dataType)"
+            v-if="!['collections', 'collectionItems', 'users', 'tokens'].includes(dataType)"
             data-testid="add-to-collection-button"
             class="dropdown-item"
             @click="handleAddToCollection"
@@ -182,7 +182,7 @@
             Remove from collection
           </a>
           <a
-            v-if="!['collections', 'collectionItems', 'users'].includes(dataType)"
+            v-if="!['collections', 'collectionItems', 'users', 'tokens'].includes(dataType)"
             data-testid="batch-share-button"
             class="dropdown-item"
             @click="handleBatchShare"
@@ -190,7 +190,7 @@
             Batch share
           </a>
           <a
-            v-if="!['collectionItems', 'users'].includes(dataType)"
+            v-if="!['collectionItems', 'users', 'tokens'].includes(dataType)"
             data-testid="delete-selected-button"
             class="dropdown-item"
             @click="confirmDeletion"
@@ -246,6 +246,14 @@
           >
             Deactivate selected users
           </a>
+          <a
+            v-if="dataType === 'tokens'"
+            data-testid="bulk-invalidate-tokens-button"
+            class="dropdown-item"
+            @click="handleBulkInvalidateTokens"
+          >
+            Invalidate selected tokens
+          </a>
         </div>
       </div>
     </div>
@@ -291,6 +299,7 @@ import {
   saveRole,
   addUserToGroup,
   saveUserManagers,
+  invalidateToken,
 } from "@/server_fetch_utils.js";
 
 export default {
@@ -362,6 +371,7 @@ export default {
     "bulk-activate-users",
     "bulk-deactivate-users",
     "users-data-changed",
+    "bulk-invalidate-tokens",
   ],
   data() {
     return {
@@ -801,6 +811,76 @@ export default {
         this.isSelectedDropdownVisible = false;
         this.$emit("users-data-changed");
         this.$emit("delete-selected-items");
+      }
+    },
+    async handleBulkInvalidateTokens() {
+      const activeTokens = this.itemsSelected.filter((token) => token.active);
+
+      if (activeTokens.length === 0) {
+        await DialogService.alert({
+          title: "No Active Tokens",
+          message: "All selected tokens are already invalidated.",
+          type: "info",
+        });
+        return;
+      }
+
+      const confirmed = await DialogService.confirm({
+        title: "Invalidate Access Tokens",
+        message: `Are you sure you want to invalidate ${activeTokens.length} active token(s)?<br><br>This action cannot be undone and will immediately block access for anyone using these tokens.`,
+        type: "error",
+        confirmButtonText: "Invalidate Tokens",
+        cancelButtonText: "Cancel",
+      });
+
+      if (!confirmed) {
+        return;
+      }
+
+      this.isDeletingItems = true;
+      this.itemCount = activeTokens.length;
+
+      try {
+        const results = await Promise.allSettled(
+          activeTokens.map((token) => invalidateToken(token.refcode)),
+        );
+
+        const successCount = results.filter((r) => r.status === "fulfilled").length;
+        const failureCount = results.filter((r) => r.status === "rejected").length;
+
+        results.forEach((result, index) => {
+          if (result.status === "fulfilled") {
+            const token = activeTokens[index];
+            if (token.allTokens) {
+              const tokenInArray = token.allTokens.find((t) => t._id === token._id);
+              if (tokenInArray) {
+                tokenInArray.active = false;
+                tokenInArray.invalidated_at = new Date().toISOString();
+              }
+            }
+          }
+        });
+
+        let message = `${successCount} token(s) successfully invalidated.`;
+        if (failureCount > 0) {
+          message += ` ${failureCount} token(s) failed to invalidate.`;
+        }
+
+        await DialogService.alert({
+          title: failureCount > 0 ? "Partially Successful" : "Success",
+          message: message,
+          type: failureCount > 0 ? "warning" : "info",
+        });
+
+        this.$emit("bulk-invalidate-tokens");
+      } catch (error) {
+        console.error("Error invalidating tokens:", error);
+        await DialogService.error({
+          title: "Error",
+          message: "Failed to invalidate some tokens.",
+        });
+      } finally {
+        this.isDeletingItems = false;
       }
     },
   },

--- a/webapp/src/components/DynamicDataTableButtons.vue
+++ b/webapp/src/components/DynamicDataTableButtons.vue
@@ -199,6 +199,39 @@
           </a>
           <a
             v-if="dataType === 'users'"
+            data-testid="bulk-change-role-button"
+            class="dropdown-item"
+            @click="
+              showBulkChangeRoleModal = true;
+              isSelectedDropdownVisible = false;
+            "
+          >
+            Change role
+          </a>
+          <a
+            v-if="dataType === 'users'"
+            data-testid="bulk-add-to-group-button"
+            class="dropdown-item"
+            @click="
+              showBulkAddToGroupModal = true;
+              isSelectedDropdownVisible = false;
+            "
+          >
+            Add to group
+          </a>
+          <a
+            v-if="dataType === 'users'"
+            data-testid="bulk-change-managers-button"
+            class="dropdown-item"
+            @click="
+              showBulkChangeManagersModal = true;
+              isSelectedDropdownVisible = false;
+            "
+          >
+            Add manager(s)
+          </a>
+          <a
+            v-if="dataType === 'users'"
             data-testid="bulk-activate-users-button"
             class="dropdown-item"
             @click="handleBulkActivateUsers"
@@ -216,6 +249,22 @@
         </div>
       </div>
     </div>
+    <BulkChangeRoleModal
+      v-model="showBulkChangeRoleModal"
+      :selected-users="itemsSelected"
+      @role-selected="handleBulkChangeRole"
+    />
+    <BulkAddToGroupModal
+      v-model="showBulkAddToGroupModal"
+      :selected-users="itemsSelected"
+      @group-selected="handleBulkAddToGroup"
+    />
+    <BulkChangeManagersModal
+      v-model="showBulkChangeManagersModal"
+      :selected-users="itemsSelected"
+      :all-users="allUsers"
+      @managers-selected="handleBulkChangeManagers"
+    />
   </div>
 </template>
 
@@ -228,6 +277,10 @@ import InputText from "primevue/inputtext";
 import MultiSelect from "primevue/multiselect";
 import "primeicons/primeicons.css";
 
+import BulkChangeRoleModal from "@/components/BulkChangeRoleModal.vue";
+import BulkAddToGroupModal from "@/components/BulkAddToGroupModal.vue";
+import BulkChangeManagersModal from "@/components/BulkChangeManagersModal.vue";
+
 import {
   deleteSample,
   deleteCollection,
@@ -235,6 +288,9 @@ import {
   deleteEquipment,
   removeItemsFromCollection,
   saveUser,
+  saveRole,
+  addUserToGroup,
+  saveUserManagers,
 } from "@/server_fetch_utils.js";
 
 export default {
@@ -243,6 +299,9 @@ export default {
     InputIcon,
     InputText,
     MultiSelect,
+    BulkChangeRoleModal,
+    BulkAddToGroupModal,
+    BulkChangeManagersModal,
   },
   props: {
     dataType: {
@@ -281,6 +340,11 @@ export default {
       required: false,
       default: null,
     },
+    allUsers: {
+      type: Array,
+      required: false,
+      default: () => [],
+    },
   },
   emits: [
     "open-create-item-modal",
@@ -297,6 +361,7 @@ export default {
     "remove-selected-items-from-collection",
     "bulk-activate-users",
     "bulk-deactivate-users",
+    "users-data-changed",
   ],
   data() {
     return {
@@ -305,6 +370,9 @@ export default {
       isSettingsDropdownVisible: false,
       isDeletingItems: false,
       itemCount: 0,
+      showBulkChangeRoleModal: false,
+      showBulkAddToGroupModal: false,
+      showBulkChangeManagersModal: false,
     };
   },
   computed: {
@@ -459,6 +527,7 @@ export default {
       } finally {
         this.isDeletingItems = false;
         this.isSelectedDropdownVisible = false;
+        this.$emit("users-data-changed");
         this.$emit("delete-selected-items");
       }
     },
@@ -509,6 +578,228 @@ export default {
       } finally {
         this.isDeletingItems = false;
         this.isSelectedDropdownVisible = false;
+        this.$emit("users-data-changed");
+        this.$emit("delete-selected-items");
+      }
+    },
+    async handleBulkChangeRole(newRole) {
+      const adminUsers = this.itemsSelected.filter((u) => u.role === "admin");
+
+      if (adminUsers.length > 0 && newRole !== "admin") {
+        const confirmed = await DialogService.confirm({
+          title: "Remove Admin Privileges",
+          message: `You are about to remove admin privileges from ${adminUsers.length} admin user(s). This action will revoke their full system access. Are you sure?`,
+          type: "warning",
+        });
+        if (!confirmed) {
+          return;
+        }
+      }
+
+      const confirmed = await DialogService.confirm({
+        title: "Change User Roles",
+        message: `Are you sure you want to change the role of ${this.itemsSelected.length} user(s) to "${newRole}"?`,
+        type: "warning",
+      });
+
+      if (!confirmed) {
+        return;
+      }
+
+      try {
+        this.itemCount = this.itemsSelected.length;
+        this.isDeletingItems = true;
+
+        const results = await Promise.allSettled(
+          this.itemsSelected.map((user) => saveRole(user.immutable_id, { role: newRole })),
+        );
+
+        const successCount = results.filter((r) => r.status === "fulfilled").length;
+        const failureCount = results.filter((r) => r.status === "rejected").length;
+
+        results.forEach((result, index) => {
+          if (result.status === "fulfilled") {
+            const user = this.itemsSelected[index];
+            if (user.allUsers) {
+              const userInArray = user.allUsers.find((u) => u.immutable_id === user.immutable_id);
+              if (userInArray) {
+                userInArray.role = newRole;
+              }
+            }
+          }
+        });
+
+        let message = `${successCount} user(s) successfully updated to "${newRole}".`;
+        if (failureCount > 0) {
+          message += ` ${failureCount} user(s) failed to update.`;
+        }
+        if (adminUsers.length > 0 && newRole !== "admin") {
+          message += ` ${adminUsers.length} admin(s) had their privileges revoked.`;
+        }
+
+        DialogService.alert({
+          title: failureCount > 0 ? "Partially Successful" : "Success",
+          message: message,
+          type: failureCount > 0 ? "warning" : "info",
+        });
+      } catch (error) {
+        console.error("Error changing user roles:", error);
+        DialogService.error({
+          title: "Error",
+          message: "Failed to change roles for some users.",
+        });
+      } finally {
+        this.isDeletingItems = false;
+        this.isSelectedDropdownVisible = false;
+        this.$emit("users-data-changed");
+        this.$emit("delete-selected-items");
+      }
+    },
+    async handleBulkAddToGroup(selectedGroups) {
+      const groupNames = selectedGroups.map((g) => g.display_name).join(", ");
+      const confirmed = await DialogService.confirm({
+        title: "Add Users to Groups",
+        message: `Are you sure you want to add ${this.itemsSelected.length} user(s) to: ${groupNames}?`,
+        type: "info",
+      });
+
+      if (!confirmed) {
+        return;
+      }
+
+      try {
+        this.itemCount = this.itemsSelected.length;
+        this.isDeletingItems = true;
+
+        const promises = [];
+        for (const group of selectedGroups) {
+          for (const user of this.itemsSelected) {
+            promises.push(addUserToGroup(group.immutable_id, user.immutable_id));
+          }
+        }
+
+        const results = await Promise.allSettled(promises);
+
+        const successCount = results.filter((r) => r.status === "fulfilled").length;
+        const failureCount = results.filter((r) => r.status === "rejected").length;
+
+        results.forEach((result, index) => {
+          if (result.status === "fulfilled") {
+            const groupIndex = Math.floor(index / this.itemsSelected.length);
+            const userIndex = index % this.itemsSelected.length;
+            const group = selectedGroups[groupIndex];
+            const user = this.itemsSelected[userIndex];
+
+            if (user.allUsers) {
+              const userInArray = user.allUsers.find((u) => u.immutable_id === user.immutable_id);
+              if (userInArray) {
+                if (!userInArray.groups) {
+                  userInArray.groups = [];
+                }
+                const groupExists = userInArray.groups.some(
+                  (g) => g.immutable_id === group.immutable_id,
+                );
+                if (!groupExists) {
+                  userInArray.groups.push({
+                    immutable_id: group.immutable_id,
+                    display_name: group.display_name,
+                  });
+                }
+              }
+            }
+          }
+        });
+
+        let message = `Successfully processed ${successCount} operation(s).`;
+        if (failureCount > 0) {
+          message += ` ${failureCount} operation(s) failed (users may already be in groups).`;
+        }
+
+        DialogService.alert({
+          title: failureCount > 0 ? "Partially Successful" : "Success",
+          message: message,
+          type: failureCount > 0 ? "warning" : "info",
+        });
+      } catch (error) {
+        console.error("Error adding users to groups:", error);
+        DialogService.error({
+          title: "Error",
+          message: "Failed to add users to groups.",
+        });
+      } finally {
+        this.isDeletingItems = false;
+        this.isSelectedDropdownVisible = false;
+        console.log("Emitting users-data-changed");
+        this.$emit("users-data-changed");
+        this.$emit("delete-selected-items");
+      }
+    },
+    async handleBulkChangeManagers(newManagers) {
+      const confirmed = await DialogService.confirm({
+        title: "Add Managers",
+        message: `Are you sure you want to add these managers to ${this.itemsSelected.length} user(s)? Existing managers will be kept.`,
+        type: "warning",
+      });
+
+      if (!confirmed) {
+        return;
+      }
+
+      try {
+        this.itemCount = this.itemsSelected.length;
+        this.isDeletingItems = true;
+
+        const newManagerIds = newManagers.map((m) => m.immutable_id);
+
+        const results = await Promise.allSettled(
+          this.itemsSelected.map((user) => {
+            const existingManagerIds = (user.managers || []).map((m) => m.immutable_id);
+            const mergedManagerIds = [...new Set([...existingManagerIds, ...newManagerIds])];
+            return saveUserManagers(user.immutable_id, mergedManagerIds);
+          }),
+        );
+
+        const successCount = results.filter((r) => r.status === "fulfilled").length;
+        const failureCount = results.filter((r) => r.status === "rejected").length;
+
+        results.forEach((result, index) => {
+          if (result.status === "fulfilled") {
+            const user = this.itemsSelected[index];
+            if (user.allUsers) {
+              const userInArray = user.allUsers.find((u) => u.immutable_id === user.immutable_id);
+              if (userInArray) {
+                const existingManagers = userInArray.managers || [];
+                const allManagerIds = [
+                  ...new Set([...existingManagers.map((m) => m.immutable_id), ...newManagerIds]),
+                ];
+                userInArray.managers = this.allUsers.filter((u) =>
+                  allManagerIds.includes(u.immutable_id),
+                );
+              }
+            }
+          }
+        });
+
+        let message = `${successCount} user(s) successfully updated.`;
+        if (failureCount > 0) {
+          message += ` ${failureCount} user(s) failed to update.`;
+        }
+
+        DialogService.alert({
+          title: failureCount > 0 ? "Partially Successful" : "Success",
+          message: message,
+          type: failureCount > 0 ? "warning" : "info",
+        });
+      } catch (error) {
+        console.error("Error changing user managers:", error);
+        DialogService.error({
+          title: "Error",
+          message: "Failed to change managers for some users.",
+        });
+      } finally {
+        this.isDeletingItems = false;
+        this.isSelectedDropdownVisible = false;
+        this.$emit("users-data-changed");
         this.$emit("delete-selected-items");
       }
     },

--- a/webapp/src/components/DynamicDataTableButtons.vue
+++ b/webapp/src/components/DynamicDataTableButtons.vue
@@ -166,7 +166,7 @@
           aria-labelledby="dropdownMenuButton"
         >
           <a
-            v-if="dataType !== 'collections' && dataType !== 'collectionItems'"
+            v-if="!['collections', 'collectionItems', 'users'].includes(dataType)"
             data-testid="add-to-collection-button"
             class="dropdown-item"
             @click="handleAddToCollection"
@@ -182,7 +182,7 @@
             Remove from collection
           </a>
           <a
-            v-if="dataType !== 'collections' && dataType !== 'collectionItems'"
+            v-if="!['collections', 'collectionItems', 'users'].includes(dataType)"
             data-testid="batch-share-button"
             class="dropdown-item"
             @click="handleBatchShare"
@@ -190,12 +190,28 @@
             Batch share
           </a>
           <a
-            v-if="dataType !== 'collectionItems'"
+            v-if="!['collectionItems', 'users'].includes(dataType)"
             data-testid="delete-selected-button"
             class="dropdown-item"
             @click="confirmDeletion"
           >
             Delete selected
+          </a>
+          <a
+            v-if="dataType === 'users'"
+            data-testid="bulk-activate-users-button"
+            class="dropdown-item"
+            @click="handleBulkActivateUsers"
+          >
+            Activate selected users
+          </a>
+          <a
+            v-if="dataType === 'users'"
+            data-testid="bulk-deactivate-users-button"
+            class="dropdown-item"
+            @click="handleBulkDeactivateUsers"
+          >
+            Deactivate selected users
           </a>
         </div>
       </div>
@@ -218,6 +234,7 @@ import {
   deleteStartingMaterial,
   deleteEquipment,
   removeItemsFromCollection,
+  saveUser,
 } from "@/server_fetch_utils.js";
 
 export default {
@@ -278,6 +295,8 @@ export default {
     "update:selected-columns",
     "reset-table",
     "remove-selected-items-from-collection",
+    "bulk-activate-users",
+    "bulk-deactivate-users",
   ],
   data() {
     return {
@@ -395,6 +414,103 @@ export default {
     handleBatchShare() {
       this.$emit("open-batch-share-modal");
       this.isSelectedDropdownVisible = false;
+    },
+    async handleBulkActivateUsers() {
+      const userIds = this.itemsSelected.map((u) => u.immutable_id);
+
+      const confirmed = await DialogService.confirm({
+        title: "Activate Users",
+        message: `Are you sure you want to activate ${userIds.length} user(s)?`,
+        type: "info",
+      });
+
+      if (!confirmed) {
+        this.isSelectedDropdownVisible = false;
+        return;
+      }
+
+      try {
+        this.itemCount = userIds.length;
+        this.isDeletingItems = true;
+
+        const promises = userIds.map((userId) => saveUser(userId, { account_status: "active" }));
+        await Promise.all(promises);
+
+        this.itemsSelected.forEach((user) => {
+          if (user.allUsers) {
+            const userInArray = user.allUsers.find((u) => u.immutable_id === user.immutable_id);
+            if (userInArray) {
+              userInArray.account_status = "active";
+            }
+          }
+        });
+
+        DialogService.alert({
+          title: "Success",
+          message: `${userIds.length} user(s) activated successfully.`,
+          type: "info",
+        });
+      } catch (error) {
+        console.error("Error activating users:", error);
+        DialogService.error({
+          title: "Error",
+          message: "Failed to activate some users.",
+        });
+      } finally {
+        this.isDeletingItems = false;
+        this.isSelectedDropdownVisible = false;
+        this.$emit("delete-selected-items");
+      }
+    },
+
+    async handleBulkDeactivateUsers() {
+      const userIds = this.itemsSelected.map((u) => u.immutable_id);
+
+      const confirmed = await DialogService.confirm({
+        title: "Deactivate Users",
+        message: `Are you sure you want to deactivate ${userIds.length} user(s)?`,
+        type: "warning",
+      });
+
+      if (!confirmed) {
+        this.isSelectedDropdownVisible = false;
+        return;
+      }
+
+      try {
+        this.itemCount = userIds.length;
+        this.isDeletingItems = true;
+
+        const promises = userIds.map((userId) =>
+          saveUser(userId, { account_status: "deactivated" }),
+        );
+        await Promise.all(promises);
+
+        this.itemsSelected.forEach((user) => {
+          if (user.allUsers) {
+            const userInArray = user.allUsers.find((u) => u.immutable_id === user.immutable_id);
+            if (userInArray) {
+              userInArray.account_status = "deactivated";
+            }
+          }
+        });
+
+        DialogService.alert({
+          title: "Success",
+          message: `${userIds.length} user(s) deactivated successfully.`,
+          type: "info",
+        });
+      } catch (error) {
+        console.error("Error deactivating users:", error);
+        DialogService.error({
+          title: "Error",
+          message: "Failed to deactivate some users.",
+        });
+      } finally {
+        this.isDeletingItems = false;
+        this.isSelectedDropdownVisible = false;
+        this.$emit("delete-selected-items");
+      }
     },
   },
 };

--- a/webapp/src/components/DynamicDataTableButtons.vue
+++ b/webapp/src/components/DynamicDataTableButtons.vue
@@ -166,7 +166,9 @@
           aria-labelledby="dropdownMenuButton"
         >
           <a
-            v-if="!['collections', 'collectionItems', 'users', 'tokens'].includes(dataType)"
+            v-if="
+              !['collections', 'collectionItems', 'users', 'tokens', 'groups'].includes(dataType)
+            "
             data-testid="add-to-collection-button"
             class="dropdown-item"
             @click="handleAddToCollection"
@@ -182,7 +184,9 @@
             Remove from collection
           </a>
           <a
-            v-if="!['collections', 'collectionItems', 'users', 'tokens'].includes(dataType)"
+            v-if="
+              !['collections', 'collectionItems', 'users', 'tokens', 'groups'].includes(dataType)
+            "
             data-testid="batch-share-button"
             class="dropdown-item"
             @click="handleBatchShare"
@@ -190,7 +194,7 @@
             Batch share
           </a>
           <a
-            v-if="!['collectionItems', 'users', 'tokens'].includes(dataType)"
+            v-if="!['collectionItems', 'users', 'tokens', 'groups'].includes(dataType)"
             data-testid="delete-selected-button"
             class="dropdown-item"
             @click="confirmDeletion"
@@ -254,6 +258,14 @@
           >
             Invalidate selected tokens
           </a>
+          <a
+            v-if="dataType === 'groups'"
+            data-testid="bulk-delete-groups-button"
+            class="dropdown-item"
+            @click="handleBulkDeleteGroups"
+          >
+            Delete selected groups
+          </a>
         </div>
       </div>
     </div>
@@ -300,6 +312,7 @@ import {
   addUserToGroup,
   saveUserManagers,
   invalidateToken,
+  deleteGroup,
 } from "@/server_fetch_utils.js";
 
 export default {
@@ -372,6 +385,7 @@ export default {
     "bulk-deactivate-users",
     "users-data-changed",
     "bulk-invalidate-tokens",
+    "bulk-delete-groups",
   ],
   data() {
     return {
@@ -878,6 +892,52 @@ export default {
         await DialogService.error({
           title: "Error",
           message: "Failed to invalidate some tokens.",
+        });
+      } finally {
+        this.isDeletingItems = false;
+      }
+    },
+    async handleBulkDeleteGroups() {
+      const confirmed = await DialogService.confirm({
+        title: "Delete Groups",
+        message: `Are you sure you want to delete ${this.itemsSelected.length} group(s)?<br><br>This action cannot be undone.`,
+        type: "error",
+        confirmButtonText: "Delete Groups",
+        cancelButtonText: "Cancel",
+      });
+
+      if (!confirmed) {
+        return;
+      }
+
+      this.isDeletingItems = true;
+      this.itemCount = this.itemsSelected.length;
+
+      try {
+        const results = await Promise.allSettled(
+          this.itemsSelected.map((group) => deleteGroup(group.immutable_id || group._id)),
+        );
+
+        const successCount = results.filter((r) => r.status === "fulfilled").length;
+        const failureCount = results.filter((r) => r.status === "rejected").length;
+
+        let message = `${successCount} group(s) successfully deleted.`;
+        if (failureCount > 0) {
+          message += ` ${failureCount} group(s) failed to delete.`;
+        }
+
+        await DialogService.alert({
+          title: failureCount > 0 ? "Partially Successful" : "Success",
+          message: message,
+          type: failureCount > 0 ? "warning" : "info",
+        });
+
+        this.$emit("bulk-delete-groups");
+      } catch (error) {
+        console.error("Error deleting groups:", error);
+        await DialogService.error({
+          title: "Error",
+          message: "Failed to delete some groups.",
         });
       } finally {
         this.isDeletingItems = false;

--- a/webapp/src/components/GroupActionsCell.vue
+++ b/webapp/src/components/GroupActionsCell.vue
@@ -1,0 +1,90 @@
+<template>
+  <span class="mx-auto" style="text-align: center">
+    <button
+      class="btn btn-outline-success group-action-button mr-2"
+      title="Edit group"
+      @click="handleEdit"
+    >
+      Edit
+    </button>
+    <button
+      class="btn btn-outline-danger group-action-button"
+      title="Delete group"
+      :disabled="isDeleting"
+      @click="handleDelete"
+    >
+      <span v-if="isDeleting">Deleting...</span>
+      <span v-else>Delete</span>
+    </button>
+  </span>
+</template>
+
+<script>
+import { DialogService } from "@/services/DialogService";
+import { deleteGroup } from "@/server_fetch_utils.js";
+
+export default {
+  name: "GroupActionsCell",
+  props: {
+    group: {
+      type: Object,
+      required: true,
+    },
+    allGroups: {
+      type: Array,
+      required: true,
+    },
+  },
+  emits: ["edit-group", "group-deleted"],
+  data() {
+    return {
+      isDeleting: false,
+    };
+  },
+  methods: {
+    handleEdit() {
+      this.$emit("edit-group", this.group);
+    },
+    async handleDelete() {
+      const confirmed = await DialogService.confirm({
+        title: "Delete Group",
+        message: `Are you sure you want to delete the group "${this.group.display_name}"?<br><br>This action cannot be undone.`,
+        type: "error",
+        confirmButtonText: "Delete Group",
+        cancelButtonText: "Cancel",
+      });
+
+      if (!confirmed) {
+        return;
+      }
+
+      this.isDeleting = true;
+
+      try {
+        const groupId = this.group.immutable_id || this.group._id;
+        await deleteGroup(groupId);
+
+        this.$emit("group-deleted");
+      } catch (error) {
+        console.error("Error deleting group:", error);
+        await DialogService.error({
+          title: "Error",
+          message: `Error deleting group: ${error.message}`,
+        });
+      } finally {
+        this.isDeleting = false;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.group-action-button {
+  font-family: var(--font-monospace);
+  text-transform: uppercase;
+  font-size: 0.8em;
+  padding: 0.15rem 0.3rem;
+  border: 2px solid;
+}
+</style>

--- a/webapp/src/components/GroupIdCell.vue
+++ b/webapp/src/components/GroupIdCell.vue
@@ -1,0 +1,22 @@
+<template>
+  <span class="badge badge-light table-group-id">{{ groupId }}</span>
+</template>
+
+<script>
+export default {
+  name: "GroupIdCell",
+  props: {
+    groupId: {
+      type: String,
+      required: true,
+    },
+  },
+};
+</script>
+
+<style scoped>
+.table-group-id {
+  border: 2px solid #ccc;
+  font-family: var(--font-monospace);
+}
+</style>

--- a/webapp/src/components/GroupMembersCell.vue
+++ b/webapp/src/components/GroupMembersCell.vue
@@ -1,0 +1,16 @@
+<template>
+  <span>{{ members.length }}</span>
+</template>
+
+<script>
+export default {
+  name: "GroupMembersCell",
+  props: {
+    members: {
+      type: Array,
+      required: true,
+      default: () => [],
+    },
+  },
+};
+</script>

--- a/webapp/src/components/TokenActionsCell.vue
+++ b/webapp/src/components/TokenActionsCell.vue
@@ -1,0 +1,85 @@
+<template>
+  <span class="mx-auto" style="text-align: center">
+    <button
+      v-if="token.active"
+      class="btn btn-outline-danger token-action-button"
+      :disabled="isInvalidating"
+      @click="handleInvalidate"
+    >
+      <span v-if="isInvalidating">Invalidating...</span>
+      <span v-else>Invalidate</span>
+    </button>
+    <button v-else class="btn btn-outline-secondary token-action-button" disabled>
+      Invalidated
+    </button>
+  </span>
+</template>
+
+<script>
+import { DialogService } from "@/services/DialogService";
+import { invalidateToken } from "@/server_fetch_utils.js";
+
+export default {
+  name: "TokenActionsCell",
+  props: {
+    token: {
+      type: Object,
+      required: true,
+    },
+    allTokens: {
+      type: Array,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      isInvalidating: false,
+    };
+  },
+  methods: {
+    async handleInvalidate() {
+      const confirmed = await DialogService.confirm({
+        title: "Invalidate Access Token",
+        message: `Are you sure you want to invalidate the access token for <strong>${this.token.item_id}</strong> (${this.token.refcode})?<br><br>This action cannot be undone and will immediately block access for anyone using this token.`,
+        type: "error",
+        confirmButtonText: "Invalidate Token",
+        cancelButtonText: "Cancel",
+      });
+
+      if (!confirmed) {
+        return;
+      }
+
+      this.isInvalidating = true;
+
+      try {
+        await invalidateToken(this.token.refcode);
+
+        const tokenInArray = this.allTokens.find((t) => t._id === this.token._id);
+        if (tokenInArray) {
+          tokenInArray.active = false;
+          tokenInArray.invalidated_at = new Date().toISOString();
+        }
+      } catch (error) {
+        console.error("Error invalidating token:", error);
+        await DialogService.error({
+          title: "Error",
+          message: `Error invalidating token: ${error.message}`,
+        });
+      } finally {
+        this.isInvalidating = false;
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.token-action-button {
+  font-family: var(--font-monospace);
+  text-transform: uppercase;
+  font-size: 0.8em;
+  padding: 0.15rem 0.3rem;
+  border: 2px solid;
+}
+</style>

--- a/webapp/src/components/TokenCreatedByCell.vue
+++ b/webapp/src/components/TokenCreatedByCell.vue
@@ -1,0 +1,25 @@
+<template>
+  <div v-if="creator" class="d-flex align-items-center">
+    <UserBubble :creator="creator" :size="24" />
+    <span class="ms-2">{{ creator.display_name }}</span>
+  </div>
+  <span v-else class="text-muted">Unknown</span>
+</template>
+
+<script>
+import UserBubble from "@/components/UserBubble.vue";
+
+export default {
+  name: "TokenCreatedByCell",
+  components: {
+    UserBubble,
+  },
+  props: {
+    creator: {
+      type: Object,
+      required: false,
+      default: null,
+    },
+  },
+};
+</script>

--- a/webapp/src/components/TokenStatusCell.vue
+++ b/webapp/src/components/TokenStatusCell.vue
@@ -1,0 +1,16 @@
+<template>
+  <span v-if="active" class="badge badge-success text-uppercase">Active</span>
+  <span v-else class="badge badge-danger text-uppercase">Invalidated</span>
+</template>
+
+<script>
+export default {
+  name: "TokenStatusCell",
+  props: {
+    active: {
+      type: Boolean,
+      required: true,
+    },
+  },
+};
+</script>

--- a/webapp/src/components/TokenTable.vue
+++ b/webapp/src/components/TokenTable.vue
@@ -1,119 +1,106 @@
 <template>
-  <table class="table table-hover table-sm" data-testid="tokens-table">
-    <thead>
-      <tr>
-        <th scope="col">Item</th>
-        <th scope="col">Token Status</th>
-        <th scope="col">Refcode</th>
-        <th scope="col">Item Type</th>
-        <th scope="col">Created By</th>
-        <th scope="col">Date Created</th>
-        <th scope="col">Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr v-if="isLoading">
-        <td colspan="6" class="text-center">
-          <div class="spinner-border spinner-border-sm" role="status"></div>
-          Loading tokens...
-        </td>
-      </tr>
-      <tr v-else-if="tokens.length === 0">
-        <td colspan="6" class="text-center text-muted">No access tokens found</td>
-      </tr>
-      <tr v-for="token in sortedTokens" v-else :key="token._id">
-        <td align="left">
-          <FormattedItemName
-            v-if="token.item_id"
-            :item_id="token.item_id"
-            :item-type="token.item_type"
-            enable-click
-          />
-        </td>
-        <td align="left">
-          <span v-if="token.active" class="badge badge-success text-uppercase"> Active </span>
-          <span v-else class="badge badge-danger text-uppercase"> Invalidated </span>
-        </td>
-        <td align="left">
-          <FormattedRefcode
-            :refcode="token.refcode"
-            :enable-q-r-code="token.item_type !== 'deleted'"
-          />
-        </td>
-        <td align="left">{{ token.item_type || "Unknown" }}</td>
-        <td>
-          <div v-if="token.created_by_info" class="d-flex align-items-center">
-            <UserBubble :creator="token.created_by_info" :size="24" />
-            <span class="ms-2">{{ token.created_by_info.display_name }}</span>
-          </div>
-          <span v-else class="text-muted">Unknown</span>
-        </td>
-        <td align="left">{{ formatDate(token.created_at) }}</td>
-        <td align="left">
-          <button
-            v-if="token.active"
-            class="btn btn-outline-danger btn-sm text-uppercase text-monospace"
-            :disabled="invalidatingTokens.has(token._id)"
-            @click="confirmInvalidateToken(token)"
-          >
-            <span v-if="invalidatingTokens.has(token._id)"> Invalidating... </span>
-            <span v-else> Invalidate </span>
-          </button>
-          <button
-            v-else
-            class="btn btn-outline-secondary btn-sm text-uppercase text-monospace"
-            disabled
-          >
-            Invalidated
-          </button>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+  <DynamicDataTable
+    :columns="tokenColumns"
+    :data="tokens"
+    data-type="tokens"
+    :global-filter-fields="['item_id', 'refcode', 'item_type']"
+    :show-buttons="true"
+    @tokens-data-changed="loadTokens"
+  />
 </template>
 
 <script>
+import DynamicDataTable from "@/components/DynamicDataTable";
 import { API_URL } from "@/resources.js";
-
-import { DialogService } from "@/services/DialogService";
-
-import FormattedItemName from "@/components/FormattedItemName.vue";
-import FormattedRefcode from "@/components/FormattedRefcode.vue";
-import UserBubble from "@/components/UserBubble.vue";
 
 export default {
   name: "TokenTable",
-  components: {
-    FormattedRefcode,
-    FormattedItemName,
-    UserBubble,
-  },
+  components: { DynamicDataTable },
   data() {
     return {
-      tokens: [],
-      isLoading: false,
-      invalidatingTokens: new Set(),
+      tokensList: null,
+      tokenColumns: [
+        {
+          field: "item_id",
+          header: "Item",
+          body: "FormattedItemName",
+          bodyConfig: {
+            item_id: "item_id",
+            itemType: "item_type",
+            enableClick: true,
+          },
+          label: "Item",
+          filter: true,
+        },
+        {
+          field: "active",
+          header: "Token Status",
+          body: "TokenStatusCell",
+          label: "Status",
+          filter: true,
+        },
+        {
+          field: "refcode",
+          header: "Refcode",
+          body: "FormattedRefcode",
+          bodyConfig: {
+            refcode: "refcode",
+            enableQRCode: true,
+          },
+          label: "Refcode",
+          filter: true,
+        },
+        {
+          field: "item_type",
+          header: "Item Type",
+          label: "Item Type",
+          filter: true,
+        },
+        {
+          field: "created_by_info",
+          header: "Created By",
+          body: "TokenCreatedByCell",
+          bodyConfig: {
+            creator: "created_by_info",
+          },
+          label: "Created By",
+          filter: true,
+        },
+        {
+          field: "created_at",
+          header: "Date Created",
+          label: "Date Created",
+          filter: true,
+        },
+        {
+          field: "actions",
+          header: "Actions",
+          body: "TokenActionsCell",
+          bodyConfig: {
+            token: "token",
+            allTokens: "allTokens",
+          },
+        },
+      ],
     };
   },
   computed: {
-    sortedTokens() {
-      return [...this.tokens].sort((a, b) => {
-        if (a.active !== b.active) {
-          return a.active ? -1 : 1;
-        }
-        return new Date(b.created_at) - new Date(a.created_at);
-      });
+    tokens() {
+      if (!this.tokensList) {
+        return null;
+      }
+      return this.tokensList.map((token) => ({
+        ...token,
+        token: token,
+        allTokens: this.tokensList,
+      }));
     },
   },
-
   created() {
     this.loadTokens();
   },
-
   methods: {
     async loadTokens() {
-      this.isLoading = true;
-
       try {
         const response = await fetch(`${API_URL}/access-tokens`, {
           method: "GET",
@@ -123,83 +110,14 @@ export default {
         const data = await response.json();
 
         if (response.ok && data.status === "success") {
-          this.tokens = data.tokens;
+          this.tokensList = data.tokens;
         } else {
           console.error("Failed to load tokens:", data.message);
         }
       } catch (error) {
         console.error("Error loading tokens:", error);
-      } finally {
-        this.isLoading = false;
-      }
-    },
-    async confirmInvalidateToken(token) {
-      const confirmed = await DialogService.confirm({
-        title: "Invalidate Access Token",
-        message: `Are you sure you want to invalidate the access token for <strong>${token.item_id}</strong> (${token.refcode})? <br><br>This action cannot be undone and will immediately block access for anyone using this token.`,
-        type: "error",
-        confirmButtonText: "Invalidate Token",
-        cancelButtonText: "Cancel",
-      });
-
-      if (confirmed) {
-        await this.invalidateToken(token);
-      }
-    },
-    async invalidateToken(token) {
-      this.invalidatingTokens.add(token._id);
-
-      try {
-        const response = await fetch(`${API_URL}/items/${token.refcode}/invalidate-access-token`, {
-          method: "POST",
-          credentials: "include",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            token: "admin-invalidation",
-          }),
-        });
-
-        const data = await response.json();
-
-        if (response.ok && data.status === "success") {
-          // Mettre à jour le token dans la liste
-          const index = this.tokens.findIndex((t) => t._id === token._id);
-          if (index !== -1) {
-            this.tokens[index].active = false;
-            this.tokens[index].invalidated_at = new Date().toISOString();
-          }
-        } else {
-          alert(`Failed to invalidate token: ${data.detail || data.message}`);
-        }
-      } catch (error) {
-        console.error("Error invalidating token:", error);
-        alert(`Error invalidating token: ${error.message}`);
-      } finally {
-        this.invalidatingTokens.delete(token._id);
-      }
-    },
-
-    formatDate(dateString) {
-      if (!dateString) return "Unknown";
-      try {
-        return new Date(dateString).toLocaleDateString();
-      } catch {
-        return "Invalid date";
       }
     },
   },
 };
 </script>
-
-<style scoped>
-td {
-  vertical-align: middle;
-}
-
-.table-item-id {
-  font-size: 1.2em;
-  font-weight: normal;
-}
-</style>

--- a/webapp/src/components/UserActionsCell.vue
+++ b/webapp/src/components/UserActionsCell.vue
@@ -1,0 +1,74 @@
+<template>
+  <span class="mx-auto" style="text-align: center">
+    <button
+      v-if="user.account_status === 'active'"
+      class="btn btn-outline-danger status-action-button"
+      @click="handleStatusChange('deactivated')"
+    >
+      Deactivate
+    </button>
+    <button
+      v-else
+      class="btn btn-outline-success status-action-button"
+      @click="handleStatusChange('active')"
+    >
+      Activate
+    </button>
+  </span>
+</template>
+
+<script>
+import { DialogService } from "@/services/DialogService";
+import { saveUser } from "@/server_fetch_utils.js";
+
+export default {
+  name: "UserActionsCell",
+  props: {
+    user: {
+      type: Object,
+      required: true,
+    },
+    allUsers: {
+      type: Array,
+      required: true,
+    },
+  },
+  methods: {
+    async handleStatusChange(newStatus) {
+      const originalStatus = this.user.account_status;
+
+      const confirmed = await DialogService.confirm({
+        title: "Change User Status",
+        message: `Are you sure you want to change ${this.user.display_name}'s status from "${originalStatus}" to "${newStatus}"?`,
+        type: "warning",
+      });
+
+      if (confirmed) {
+        try {
+          await saveUser(this.user.immutable_id, { account_status: newStatus });
+
+          const userInArray = this.allUsers.find((u) => u.immutable_id === this.user.immutable_id);
+          if (userInArray) {
+            userInArray.account_status = newStatus;
+          }
+        } catch (err) {
+          DialogService.error({
+            title: "Error",
+            message: "Failed to update user status.",
+          });
+        }
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.status-action-button {
+  font-family: var(--font-monospace);
+  text-transform: uppercase;
+  font-size: 0.8em;
+  padding: 0.15rem 0.3rem;
+  border: 2px solid;
+}
+</style>

--- a/webapp/src/components/UserGroupsCell.vue
+++ b/webapp/src/components/UserGroupsCell.vue
@@ -1,0 +1,187 @@
+<template>
+  <div class="groups-cell-wrapper">
+    <div v-if="!isEditing" class="groups-display" @click="startEditing">
+      <span v-if="!localGroups.length" class="text-muted small">No groups</span>
+      <FormattedGroupName
+        v-else-if="localGroups.length === 1"
+        :group="localGroups[0]"
+        :show-name="true"
+        :size="24"
+      />
+      <GroupsIconCounter v-else :groups="localGroups" :size="24" />
+    </div>
+    <vSelect
+      v-else
+      ref="groupSelect"
+      v-model="localGroups"
+      :options="allGroups"
+      label="display_name"
+      multiple
+      placeholder="No groups"
+      :clearable="false"
+      :taggable="false"
+      @open="onDropdownOpen"
+      @close="onDropdownClose"
+    >
+      <template #option="option">
+        <span>{{ option.display_name }}</span>
+      </template>
+      <template #selected-option="option">
+        <span class="small">{{ option.display_name }}</span>
+      </template>
+    </vSelect>
+  </div>
+</template>
+
+<script>
+import { DialogService } from "@/services/DialogService";
+import vSelect from "vue-select";
+import FormattedGroupName from "@/components/FormattedGroupName.vue";
+import GroupsIconCounter from "@/components/GroupsIconCounter.vue";
+import { addUserToGroup, removeUserFromGroup } from "@/server_fetch_utils.js";
+
+export default {
+  name: "UserGroupsCell",
+  components: { vSelect, FormattedGroupName, GroupsIconCounter },
+  props: {
+    user: {
+      type: Object,
+      required: true,
+    },
+    allGroups: {
+      type: Array,
+      required: true,
+    },
+  },
+  data() {
+    const matchedGroups = this.matchGroupsToOptions(this.user?.groups || []);
+    return {
+      isEditing: false,
+      localGroups: matchedGroups,
+      savedGroups: matchedGroups,
+    };
+  },
+  watch: {
+    "user.groups": {
+      handler(newVal) {
+        const matched = this.matchGroupsToOptions(newVal || []);
+        this.localGroups = matched;
+        this.savedGroups = matched;
+      },
+      deep: true,
+    },
+  },
+  methods: {
+    matchGroupsToOptions(groups) {
+      return groups.map(
+        (g) => this.allGroups.find((ag) => String(ag.immutable_id) === String(g.immutable_id)) || g,
+      );
+    },
+    async startEditing() {
+      this.isEditing = true;
+      await this.$nextTick();
+      this.$refs.groupSelect?.$refs.search?.focus();
+    },
+    onDropdownOpen() {
+      const cell = this.$el.closest("td");
+      const row = this.$el.closest("tr");
+      if (cell) {
+        cell.style.overflow = "visible";
+        cell.style.zIndex = "1000";
+        cell.style.position = "relative";
+      }
+      if (row) {
+        row.style.zIndex = "1000";
+      }
+    },
+    async onDropdownClose() {
+      const cell = this.$el.closest("td");
+      const row = this.$el.closest("tr");
+      if (cell) {
+        cell.style.overflow = "";
+        cell.style.zIndex = "";
+        cell.style.position = "";
+      }
+      if (row) {
+        row.style.zIndex = "";
+      }
+
+      await this.saveIfChanged();
+      this.isEditing = false;
+    },
+    async saveIfChanged() {
+      const newIds = this.localGroups.map((g) => String(g.immutable_id)).sort();
+      const savedIds = this.savedGroups.map((g) => String(g.immutable_id)).sort();
+
+      if (JSON.stringify(newIds) === JSON.stringify(savedIds)) {
+        return;
+      }
+
+      const confirmed = await DialogService.confirm({
+        title: "Update Groups",
+        message: `Are you sure you want to update groups for ${this.user.display_name}?`,
+        type: "info",
+      });
+
+      if (!confirmed) {
+        this.localGroups = [...this.savedGroups];
+        return;
+      }
+
+      const groupsToAdd = this.localGroups.filter(
+        (ng) => !this.savedGroups.find((sg) => String(sg.immutable_id) === String(ng.immutable_id)),
+      );
+      const groupsToRemove = this.savedGroups.filter(
+        (sg) => !this.localGroups.find((ng) => String(ng.immutable_id) === String(sg.immutable_id)),
+      );
+
+      try {
+        await Promise.all([
+          ...groupsToAdd.map((g) => addUserToGroup(String(g.immutable_id), this.user.immutable_id)),
+          ...groupsToRemove.map((g) =>
+            removeUserFromGroup(String(g.immutable_id), this.user.immutable_id),
+          ),
+        ]);
+
+        this.localGroups = [...this.localGroups];
+        this.savedGroups = [...this.localGroups];
+
+        DialogService.alert({
+          title: "Success",
+          message: "Groups updated successfully.",
+          type: "info",
+        });
+      } catch {
+        this.localGroups = [...this.savedGroups];
+        DialogService.error({
+          title: "Error",
+          message: "Failed to update user groups.",
+        });
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.groups-cell-wrapper {
+  position: relative;
+  z-index: auto;
+}
+
+.groups-display {
+  cursor: pointer;
+  min-height: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+}
+
+.groups-cell-wrapper :deep(.vs--open) {
+  z-index: 1001;
+}
+
+.groups-cell-wrapper :deep(.vs__dropdown-menu) {
+  z-index: 1001;
+  position: absolute;
+}
+</style>

--- a/webapp/src/components/UserManagersCell.vue
+++ b/webapp/src/components/UserManagersCell.vue
@@ -1,0 +1,115 @@
+<template>
+  <vSelect
+    v-model="localManagers"
+    :options="potentialManagers"
+    label="display_name"
+    multiple
+    placeholder="No managers"
+    :clearable="false"
+    @update:model-value="handleManagersChange"
+  >
+    <template #option="option">
+      <div class="d-flex align-items-center">
+        <UserBubble :creator="option" :size="20" />
+        <span class="ml-2">{{ option.display_name }}</span>
+        <span class="ml-auto"><RoleBadge :role="option.role" /></span>
+      </div>
+    </template>
+    <template #selected-option="option">
+      <div class="d-flex align-items-center">
+        <UserBubble :creator="option" :size="18" />
+        <span class="ml-2 small">{{ option.display_name }}</span>
+      </div>
+    </template>
+  </vSelect>
+</template>
+
+<script>
+import { DialogService } from "@/services/DialogService";
+import vSelect from "vue-select";
+import UserBubble from "@/components/UserBubble.vue";
+import RoleBadge from "@/components/RoleBadge.vue";
+import { saveUserManagers } from "@/server_fetch_utils.js";
+
+export default {
+  name: "UserManagersCell",
+  components: {
+    vSelect,
+    UserBubble,
+    RoleBadge,
+  },
+  props: {
+    user: {
+      type: Object,
+      required: true,
+    },
+    allUsers: {
+      type: Array,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      localManagers: this.user?.managers ? [...this.user.managers] : [],
+    };
+  },
+  computed: {
+    potentialManagers() {
+      if (!this.allUsers || !Array.isArray(this.allUsers)) {
+        return [];
+      }
+      return this.allUsers.filter((u) => u.immutable_id !== this.user.immutable_id);
+    },
+  },
+  watch: {
+    "user.managers": {
+      handler(newVal) {
+        if (newVal !== undefined) {
+          this.localManagers = [...(newVal || [])];
+        }
+      },
+      deep: true,
+    },
+  },
+  methods: {
+    async handleManagersChange(newManagers) {
+      if (!newManagers) newManagers = [];
+
+      const originalManagers = [...this.localManagers];
+      const managerIds = newManagers.map((m) => m.immutable_id);
+      const originalManagerIds = originalManagers.map((m) => m.immutable_id);
+
+      if (JSON.stringify(managerIds.sort()) === JSON.stringify(originalManagerIds.sort())) {
+        return;
+      }
+
+      const confirmed = await DialogService.confirm({
+        title: "Update Managers",
+        message: `Are you sure you want to update managers for ${this.user.display_name}?`,
+        type: "info",
+      });
+
+      if (!confirmed) {
+        this.localManagers = originalManagers;
+        return;
+      }
+
+      try {
+        await saveUserManagers(this.user.immutable_id, managerIds);
+
+        const userInArray = this.allUsers.find((u) => u.immutable_id === this.user.immutable_id);
+        if (userInArray) {
+          userInArray.managers = newManagers;
+        }
+        this.localManagers = newManagers;
+      } catch (err) {
+        this.localManagers = originalManagers;
+        DialogService.error({
+          title: "Error",
+          message: "Failed to update user managers.",
+        });
+      }
+    },
+  },
+};
+</script>

--- a/webapp/src/components/UserRoleCell.vue
+++ b/webapp/src/components/UserRoleCell.vue
@@ -1,0 +1,97 @@
+<template>
+  <vSelect
+    v-model="localRole"
+    :options="roleOptions"
+    :clearable="false"
+    :searchable="false"
+    @update:model-value="handleRoleChange"
+  >
+    <template #option="option">
+      <RoleBadge :role="option.label" />
+    </template>
+    <template #selected-option="option">
+      <RoleBadge :role="option.label" />
+    </template>
+  </vSelect>
+</template>
+
+<script>
+import { DialogService } from "@/services/DialogService";
+import vSelect from "vue-select";
+import RoleBadge from "@/components/RoleBadge.vue";
+import { saveRole } from "@/server_fetch_utils.js";
+
+export default {
+  name: "UserRoleCell",
+  components: {
+    RoleBadge,
+    vSelect,
+  },
+  props: {
+    user: {
+      type: Object,
+      required: true,
+    },
+    allUsers: {
+      type: Array,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      roleOptions: ["user", "admin", "manager"],
+      localRole: this.user?.role || "user",
+    };
+  },
+  watch: {
+    "user.role"(newVal) {
+      if (newVal !== undefined) {
+        this.localRole = newVal;
+      }
+    },
+  },
+  methods: {
+    async handleRoleChange(newRole) {
+      const originalRole = this.localRole;
+
+      if (originalRole === "admin" && newRole !== "admin") {
+        const confirmed = await DialogService.confirm({
+          title: "Change Admin Role",
+          message: `Are you sure you want to remove admin privileges from ${this.user.display_name}?`,
+          type: "warning",
+        });
+        if (!confirmed) {
+          this.localRole = originalRole;
+          return;
+        }
+      }
+
+      const confirmed = await DialogService.confirm({
+        title: "Change User Role",
+        message: `Are you sure you want to change ${this.user.display_name}'s role from "${originalRole}" to "${newRole}"?`,
+        type: "warning",
+      });
+
+      if (confirmed) {
+        try {
+          await saveRole(this.user.immutable_id, { role: newRole });
+
+          const userInArray = this.allUsers.find((u) => u.immutable_id === this.user.immutable_id);
+          if (userInArray) {
+            userInArray.role = newRole;
+          }
+          this.localRole = newRole;
+        } catch (err) {
+          this.localRole = originalRole;
+          DialogService.error({
+            title: "Error",
+            message: "Failed to update user role.",
+          });
+        }
+      } else {
+        this.localRole = originalRole;
+      }
+    },
+  },
+};
+</script>

--- a/webapp/src/components/UserRoleCell.vue
+++ b/webapp/src/components/UserRoleCell.vue
@@ -1,18 +1,22 @@
 <template>
-  <vSelect
-    v-model="localRole"
-    :options="roleOptions"
-    :clearable="false"
-    :searchable="false"
-    @update:model-value="handleRoleChange"
-  >
-    <template #option="option">
-      <RoleBadge :role="option.label" />
-    </template>
-    <template #selected-option="option">
-      <RoleBadge :role="option.label" />
-    </template>
-  </vSelect>
+  <div class="role-cell-wrapper">
+    <vSelect
+      v-model="localRole"
+      :options="roleOptions"
+      :clearable="false"
+      :searchable="false"
+      @open="onDropdownOpen"
+      @close="onDropdownClose"
+      @update:model-value="handleRoleChange"
+    >
+      <template #option="option">
+        <RoleBadge :role="option.label" />
+      </template>
+      <template #selected-option="option">
+        <RoleBadge :role="option.label" />
+      </template>
+    </vSelect>
+  </div>
 </template>
 
 <script>
@@ -51,6 +55,30 @@ export default {
     },
   },
   methods: {
+    onDropdownOpen() {
+      const cell = this.$el.closest("td");
+      const row = this.$el.closest("tr");
+      if (cell) {
+        cell.style.overflow = "visible";
+        cell.style.zIndex = "1000";
+        cell.style.position = "relative";
+      }
+      if (row) {
+        row.style.zIndex = "1000";
+      }
+    },
+    onDropdownClose() {
+      const cell = this.$el.closest("td");
+      const row = this.$el.closest("tr");
+      if (cell) {
+        cell.style.overflow = "";
+        cell.style.zIndex = "";
+        cell.style.position = "";
+      }
+      if (row) {
+        row.style.zIndex = "";
+      }
+    },
     async handleRoleChange(newRole) {
       const originalRole = this.localRole;
 
@@ -95,3 +123,19 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.role-cell-wrapper {
+  position: relative;
+  z-index: auto;
+}
+
+.role-cell-wrapper :deep(.vs--open) {
+  z-index: 1001;
+}
+
+.role-cell-wrapper :deep(.vs__dropdown-menu) {
+  z-index: 1001;
+  position: absolute;
+}
+</style>

--- a/webapp/src/components/UserStatusCell.vue
+++ b/webapp/src/components/UserStatusCell.vue
@@ -1,0 +1,58 @@
+<template>
+  <span v-if="status === 'active'" class="mx-auto dot badge-success"></span>
+  <span v-else-if="status === 'unverified'" class="badge activity-badge text-danger">
+    Unverified
+  </span>
+  <span v-else-if="status === 'deactivated'" class="badge activity-badge text-secondary">
+    Deactivated
+  </span>
+</template>
+
+<script>
+export default {
+  name: "UserStatusCell",
+  props: {
+    status: {
+      type: String,
+      required: true,
+    },
+  },
+};
+</script>
+
+<style scoped>
+.dot {
+  height: 0.5rem;
+  width: 0.5rem;
+  border-radius: 50%;
+  color: #ffffff00;
+  border: solid 1px;
+  display: inline-block;
+  margin-left: auto;
+  margin-right: auto;
+  position: relative;
+}
+
+.dot.badge-success {
+  border-color: #28a745;
+  background: repeating-linear-gradient(
+    45deg,
+    transparent,
+    transparent 1.5px,
+    #28a745 1.5px,
+    #28a745 2px
+  ) !important;
+  box-shadow:
+    0 0 2px #28a745,
+    0 0 4px #28a745,
+    0 0 6px #28a745;
+}
+
+.activity-badge {
+  font-family: var(--font-monospace);
+  text-transform: uppercase;
+  border: 2px solid;
+  border-radius: 0.25rem;
+  font-size: 0.8em;
+}
+</style>

--- a/webapp/src/components/UserTable.vue
+++ b/webapp/src/components/UserTable.vue
@@ -25,11 +25,13 @@ export default {
           header: "Status",
           body: "UserStatusCell",
           label: "Status",
+          filter: true,
         },
         {
           field: "display_name",
           header: "Display Name",
           label: "Display Name",
+          filter: true,
         },
         {
           field: "role",
@@ -37,6 +39,7 @@ export default {
           body: "UserRoleCell",
           bodyConfig: { allUsers: "allUsers" },
           label: "Role",
+          filter: true,
         },
         {
           field: "groups",
@@ -44,6 +47,7 @@ export default {
           body: "Creators",
           bodyConfig: { groups: "groups", creators: [] },
           label: "Groups",
+          filter: true,
         },
         {
           field: "managers",

--- a/webapp/src/components/UserTable.vue
+++ b/webapp/src/components/UserTable.vue
@@ -5,12 +5,13 @@
     data-type="users"
     :global-filter-fields="['display_name', 'role', 'groupsList']"
     :show-buttons="true"
+    @users-data-changed="getUsers"
   />
 </template>
 
 <script>
 import DynamicDataTable from "@/components/DynamicDataTable";
-import { getUsersList } from "@/server_fetch_utils.js";
+import { getUsersList, getAdminGroupsList } from "@/server_fetch_utils.js";
 
 export default {
   name: "UserTable",
@@ -41,6 +42,7 @@ export default {
           field: "groups",
           header: "Groups",
           body: "Creators",
+          bodyConfig: { groups: "groups", creators: [] },
           label: "Groups",
         },
         {
@@ -72,6 +74,7 @@ export default {
   },
   created() {
     this.getUsers();
+    this.getGroups();
   },
   methods: {
     async getUsers() {
@@ -96,6 +99,12 @@ export default {
         });
 
         this.usersList = data;
+      }
+    },
+    async getGroups() {
+      const groups = await getAdminGroupsList();
+      if (groups && !groups.message) {
+        this.$store.commit("setGroupsList", groups);
       }
     },
   },

--- a/webapp/src/components/UserTable.vue
+++ b/webapp/src/components/UserTable.vue
@@ -1,136 +1,73 @@
 <template>
-  <table class="table table-hover table-sm table-responsive-sm" data-testid="user-table">
-    <thead>
-      <tr>
-        <th scope="col">Status</th>
-        <th scope="col">Display Name</th>
-        <th scope="col">Role</th>
-        <th scope="col">Managers</th>
-        <th scope="col">Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr v-for="user in users" :key="user.immutable_id">
-        <td style="text-align: left">
-          <span v-if="user.account_status === 'active'" class="mx-auto dot badge-success"></span>
-          <span
-            v-else-if="user.account_status === 'unverified'"
-            class="badge activity-badge text-danger"
-          >
-            Unverified
-          </span>
-          <span
-            v-else-if="user.account_status === 'deactivated'"
-            class="badge activity-badge text-secondary"
-          >
-            Deactivated
-          </span>
-        </td>
-        <td align="left">
-          {{ user.display_name }}
-        </td>
-        <td align="left">
-          <vSelect
-            v-model="user.role"
-            :options="roleOptions"
-            :clearable="false"
-            :searchable="false"
-            @update:model-value="(value) => confirmUpdateUserRole(user.immutable_id, value)"
-          >
-            <template #option="option">
-              <RoleBadge :role="option.label" />
-            </template>
-            <template #selected-option="option">
-              <RoleBadge :role="option.label" />
-            </template>
-          </vSelect>
-        </td>
-        <td align="left">
-          <vSelect
-            v-model="user.managers"
-            :options="potentialManagersMap[user.immutable_id]"
-            label="display_name"
-            multiple
-            placeholder="No managers"
-            :clearable="false"
-            @update:model-value="(value) => handleManagersChange(user.immutable_id, value)"
-          >
-            <template #option="option">
-              <div class="d-flex align-items-center">
-                <UserBubble :creator="option" :size="20" />
-                <span class="ml-2">{{ option.display_name }}</span>
-                <span class="ml-auto"><RoleBadge :role="option.role" /></span>
-              </div>
-            </template>
-
-            <template #selected-option="option">
-              <div class="d-flex align-items-center">
-                <UserBubble :creator="option" :size="18" />
-                <span class="ml-2 small">{{ option.display_name }}</span>
-              </div>
-            </template>
-          </vSelect>
-        </td>
-        <td align="left">
-          <span class="mx-auto" style="text-align: center">
-            <button
-              v-if="user.account_status === 'active'"
-              class="btn btn-outline-danger status-action-button"
-              @click="confirmUpdateUserStatus(user.immutable_id, 'deactivated')"
-            >
-              Deactivate
-            </button>
-            <button
-              v-else-if="user.account_status === 'unverified'"
-              class="btn btn-outline-success status-action-button"
-              @click="confirmUpdateUserStatus(user.immutable_id, 'active')"
-            >
-              Activate
-            </button>
-            <button
-              v-else-if="user.account_status === 'deactivated'"
-              class="btn btn-outline-success status-action-button"
-              @click="confirmUpdateUserStatus(user.immutable_id, 'active')"
-            >
-              Activate
-            </button>
-          </span>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+  <DynamicDataTable
+    :columns="userColumns"
+    :data="users"
+    data-type="users"
+    :global-filter-fields="['display_name', 'role', 'groupsList']"
+    :show-buttons="true"
+  />
 </template>
 
 <script>
-import { DialogService } from "@/services/DialogService";
-import vSelect from "vue-select";
-import UserBubble from "@/components/UserBubble.vue";
-import RoleBadge from "@/components/RoleBadge.vue";
-import { getUsersList, saveRole, saveUser, saveUserManagers } from "@/server_fetch_utils.js";
+import DynamicDataTable from "@/components/DynamicDataTable";
+import { getUsersList } from "@/server_fetch_utils.js";
 
 export default {
-  components: {
-    RoleBadge,
-    vSelect,
-    UserBubble,
-  },
-
+  name: "UserTable",
+  components: { DynamicDataTable },
   data() {
     return {
-      users: null,
-      original_users: null,
-      tempRole: null,
-      roleOptions: ["user", "admin", "manager"],
+      usersList: null,
+      userColumns: [
+        {
+          field: "account_status",
+          header: "Status",
+          body: "UserStatusCell",
+          label: "Status",
+        },
+        {
+          field: "display_name",
+          header: "Display Name",
+          label: "Display Name",
+        },
+        {
+          field: "role",
+          header: "Role",
+          body: "UserRoleCell",
+          bodyConfig: { allUsers: "allUsers" },
+          label: "Role",
+        },
+        {
+          field: "groups",
+          header: "Groups",
+          body: "Creators",
+          label: "Groups",
+        },
+        {
+          field: "managers",
+          header: "Managers",
+          body: "UserManagersCell",
+          bodyConfig: { allUsers: "allUsers" },
+        },
+        {
+          field: "actions",
+          header: "Actions",
+          body: "UserActionsCell",
+          bodyConfig: { allUsers: "allUsers" },
+        },
+      ],
     };
   },
   computed: {
-    potentialManagersMap() {
-      if (!this.users) return {};
-      const map = {};
-      this.users.forEach((u) => {
-        map[u.immutable_id] = this.users.filter((user) => user.immutable_id !== u.immutable_id);
-      });
-      return map;
+    users() {
+      if (!this.usersList) {
+        return null;
+      }
+      return this.usersList.map((user) => ({
+        ...user,
+        allUsers: this.usersList,
+        groupsList: (user.groups || []).map((g) => g.display_name).join(", "),
+      }));
     },
   },
   created() {
@@ -138,12 +75,11 @@ export default {
   },
   methods: {
     async getUsers() {
-      let data = await getUsersList();
+      const data = await getUsersList();
       if (data != null) {
         const byId = {};
         data.forEach((u) => {
-          const id = u.immutable_id;
-          byId[id] = u;
+          byId[u.immutable_id] = u;
         });
 
         data.forEach((user) => {
@@ -159,209 +95,9 @@ export default {
             .filter(Boolean);
         });
 
-        this.users = JSON.parse(JSON.stringify(data));
-        this.original_users = JSON.parse(JSON.stringify(data));
+        this.usersList = data;
       }
-    },
-    getPotentialManagers(userId) {
-      if (!this.users) return [];
-
-      const potentials = this.users.filter((u) => {
-        const isEligible = u.immutable_id !== userId;
-        return isEligible;
-      });
-
-      return potentials.sort((a, b) => (a.display_name || "").localeCompare(b.display_name || ""));
-    },
-
-    async confirmUpdateUserRole(user_id, new_role) {
-      const originalCurrentUser = this.original_users.find((user) => user.immutable_id === user_id);
-
-      if (!originalCurrentUser) {
-        DialogService.error({
-          title: "Error",
-          message: "Original user not found (id mismatch).",
-        });
-        const uiUser = this.users.find((u) => u.immutable_id === user_id);
-        if (uiUser) uiUser.role = uiUser.role || "user";
-        return;
-      }
-
-      if (originalCurrentUser.role === "admin" && new_role !== "admin") {
-        const confirmed = await DialogService.confirm({
-          title: "Change Admin Role",
-          message: `Are you sure you want to remove admin privileges from ${originalCurrentUser.display_name}?`,
-          type: "warning",
-        });
-        if (!confirmed) {
-          this.users.find((user) => user.immutable_id === user_id).role = originalCurrentUser.role;
-          return;
-        }
-      }
-
-      const confirmed = await DialogService.confirm({
-        title: "Change User Role",
-        message: `Are you sure you want to change ${originalCurrentUser.display_name}'s role from "${originalCurrentUser.role}" to "${new_role}"?`,
-        type: "warning",
-      });
-
-      if (confirmed) {
-        try {
-          await this.updateUserRole(user_id, new_role);
-        } catch (err) {
-          this.users.find((user) => user.immutable_id === user_id).role = originalCurrentUser.role;
-        }
-      } else {
-        this.users.find((user) => user.immutable_id === user_id).role = originalCurrentUser.role;
-      }
-    },
-
-    async handleManagersChange(userId, managers) {
-      if (!managers) managers = [];
-
-      const managerIds = managers.map((m) => m.immutable_id);
-
-      const userIndex = this.users.findIndex((u) => u.immutable_id === userId);
-      const originalIndex = this.original_users.findIndex((u) => u.immutable_id === userId);
-
-      if (userIndex === -1 || originalIndex === -1) {
-        DialogService.error({
-          title: "Error",
-          message: "User not found.",
-        });
-        return;
-      }
-
-      const originalUser = this.original_users[originalIndex];
-      const originalManagerIds = (originalUser?.managers || []).map((m) => m.immutable_id);
-
-      if (JSON.stringify(managerIds.sort()) === JSON.stringify(originalManagerIds.sort())) return;
-
-      const confirmed = await DialogService.confirm({
-        title: "Update Managers",
-        message: `Are you sure you want to update managers for ${this.users[userIndex].display_name}?`,
-        type: "info",
-      });
-
-      if (!confirmed) {
-        this.users[userIndex].managers = [...originalUser.managers];
-        return;
-      }
-
-      try {
-        await saveUserManagers(userId, managerIds);
-
-        const newManagers = this.potentialManagersMap[userId].filter((u) =>
-          managerIds.includes(u.immutable_id),
-        );
-
-        this.users[userIndex].managers = newManagers;
-        this.original_users[originalIndex].managers = [...newManagers];
-      } catch (err) {
-        this.users[userIndex].managers = [...originalUser.managers];
-      }
-    },
-    async confirmUpdateUserStatus(user_id, new_status) {
-      const originalCurrentUser = this.original_users.find((user) => user.immutable_id === user_id);
-
-      if (!originalCurrentUser) {
-        DialogService.error({
-          title: "Error",
-          message: "Original user not found (id mismatch).",
-        });
-        return;
-      }
-
-      const confirmed = await DialogService.confirm({
-        title: "Change User Status",
-        message: `Are you sure you want to change ${originalCurrentUser.display_name}'s status from "${originalCurrentUser.account_status}" to "${new_status}"?`,
-        type: "warning",
-      });
-      if (confirmed) {
-        this.users.find((user) => user.immutable_id == user_id).account_status = new_status;
-        try {
-          await this.updateUserStatus(user_id, new_status);
-        } catch (err) {
-          this.users.find((user) => user.immutable_id === user_id).account_status =
-            originalCurrentUser.account_status;
-        }
-      } else {
-        this.users.find((user) => user.immutable_id === user_id).account_status =
-          originalCurrentUser.account_status;
-      }
-    },
-
-    async updateUserRole(user_id, user_role) {
-      await saveRole(user_id, { role: user_role });
-      this.original_users = JSON.parse(JSON.stringify(this.users));
-    },
-
-    async updateUserStatus(user_id, status) {
-      await saveUser(user_id, { account_status: status });
-      this.original_users = JSON.parse(JSON.stringify(this.users));
     },
   },
 };
 </script>
-
-<style scoped>
-td {
-  vertical-align: middle;
-}
-
-.table-item-id {
-  font-size: 1.2em;
-  font-weight: normal;
-}
-select {
-  border: 1px solid #ccc;
-  border-radius: 0.25rem;
-}
-
-.dot {
-  height: 0.5rem;
-  width: 0.5rem;
-  border-radius: 50%;
-  color: #ffffff00;
-  border: solid 1px;
-  display: inline-block;
-  margin-left: auto;
-  margin-right: auto;
-  position: relative;
-}
-
-.dot.badge-success {
-  border-color: #28a745;
-  background: repeating-linear-gradient(
-    45deg,
-    transparent,
-    transparent 1.5px,
-    #28a745 1.5px,
-    #28a745 2px
-  ) !important;
-  box-shadow:
-    0 0 2px #28a745,
-    0 0 4px #28a745,
-    0 0 6px #28a745;
-}
-
-.status-action-button {
-  font-family: var(--font-monospace);
-  text-transform: uppercase;
-  font-size: 0.8em;
-  padding: 0.15rem 0.3rem;
-  border: 2px solid;
-}
-
-.activity-badge {
-  font-family: var(--font-monospace);
-  text-transform: uppercase;
-  border: 2px solid;
-  border-radius: 0.25rem;
-}
-
-.vs__dropdown-option--highlight .formatted-role-name {
-  color: white !important;
-  border: none !important;
-}
-</style>

--- a/webapp/src/components/UserTable.vue
+++ b/webapp/src/components/UserTable.vue
@@ -44,8 +44,7 @@ export default {
         {
           field: "groups",
           header: "Groups",
-          body: "Creators",
-          bodyConfig: { groups: "groups", creators: [] },
+          body: "UserGroupsCell",
           label: "Groups",
           filter: true,
         },
@@ -72,6 +71,7 @@ export default {
       return this.usersList.map((user) => ({
         ...user,
         allUsers: this.usersList,
+        allGroups: this.$store.state.groups_list || [],
         groupsList: (user.groups || []).map((g) => g.display_name).join(", "),
       }));
     },

--- a/webapp/src/primevue-theme-preset.js
+++ b/webapp/src/primevue-theme-preset.js
@@ -85,6 +85,21 @@ const DatalabPreset = definePreset(Aura, {
           color: black;
           background: none;
         }
+        .p-datatable .v-select .vs__dropdown-menu {
+          z-index: 9999 !important;
+        }
+        .p-datatable tbody {
+          overflow: visible !important;
+        }
+        .p-datatable tbody tr {
+          overflow: visible !important;
+        }
+        .p-datatable tbody td {
+          overflow: visible !important;
+        }
+        .p-datatable td .v-select {
+          position: static;
+        }
       `,
 });
 

--- a/webapp/src/primevue-theme-preset.js
+++ b/webapp/src/primevue-theme-preset.js
@@ -88,15 +88,6 @@ const DatalabPreset = definePreset(Aura, {
         .p-datatable .v-select .vs__dropdown-menu {
           z-index: 9999 !important;
         }
-        .p-datatable tbody {
-          overflow: visible !important;
-        }
-        .p-datatable tbody tr {
-          overflow: visible !important;
-        }
-        .p-datatable tbody td {
-          overflow: visible !important;
-        }
         .p-datatable td .v-select {
           position: static;
         }

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -1471,3 +1471,20 @@ export async function compareItemVersions(refcode, baseVersion, targetVersion) {
       throw error;
     });
 }
+
+export function invalidateToken(refcode) {
+  return fetch_post(`${API_URL}/items/${refcode}/invalidate-access-token`, {
+    token: "admin-invalidation",
+  })
+    .then(function (response_json) {
+      if (response_json.status !== "success") {
+        throw new Error(
+          "Failed to invalidate token: " + (response_json.detail || response_json.message),
+        );
+      }
+      return response_json;
+    })
+    .catch(function (error) {
+      throw error;
+    });
+}

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -61,6 +61,10 @@ export default createStore({
         page: 0,
         rows: 20,
       },
+      users: {
+        page: 0,
+        rows: 20,
+      },
     },
     block_errors: {},
     block_infos: {},

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -66,6 +66,10 @@ export default createStore({
         page: 0,
         rows: 20,
       },
+      tokens: {
+        page: 0,
+        rows: 20,
+      },
     },
     block_errors: {},
     block_infos: {},

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -18,6 +18,7 @@ export default createStore({
     equipment_list: null,
     starting_material_list: null,
     collection_list: null,
+    groups_list: null,
     saved_status_items: {},
     saved_status_blocks: {},
     saved_status_collections: {},
@@ -90,6 +91,9 @@ export default createStore({
     setCollectionList(state, collectionSummaries) {
       // collectionSummaries is an array of json objects summarizing the available collections
       state.collection_list = collectionSummaries || [];
+    },
+    setGroupsList(state, groups) {
+      state.groups_list = groups;
     },
     setDisplayName(state, displayName) {
       state.currentUserDisplayName = displayName;

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -70,6 +70,10 @@ export default createStore({
         page: 0,
         rows: 20,
       },
+      groups: {
+        page: 0,
+        rows: 10,
+      },
     },
     block_errors: {},
     block_infos: {},


### PR DESCRIPTION
## Changes
Migrated all admin tables (Users, Access Tokens &Groups) to PrimeVue DataTable with full bulk operations support and advanced filtering.

## Added

### UserTable
* Checkboxes for multi-user selection
* Bulk operations dropdown with:
  * Activate/deactivate users
  * Change user role
  * Add users to group(s)
  * Assign manager(s)
* Column filters

### TokenTable
* Checkboxes for multi-token selection
* Bulk invalidate tokens operation
* Column filters (token status, item type, refcode, created by)

### GroupTable
* Checkboxes for multi-group selection
* Bulk delete groups operation
* Column filters (group ID, name, description)

`DynamicDataTable` and `DynamicDataTableButtons` are getting quite large now (~800+ lines). We should consider extracting the config mapping and splitting bulk actions by domain (inventory/users/tokens) into separate files to keep things manageable.