### PR TITLE
Disable add item buttons when not logged in

### DIFF
--- a/webapp/src/components/DynamicDataTableButtons.vue
+++ b/webapp/src/components/DynamicDataTableButtons.vue
@@ -23,7 +23,14 @@
         <button
           data-testid="add-item-button"
           class="btn btn-default btn-action"
-          :title="adminSuperUserMode ? 'Disabled in super-user mode' : ''"
+          :disabled="!isLoggedIn || adminSuperUserMode"
+          :title="
+            !isLoggedIn
+              ? 'Log in to add items'
+              : adminSuperUserMode
+                ? 'Disabled in super-user mode'
+                : ''
+          "
           @click="$emit('open-create-item-modal')"
         >
           Add an item
@@ -31,8 +38,14 @@
         <button
           data-testid="batch-item-button"
           class="btn btn-default btn-action"
-          :disabled="adminSuperUserMode"
-          :title="adminSuperUserMode ? 'Disabled in super-user mode' : ''"
+          :disabled="!isLoggedIn || adminSuperUserMode"
+          :title="
+            !isLoggedIn
+              ? 'Log in to add items'
+              : adminSuperUserMode
+                ? 'Disabled in super-user mode'
+                : ''
+          "
           @click="$emit('open-batch-create-item-modal')"
         >
           Add batch of items
@@ -40,8 +53,9 @@
         <button
           data-testid="scan-qr-button"
           class="btn btn-default btn-action"
-          aria-label="Scan QR code"
-          title="Scan QR code"
+          :disabled="!isLoggedIn"
+          :aria-label="!isLoggedIn ? 'Log in to scan QR codes' : 'Scan QR code'"
+          :title="!isLoggedIn ? 'Log in to scan QR codes' : 'Scan QR code'"
           @click="$emit('open-qr-scanner-modal')"
         >
           <font-awesome-icon icon="qrcode" /> Scan QR code
@@ -278,6 +292,9 @@ export default {
   computed: {
     adminSuperUserMode() {
       return this.$store.getters.isAdminSuperUserModeActive;
+    },
+    isLoggedIn() {
+      return this.$store.state.currentUserID !== null;
     },
   },
   watch: {

--- a/webapp/src/components/DynamicDataTableButtons.vue
+++ b/webapp/src/components/DynamicDataTableButtons.vue
@@ -53,9 +53,8 @@
         <button
           data-testid="scan-qr-button"
           class="btn btn-default btn-action"
-          :disabled="!isLoggedIn"
-          :aria-label="!isLoggedIn ? 'Log in to scan QR codes' : 'Scan QR code'"
-          :title="!isLoggedIn ? 'Log in to scan QR codes' : 'Scan QR code'"
+          aria-label="Scan QR code"
+          title="Scan QR code"
           @click="$emit('open-qr-scanner-modal')"
         >
           <font-awesome-icon icon="qrcode" /> Scan QR code


### PR DESCRIPTION
Disables the add item buttons when not logged in, or when in admin mode. Prevents confusing "unable to create item" error if someone doesn't realise they're not logged in.