### PR TITLE
Add checksums to `File` for duplicate detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,11 @@ docker compose up database
 - E2E testing with Cypress
 
 
+## Database and Test Guidelines
+
+- **Avoid database migrations** for new features or functionality unless absolutely necessary. New optional fields (with `None` defaults) are preferred so that existing documents remain valid without migration.
+- **Extend tests, don't modify existing assertions.** When adding new functionality, add new assertions or new test functions rather than changing existing expected values. If existing test values must change, do so deliberately and explain the reason.
+
 ## Environment Variables
 
 Key environment variables (can also be set in config.json):

--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -653,6 +653,25 @@
         }
       }
     },
+    "FileChecksums": {
+      "title": "FileChecksums",
+      "description": "Content checksums for a file.",
+      "type": "object",
+      "properties": {
+        "md5": {
+          "title": "Md5",
+          "type": "string"
+        },
+        "sha256": {
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "md5",
+        "sha256"
+      ]
+    },
     "File": {
       "title": "File",
       "description": "A model for representing a file that has been tracked or uploaded to datalab.",
@@ -796,6 +815,9 @@
         "is_live": {
           "title": "Is Live",
           "type": "boolean"
+        },
+        "checksums": {
+          "$ref": "#/definitions/FileChecksums"
         }
       },
       "required": [

--- a/pydatalab/schemas/equipment.json
+++ b/pydatalab/schemas/equipment.json
@@ -617,6 +617,25 @@
         }
       }
     },
+    "FileChecksums": {
+      "title": "FileChecksums",
+      "description": "Content checksums for a file.",
+      "type": "object",
+      "properties": {
+        "md5": {
+          "title": "Md5",
+          "type": "string"
+        },
+        "sha256": {
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "md5",
+        "sha256"
+      ]
+    },
     "File": {
       "title": "File",
       "description": "A model for representing a file that has been tracked or uploaded to datalab.",
@@ -760,6 +779,9 @@
         "is_live": {
           "title": "Is Live",
           "type": "boolean"
+        },
+        "checksums": {
+          "$ref": "#/definitions/FileChecksums"
         }
       },
       "required": [

--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -710,6 +710,25 @@
         }
       }
     },
+    "FileChecksums": {
+      "title": "FileChecksums",
+      "description": "Content checksums for a file.",
+      "type": "object",
+      "properties": {
+        "md5": {
+          "title": "Md5",
+          "type": "string"
+        },
+        "sha256": {
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "md5",
+        "sha256"
+      ]
+    },
     "File": {
       "title": "File",
       "description": "A model for representing a file that has been tracked or uploaded to datalab.",
@@ -853,6 +872,9 @@
         "is_live": {
           "title": "Is Live",
           "type": "boolean"
+        },
+        "checksums": {
+          "$ref": "#/definitions/FileChecksums"
         }
       },
       "required": [

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -763,6 +763,25 @@
         }
       }
     },
+    "FileChecksums": {
+      "title": "FileChecksums",
+      "description": "Content checksums for a file.",
+      "type": "object",
+      "properties": {
+        "md5": {
+          "title": "Md5",
+          "type": "string"
+        },
+        "sha256": {
+          "title": "Sha256",
+          "type": "string"
+        }
+      },
+      "required": [
+        "md5",
+        "sha256"
+      ]
+    },
     "File": {
       "title": "File",
       "description": "A model for representing a file that has been tracked or uploaded to datalab.",
@@ -906,6 +925,9 @@
         "is_live": {
           "title": "Is Live",
           "type": "boolean"
+        },
+        "checksums": {
+          "$ref": "#/definitions/FileChecksums"
         }
       },
       "required": [

--- a/pydatalab/src/pydatalab/models/files.py
+++ b/pydatalab/src/pydatalab/models/files.py
@@ -1,10 +1,20 @@
 from typing import Any
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from pydatalab.models.entries import Entry
 from pydatalab.models.traits import HasOwner, HasRevisionControl
 from pydatalab.models.utils import IsoformatDateTime
+
+
+class FileChecksums(BaseModel):
+    """Content checksums for a file."""
+
+    md5: str
+    """The MD5 hex digest of the file contents."""
+
+    sha256: str
+    """The SHA-256 hex digest of the file contents."""
 
 
 class File(Entry, HasOwner, HasRevisionControl):
@@ -58,3 +68,6 @@ class File(Entry, HasOwner, HasRevisionControl):
 
     is_live: bool
     """Whether or not the file should be watched for future updates."""
+
+    checksums: FileChecksums | None
+    """Content checksums (MD5 and SHA-256) of the file."""

--- a/pydatalab/tests/server/test_files.py
+++ b/pydatalab/tests/server/test_files.py
@@ -76,6 +76,11 @@ def test_get_file_and_delete(client, default_filepath, default_sample):
     assert response.json["item_data"]["files"][0]["name"] == default_filepath.name
     assert response.json["item_data"]["files"][0]["size"] == 2465718
 
+    checksums = response.json["item_data"]["files"][0]["checksums"]
+    assert checksums is not None
+    assert len(checksums["md5"]) == 32
+    assert len(checksums["sha256"]) == 64
+
     file_response = client.get(f"/files/{file_id}/{default_filepath.name}")
     assert file_response.json is None
     assert file_response.status_code == 200


### PR DESCRIPTION
Closes #1402.

Can be used for easier duplicate file detection in the future.