### PR TITLE
Update dependabot config (trial uv, use dependency groups)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
   target-branch: main
   labels:
   - dependency_updates
+  - Python
   versioning-strategy: "increase-if-necessary"
   ignore:
     - dependency-name: "pydantic"
@@ -26,12 +27,22 @@ updates:
     time: "05:33"
   target-branch: main
   labels:
-  - CI
   - dependency_updates
+  - CI
   groups:
     github-actions:
       applies-to: version-updates
       dependency-type: production
+- package-ecosystem: npm
+  directory: "./webapp"
+  schedule:
+    day: monday
+    interval: monthly
+    time: "05:33"
+  target-branch: main
+  labels:
+  - dependency_updates
+  - javascript
 - package-ecosystem: docker
   directory: "/"
   schedule:
@@ -40,6 +51,5 @@ updates:
     time: "05:33"
   target-branch: main
   labels:
-  - CI
   - dependency_updates
   - build

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,19 @@ updates:
   - dependency_updates
   - Python
   versioning-strategy: "increase-if-necessary"
+  groups:
+    python-production:
+      applies-to: version-updates
+      dependency-type: production
+      update-types:
+        - minor
+        - patch
+    python-development:
+      applies-to: version-updates
+      dependency-type: development
+      update-types:
+        - minor
+        - patch
   ignore:
     - dependency-name: "pydantic"
       versions: [ ">=2" ]
@@ -43,6 +56,19 @@ updates:
   labels:
   - dependency_updates
   - javascript
+  groups:
+    js-production:
+      applies-to: version-updates
+      dependency-type: production
+      update-types:
+        - minor
+        - patch
+    js-development:
+      applies-to: version-updates
+      dependency-type: development
+      update-types:
+        - minor
+        - patch
 - package-ecosystem: docker
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-- package-ecosystem: pip
+- package-ecosystem: uv
   directory: "./pydatalab"
   schedule:
     interval: monthly
@@ -32,3 +32,14 @@ updates:
     github-actions:
       applies-to: version-updates
       dependency-type: production
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    day: monday
+    interval: monthly
+    time: "05:33"
+  target-branch: main
+  labels:
+  - CI
+  - dependency_updates
+  - build


### PR DESCRIPTION
The automated dependency system set up that created e.g., #1618 still leaves a lot to be desired, and we rarely get around to merging them. This PR tries to use some of the newer features in dependabot to monitor dependencies with uv, yarn and docker directly.