### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @jdbocarsly @ml-evs @BenjaminCharmes


### PR DESCRIPTION
CODEOWNERS is not really fit for purpose in this repo -- I want to be able to safely merge my own PRs using things like merge queues, without bothering people. Removing this file should mean that becomes possible again, though need to take care to restrict other people's permissions from doing this (i.e., to admins rather than anyone with write access).