### PR TITLE
Fix email auth config behaviour: never auto-activate accounts unless config var is set

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/auth.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/auth.py
@@ -639,10 +639,8 @@ def email_logged_in():
             raise UserRegistrationForbidden
 
         create_account = AccountStatus.UNVERIFIED
-        if (
-            CONFIG.EMAIL_DOMAIN_ALLOW_LIST is None
-            or CONFIG.EMAIL_AUTO_ACTIVATE_ACCOUNTS
-            or CONFIG.AUTO_ACTIVATE_ACCOUNTS
+        if CONFIG.EMAIL_DOMAIN_ALLOW_LIST is None and (
+            CONFIG.EMAIL_AUTO_ACTIVATE_ACCOUNTS or CONFIG.AUTO_ACTIVATE_ACCOUNTS
         ):
             create_account = AccountStatus.ACTIVE
 


### PR DESCRIPTION
Fixes the priority between config vars`EMAIL_DOMAIN_ALLOW_LIST` and `(EMAIL_)AUTO_ACTIVATE_ACCOUNTS` which was inverted; the latter should now take precedence.