### PR TITLE
Refactor about page into collapsible sections and add route to customise

### DIFF
--- a/.docker/app_entrypoint.sh
+++ b/.docker/app_entrypoint.sh
@@ -31,6 +31,7 @@ echo ""
 echo "  APP_VERSION: ${VUE_APP_GIT_VERSION}"
 echo "  API_URL: ${VUE_APP_API_URL}"
 echo "  LOGO_URL: ${VUE_APP_LOGO_URL}"
+echo "  LOGO_WIDTH: ${VUE_APP_LOGO_WIDTH}"
 echo "  HOMEPAGE_URL: ${VUE_APP_HOMPAGE_URL}"
 echo "  EDITABLE_INVENTORY: ${VUE_APP_EDITABLE_INVENTORY}"
 echo "  WEBSITE_TITLE: ${VUE_APP_WEBSITE_TITLE}"
@@ -44,6 +45,7 @@ for file in $ROOT_DIR/js/app.*.js* $ROOT_DIR/*html; do
     sed -i "s|0.0.0-git|${VUE_APP_GIT_VERSION}|g" $file
     sed -i "s|magic-api-url|${VUE_APP_API_URL}|g" $file
     sed -i "s|magic-logo-url|${VUE_APP_LOGO_URL}|g" $file
+    sed -i "s|magic-logo-width|${VUE_APP_LOGO_WIDTH}|g" $file
     sed -i "s|magic-homepage-url|${VUE_APP_HOMEPAGE_URL}|g" $file
     sed -i "s|magic-setting|${VUE_APP_EDITABLE_INVENTORY}|g" $file
     sed -i "s|magic-title|${VUE_APP_WEBSITE_TITLE}|g" $file

--- a/pydatalab/docs/config.md
+++ b/pydatalab/docs/config.md
@@ -94,6 +94,74 @@ Currently, there are two mechanisms for accessing remote files:
 1. You can mount the filesystem locally and provide the path in your datalab config file. For example, for Cambridge Chemistry users, you will have to (connect to the ChemNet VPN and) mount the Grey Group backup servers on your local machine, then define these folders in your config.
 2. Access over SSH: alternatively, you can set up passwordless `ssh` access to a machine (e.g., using `citadel` as a proxy jump), and paths on that remote machine can be configured as separate filesystems. The filesystem metadata will be synced periodically, and any files attached in `datalab` will be downloaded and stored locally on the `pydatalab` server (with the file being kept younger than 1 hour old on each access).
 
+## Customisation and branding
+
+Deployments can customise the look and feel of their *datalab* instance by providing files under a `public/custom/` directory in the web app.
+This directory can be a symlink to a folder in your deployment repository, or mounted as a volume in Docker.
+It should be made available at `webapp/public/custom/` relative to the *datalab* source tree.
+
+The following customisations are supported:
+
+### CSS overrides (`public/custom/override.css`)
+
+A CSS file that is loaded globally before the app styles, allowing you to override any default styling.
+Common uses include setting a custom font, accent colours, or other branding tweaks.
+If this file does not exist, it is silently ignored.
+
+For example, to set a custom font globally:
+
+```css
+@font-face {
+  font-family: "My Custom Font";
+  src: url("fonts/MyCustomFont-Regular.woff2") format("woff2");
+  font-weight: 400;
+}
+
+:root {
+  --custom-font-family: "My Custom Font";
+}
+
+#app {
+  font-family: var(--custom-font-family), sans-serif;
+}
+```
+
+### Custom fonts (`public/custom/fonts/`)
+
+Place font files (`.woff2`, `.ttf`, etc.) in this directory and reference them from `override.css` using relative paths (e.g., `url("fonts/MyFont.woff2")`).
+
+### Custom logos (`public/custom/logos/`)
+
+Place logo images in this directory.
+They can be referenced from custom components or CSS using absolute paths (e.g., `/custom/logos/mylogo.png`).
+
+The main instance logo can also be customised via the `VUE_APP_LOGO_URL` environment variable, which accepts a path relative to the `public/` directory.
+
+### Custom about page (`public/custom/components/CustomAbout.vue`)
+
+Deployments can provide a custom Vue component that will be displayed in a collapsible panel on the About page.
+Place a `CustomAbout.vue` file in `public/custom/components/` and it will automatically replace the default empty skeleton at build time (via webpack's `NormalModuleReplacementPlugin`).
+
+The component can contain any valid Vue template, script and scoped styles.
+No special configuration or flags are needed — if the file exists, it will be used.
+
+### Directory structure
+
+A typical deployment customisation directory looks like:
+
+```
+public/custom/
+├── override.css
+├── fonts/
+│   ├── MyFont-Regular.woff2
+│   └── MyFont-Bold.woff2
+├── logos/
+│   └── mylogo.png
+└── components/
+    └── CustomAbout.vue
+```
+
+
 
 ## Config API Reference
 

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 /dist
+public/custom
 
 /tests/e2e/videos/
 /tests/e2e/screenshots/

--- a/webapp/cypress/component/SampleTableTest.cy.jsx
+++ b/webapp/cypress/component/SampleTableTest.cy.jsx
@@ -145,7 +145,7 @@ describe("SampleTable Component Tests", () => {
       "ID",
       "Type",
       "Status",
-      "Sample name",
+      "Name",
       "Formula",
       "Date",
       "Collections",
@@ -169,7 +169,7 @@ describe("SampleTable Component Tests", () => {
           .within(() => {
             cy.get("td").eq(columnIndices["ID"]).should("contain.text", "sample1");
             cy.get("td").eq(columnIndices["Type"]).should("contain.text", "samples");
-            cy.get("td").eq(columnIndices["Sample name"]).should("contain.text", "Sample 1");
+            cy.get("td").eq(columnIndices["Name"]).should("contain.text", "Sample 1");
             cy.get("td").eq(columnIndices["Date"]).should("contain.text", "2023");
             cy.get("td").eq(columnIndices["Collections"]).find(".badge").should("have.length", 1);
             cy.get("td").eq(columnIndices["Creators"]).find(".avatar").should("have.length", 1);
@@ -181,7 +181,7 @@ describe("SampleTable Component Tests", () => {
           .within(() => {
             cy.get("td").eq(columnIndices["ID"]).should("contain.text", "cell1");
             cy.get("td").eq(columnIndices["Type"]).should("contain.text", "cells");
-            cy.get("td").eq(columnIndices["Sample name"]).should("contain.text", "Cell 1");
+            cy.get("td").eq(columnIndices["Name"]).should("contain.text", "Cell 1");
             cy.get("td").eq(columnIndices["Date"]).should("contain.text", "2023");
             cy.get("td").eq(columnIndices["Collections"]).find(".badge").should("have.length", 1);
             cy.get("td").eq(columnIndices["Creators"]).find(".avatar").should("have.length", 2);
@@ -406,33 +406,33 @@ describe("SampleTable Component Tests", () => {
           .should("have.attr", "title", "ACTIVE");
 
         cy.get(".p-datatable-thead th")
-          .eq(columnIndices["Sample name"])
+          .eq(columnIndices["Name"])
           .find(".p-datatable-sort-icon")
           .click();
         cy.get(".p-datatable-tbody tr")
           .eq(0)
           .find("td")
-          .eq(columnIndices["Sample name"])
+          .eq(columnIndices["Name"])
           .should("contain.text", "Cell 1");
         cy.get(".p-datatable-tbody tr")
           .eq(1)
           .find("td")
-          .eq(columnIndices["Sample name"])
+          .eq(columnIndices["Name"])
           .should("contain.text", "Cell 2");
 
         cy.get(".p-datatable-thead th")
-          .eq(columnIndices["Sample name"])
+          .eq(columnIndices["Name"])
           .find(".p-datatable-sort-icon")
           .click();
         cy.get(".p-datatable-tbody tr")
           .eq(0)
           .find("td")
-          .eq(columnIndices["Sample name"])
+          .eq(columnIndices["Name"])
           .should("contain.text", "Sample 3");
         cy.get(".p-datatable-tbody tr")
           .eq(1)
           .find("td")
-          .eq(columnIndices["Sample name"])
+          .eq(columnIndices["Name"])
           .should("contain.text", "Sample 2");
 
         cy.get(".p-datatable-thead th")

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <link rel="icon" href="<%= BASE_URL %>favicon.ico" />
     <title><%= htmlWebpackPlugin.options.title %></title>
-    <link rel="stylesheet" href="<%= BASE_URL %>custom/fonts.css" onerror="this.remove()" />
+    <link rel="stylesheet" href="<%= BASE_URL %>custom/override.css" onerror="this.remove()" />
     <script
       type="text/javascript"
       src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.3.min.js"

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <link rel="icon" href="<%= BASE_URL %>favicon.ico" />
     <title><%= htmlWebpackPlugin.options.title %></title>
+    <link rel="stylesheet" href="<%= BASE_URL %>custom/fonts.css" onerror="this.remove()" />
     <script
       type="text/javascript"
       src="https://cdn.bokeh.org/bokeh/release/bokeh-2.4.3.min.js"

--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -38,7 +38,7 @@ body {
 @import url("https://fonts.googleapis.com/css?family=Roboto+Mono");
 
 :root {
-  --font-primary: Figtree, Avenir, Arial, sans-serif;
+  --font-primary: var(--custom-font-family), Figtree, Avenir, Arial, sans-serif;
   --font-monospace: "Roboto Mono", monospace;
 }
 

--- a/webapp/src/components/CustomAbout.vue
+++ b/webapp/src/components/CustomAbout.vue
@@ -1,0 +1,12 @@
+<template>
+  <!-- Deployment-specific about page content. Override this component by
+       placing a CustomAbout.vue in public/custom/ which will be copied
+       into src/components/ at build time. -->
+</template>
+
+<script>
+export default {
+  name: "CustomAbout",
+  hasContent: false,
+};
+</script>

--- a/webapp/src/components/CustomAbout.vue
+++ b/webapp/src/components/CustomAbout.vue
@@ -1,7 +1,8 @@
 <template>
   <!-- Deployment-specific about page content. Override this component by
-       placing a CustomAbout.vue in public/custom/ which will be copied
-       into src/components/ at build time. -->
+       placing a CustomAbout.vue in public/custom/components/ and it will be
+       used instead of this skeleton at build time. -->
+  <div />
 </template>
 
 <script>

--- a/webapp/src/components/DeploymentInfo.vue
+++ b/webapp/src/components/DeploymentInfo.vue
@@ -1,0 +1,75 @@
+<template>
+  <div v-if="info" class="deployment-info">
+    <h5 v-if="title">{{ title }}</h5>
+    <div class="info-grid">
+      <div class="info-card">
+        <div class="info-label">API version</div>
+        <div class="info-value">
+          <code>{{ info.server_version ?? "unknown" }}</code>
+        </div>
+      </div>
+      <div class="info-card">
+        <div class="info-label">App version</div>
+        <div class="info-value">
+          <code>{{ appVersion }}</code>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { getInfo } from "@/server_fetch_utils.js";
+import { APP_VERSION } from "@/resources.js";
+
+export default {
+  props: {
+    title: {
+      type: String,
+      default: "",
+    },
+  },
+  data() {
+    return {
+      info: null,
+      appVersion: APP_VERSION,
+    };
+  },
+  async mounted() {
+    this.info = this.$store.state.serverInfo;
+    if (!this.info) {
+      this.info = await getInfo();
+    }
+  },
+};
+</script>
+
+<style scoped>
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.info-card {
+  background: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 6px;
+  padding: 12px;
+  text-align: center;
+}
+
+.info-label {
+  font-size: 0.75em;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #6c757d;
+  margin-bottom: 4px;
+  font-weight: 600;
+}
+
+.info-value code {
+  font-size: 0.85em;
+  color: #212529;
+}
+</style>

--- a/webapp/src/components/Navbar.vue
+++ b/webapp/src/components/Navbar.vue
@@ -10,9 +10,9 @@
       style="display: inline-block"
       target="_blank"
     >
-      <img class="logo-banner" :src="logo_url" />
+      <img class="logo-banner" :width="logo_width + 'px'" :src="logo_url" />
     </a>
-    <img v-else class="logo-banner" :src="logo_url" />
+    <img v-else class="logo-banner" :width="logo_width + 'px'" :src="logo_url" />
   </div>
 
   <div
@@ -53,7 +53,7 @@
 </template>
 
 <script>
-import { API_URL, LOGO_URL, HOMEPAGE_URL } from "@/resources.js";
+import { API_URL, LOGO_URL, LOGO_WIDTH, HOMEPAGE_URL } from "@/resources.js";
 import LoginDetails from "@/components/LoginDetails.vue";
 
 export default {
@@ -65,6 +65,7 @@ export default {
     return {
       apiUrl: API_URL,
       logo_url: LOGO_URL,
+      logo_width: LOGO_WIDTH,
       homepage_url: HOMEPAGE_URL,
       user: null,
     };
@@ -89,7 +90,6 @@ export default {
 <style scoped>
 .logo-banner {
   max-width: 200px;
-  width: 100px;
   display: block;
   margin-left: auto;
   margin-right: auto;

--- a/webapp/src/components/SampleTable.vue
+++ b/webapp/src/components/SampleTable.vue
@@ -33,7 +33,7 @@ export default {
         },
         { field: "type", header: "Type", filter: true, label: "Type" },
         { field: "status", header: "Status", body: "FormattedItemStatus", filter: true },
-        { field: "name", header: "Sample name", label: "Sample name" },
+        { field: "name", header: "Name", label: "Sample name" },
         {
           field: "chemform",
           header: "Formula",

--- a/webapp/src/resources.js
+++ b/webapp/src/resources.js
@@ -29,6 +29,7 @@ export const QR_CODE_RESOLVER_URL = process.env.VUE_APP_QR_CODE_RESOLVER_URL;
 export const FEDERATION_QR_CODE_RESOLVER_URL = "https://purl.datalab-org.io";
 
 export const LOGO_URL = process.env.VUE_APP_LOGO_URL;
+export const LOGO_WIDTH = process.env.VUE_APP_LOGO_WIDTH || "100";
 export const HOMEPAGE_URL = process.env.VUE_APP_HOMEPAGE_URL;
 export const APP_VERSION = process.env.VUE_APP_GIT_VERSION;
 

--- a/webapp/src/views/About.vue
+++ b/webapp/src/views/About.vue
@@ -5,7 +5,7 @@
       <div class="col-lg-8 mx-auto">
         <details v-if="customAboutHasContent" class="about-panel" open>
           <summary>
-            <h5 class="d-inline">About this <i>datalab</i></h5>
+            <span class="h5 d-inline">About this <i>datalab</i></span>
           </summary>
           <div class="about-panel-content">
             <CustomAbout />
@@ -14,7 +14,7 @@
 
         <details class="about-panel" open>
           <summary>
-            <h5 class="d-inline">Deployment info</h5>
+            <span class="h5 d-inline">Deployment info</span>
           </summary>
           <div class="about-panel-content">
             <DeploymentInfo :title="'Software versions'" />
@@ -29,7 +29,7 @@
 
         <details class="about-panel">
           <summary>
-            <h5 class="d-inline">About <i>datalab</i></h5>
+            <span class="h5 d-inline">About <i>datalab</i></span>
           </summary>
           <div class="about-panel-content">
             <p>
@@ -207,7 +207,7 @@ th {
   background: #efefef;
 }
 
-.about-panel summary h5 {
+.about-panel summary .h5 {
   margin: 0;
 }
 

--- a/webapp/src/views/About.vue
+++ b/webapp/src/views/About.vue
@@ -3,9 +3,14 @@
   <div class="container">
     <div class="row">
       <div class="col-lg-8 mx-auto">
-        <h4 class="p-3 mx-auto" style="width: 90%">
-          <i>datalab</i> is a place to store experimental data and the connections between them.
-        </h4>
+        <details v-if="customAboutHasContent" class="about-panel" open>
+          <summary>
+            <h5 class="d-inline">About this <i>datalab</i></h5>
+          </summary>
+          <div class="about-panel-content">
+            <CustomAbout />
+          </div>
+        </details>
 
         <details class="about-panel" open>
           <summary>
@@ -112,13 +117,13 @@
 
             <div align="center" style="padding-top: 20px">
               <a href="https://www.big-map.eu" target="_blank"
-                ><img class="funding-logo" src="/logos/bigmap.png" width="100"
+                ><img class="funding-logo" src="/logos/bigmap.png" max-width="100px"
               /></a>
               <a href="https://www.leverhulme.ac.uk" target="_blank"
-                ><img class="funding-logo" src="/logos/leverhulme.png" width="250"
+                ><img class="funding-logo" src="/logos/leverhulme.png" max-width="200px"
               /></a>
               <a href="https://www.faraday.ac.uk" target="_blank"
-                ><img class="funding-logo" src="/logos/faraday.png" width="250"
+                ><img class="funding-logo" src="/logos/faraday.png" max-width="200px"
               /></a>
             </div>
           </div>
@@ -133,9 +138,15 @@ import Navbar from "@/components/Navbar";
 import StatisticsTable from "@/components/StatisticsTable";
 import UserActivityGraph from "@/components/UserActivityGraph.vue";
 import DeploymentInfo from "@/components/DeploymentInfo.vue";
+import CustomAbout from "@/components/CustomAbout.vue";
 
 export default {
-  components: { Navbar, StatisticsTable, UserActivityGraph, DeploymentInfo },
+  components: { Navbar, StatisticsTable, UserActivityGraph, DeploymentInfo, CustomAbout },
+  computed: {
+    customAboutHasContent() {
+      return CustomAbout.hasContent !== false;
+    },
+  },
 };
 </script>
 

--- a/webapp/src/views/About.vue
+++ b/webapp/src/views/About.vue
@@ -2,129 +2,127 @@
   <Navbar />
   <div class="container">
     <div class="row">
-      <div class="col-sm-8 mx-auto">
+      <div class="col-lg-8 mx-auto">
         <h4 class="p-3 mx-auto" style="width: 90%">
-          datalab is a place to store experimental data and the connections between them.
+          <i>datalab</i> is a place to store experimental data and the connections between them.
         </h4>
 
-        <p>
-          datalab is open source (MIT license) and development occurs on GitHub at
-          <a href="https://github.com/datalab-org/datalab"
-            ><font-awesome-icon :icon="['fab', 'github']" />&nbsp;datalab-org/datalab</a
-          >
-          with documentation available on
-          <a href="https://the-datalab.readthedocs.io"
-            ><font-awesome-icon icon="book" />&nbsp;ReadTheDocs</a
-          >.
-        </p>
+        <details class="about-panel" open>
+          <summary>
+            <h5 class="d-inline">Deployment info</h5>
+          </summary>
+          <div class="about-panel-content">
+            <DeploymentInfo :title="'Software versions'" />
+          </div>
+          <div class="about-panel-content">
+            <StatisticsTable :title="'Deployment statistics'" />
+          </div>
+          <div class="about-panel-content">
+            <UserActivityGraph :combined="true" :title="'User activity'" />
+          </div>
+        </details>
 
-        <StatisticsTable :title="'Deployment stats:'" />
+        <details class="about-panel">
+          <summary>
+            <h5 class="d-inline">About <i>datalab</i></h5>
+          </summary>
+          <div class="about-panel-content">
+            <p>
+              <i>datalab</i> is open source (MIT license) and development occurs on GitHub at
+              <a href="https://github.com/datalab-org/datalab"
+                ><font-awesome-icon :icon="['fab', 'github']" />&nbsp;datalab-org/datalab</a
+              >
+              with documentation available on
+              <a href="https://the-datalab.readthedocs.io"
+                ><font-awesome-icon icon="book" />&nbsp;ReadTheDocs</a
+              >.
+            </p>
 
-        <UserActivityGraph :combined="true" :title="'User activity:'" />
+            <p><i>datalab</i> was initially conceived and developed by:</p>
+            <ul>
+              <li>
+                <a href="https://jdbocarsly.github.io">Prof Joshua Bocarsly</a> (<a
+                  href="https://www.uh.edu/nsm/chemistry"
+                  >Department of Chemistry, University of Houston</a
+                >, previously
+                <a href="https://www.ch.cam.ac.uk/"
+                  >Department of Chemistry, University of Cambridge</a
+                >)
+              </li>
+              <li>
+                <a href="https://ml-evs.science">Dr Matthew Evans</a> (<a
+                  href="https://www.ch.cam.ac.uk/"
+                  >Department of Chemistry, University of Cambridge</a
+                >, previously
+                <a href="https://uclouvain.be/en/research-institutes/imcn/modl"
+                  >MODL-IMCN, UCLouvain</a
+                >
+                &amp; <a href="https://matgenix.com">Matgenix</a>)
+              </li>
+            </ul>
+            <p>
+              with support from the group of
+              <a href="https://grey.group.ch.cam.ac.uk/group">Professor Clare Grey</a> (University
+              of Cambridge), and major contributions from:
+            </p>
+            <ul>
+              <li><a href="https://github.com/BenjaminCharmes">Benjamin Charmes</a></li>
+              <li><a href="https://github.com/be-smith/">Dr Ben Smith</a></li>
+              <li><a href="https://github.com/yue-here">Dr Yue Wu</a></li>
+            </ul>
+            <p>
+              plus contributions, feedback and testing performed by other members of the community,
+              in particular, the groups of
+              <a href="https://cliffegroup.co.uk">Prof Matt Cliffe</a> (University of Cambridge) and
+              <a href="https://www.tu.berlin/en/concat">Dr Peter Kraus</a> (TUBerlin) and the
+              company <a href="https://matgenix.com">Matgenix SRL</a>.
+            </p>
+            <p>
+              A full list of code contributions can be found on
+              <a href="https://github.com/datalab-org/datalab/graphs/contributors">GitHub</a>.
+            </p>
 
-        <h5>Deployment info:</h5>
-        <div class="p-3">
-          <table>
-            <tbody>
-              <tr>
-                <td>API version</td>
-                <td>
-                  <code>{{ apiInfo?.server_version ?? "unknown" }}</code>
-                </td>
-              </tr>
-              <tr>
-                <td>App version</td>
-                <td>
-                  <code>{{ appVersion }}</code>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+            <p>
+              Contributions to <i>datalab</i> have been supported by a mixture of academic funding
+              and consultancy work through
+              <a href="https://datalab.industries"><em>datalab industries ltd</em></a
+              >.
+            </p>
+            <p>In particular, the developers thank:</p>
+            <ul>
+              <li>
+                Initial proof-of-concept funding from the European Union's Horizon 2020 research and
+                innovation programme under grant agreement 957189 (DOI:
+                <a href="https://doi.org/10.3030/957189">10.3030/957189</a>), the
+                <a href="https://www.big-map.eu"
+                  >Battery Interface Genome - Materials Acceleration Platform (BIG-MAP)</a
+                >, as an external stakeholder project.
+              </li>
+              <li>
+                The <a href="https://www.faraday.ac.uk">Faraday Institution</a> CATMAT project
+                (FIRG016) for support of Dr Joshua Bocarsly during initial development of
+                <em>datalab</em>.
+              </li>
+              <li>
+                The <a href="https://leverhulme.ac.uk">Leverhulme Trust</a> and
+                <a href="https://newtontrust.cam.ac.uk">Isaac Newton Trust</a> for support provided
+                by an early career fellowship for Dr Matthew Evans.
+              </li>
+            </ul>
 
-        <h5>Credits and acknowledgements</h5>
-
-        <p><i>datalab</i> was initially conceived and developed by:</p>
-        <ul>
-          <li>
-            <a href="https://jdbocarsly.github.io">Prof Joshua Bocarsly</a> (<a
-              href="https://www.uh.edu/nsm/chemistry"
-              >Department of Chemistry, University of Houston</a
-            >, previously
-            <a href="https://www.ch.cam.ac.uk/">Department of Chemistry, University of Cambridge</a
-            >)
-          </li>
-          <li>
-            <a href="https://ml-evs.science">Dr Matthew Evans</a> (<a
-              href="https://www.ch.cam.ac.uk/"
-              >Department of Chemistry, University of Cambridge</a
-            >, previously
-            <a href="https://uclouvain.be/en/research-institutes/imcn/modl">MODL-IMCN, UCLouvain</a>
-            &amp; <a href="https://matgenix.com">Matgenix</a>)
-          </li>
-        </ul>
-        <p>
-          with support from the group of
-          <a href="https://grey.group.ch.cam.ac.uk/group">Professor Clare Grey</a> (University of
-          Cambridge), and major contributions from:
-        </p>
-        <ul>
-          <li><a href="https://github.com/BenjaminCharmes">Benjamin Charmes</a></li>
-          <li><a href="https://github.com/be-smith/">Dr Ben Smith</a></li>
-          <li><a href="https://github.com/yue-here">Dr Yue Wu</a></li>
-        </ul>
-        <p>
-          plus contributions, feedback and testing performed by other members of the community, in
-          particular, the groups of
-          <a href="https://cliffegroup.co.uk">Prof Matt Cliffe</a> (University of Cambridge) and
-          <a href="https://www.tu.berlin/en/concat">Dr Peter Kraus</a> (TUBerlin) and the company
-          <a href="https://matgenix.com">Matgenix SRL</a>.
-        </p>
-        <p>
-          A full list of code contributions can be found on
-          <a href="https://github.com/datalab-org/datalab/graphs/contributors">GitHub</a>.
-        </p>
-
-        <p>
-          Contributions to <i>datalab</i> have been supported by a mixture of academic funding and
-          consultancy work through
-          <a href="https://datalab.industries"><em>datalab industries ltd</em></a
-          >.
-        </p>
-        <p>In particular, the developers thank:</p>
-        <ul>
-          <li>
-            Initial proof-of-concept funding from the European Union's Horizon 2020 research and
-            innovation programme under grant agreement 957189 (DOI:
-            <a href="https://doi.org/10.3030/957189">10.3030/957189</a>), the
-            <a href="https://www.big-map.eu"
-              >Battery Interface Genome - Materials Acceleration Platform (BIG-MAP)</a
-            >, as an external stakeholder project.
-          </li>
-          <li>
-            The <a href="https://www.faraday.ac.uk">Faraday Institution</a> CATMAT project (FIRG016)
-            for support of Dr Joshua Bocarsly during initial development of <em>datalab</em>.
-          </li>
-          <li>
-            The <a href="https://leverhulme.ac.uk">Leverhulme Trust</a> and
-            <a href="https://newtontrust.cam.ac.uk">Isaac Newton Trust</a> for support provided by
-            an early career fellowship for Dr Matthew Evans.
-          </li>
-        </ul>
-
-        <div align="center" style="padding-top: 20px">
-          <a href="https://www.big-map.eu" target="_blank"
-            ><img class="funding-logo" src="/logos/bigmap.png" width="100"
-          /></a>
-          <a href="https://www.leverhulme.ac.uk" target="_blank"
-            ><img class="funding-logo" src="/logos/leverhulme.png" width="250"
-          /></a>
-          <a href="https://www.faraday.ac.uk" target="_blank"
-            ><img class="funding-logo" src="/logos/faraday.png" width="250"
-          /></a>
-        </div>
-
-        <!-- <tiny-mce-inline /> -->
+            <div align="center" style="padding-top: 20px">
+              <a href="https://www.big-map.eu" target="_blank"
+                ><img class="funding-logo" src="/logos/bigmap.png" width="100"
+              /></a>
+              <a href="https://www.leverhulme.ac.uk" target="_blank"
+                ><img class="funding-logo" src="/logos/leverhulme.png" width="250"
+              /></a>
+              <a href="https://www.faraday.ac.uk" target="_blank"
+                ><img class="funding-logo" src="/logos/faraday.png" width="250"
+              /></a>
+            </div>
+          </div>
+        </details>
       </div>
     </div>
   </div>
@@ -132,25 +130,12 @@
 
 <script>
 import Navbar from "@/components/Navbar";
-import { getInfo } from "@/server_fetch_utils.js";
 import StatisticsTable from "@/components/StatisticsTable";
 import UserActivityGraph from "@/components/UserActivityGraph.vue";
-import { APP_VERSION } from "@/resources.js";
+import DeploymentInfo from "@/components/DeploymentInfo.vue";
 
 export default {
-  components: { Navbar, StatisticsTable, UserActivityGraph },
-  data() {
-    return {
-      apiInfo: { server_version: "unknown" },
-      appVersion: APP_VERSION,
-    };
-  },
-  async mounted() {
-    this.apiInfo = this.$store.state.serverInfo;
-    if (this.apiInfo == null) {
-      this.apiInfo = await getInfo();
-    }
-  },
+  components: { Navbar, StatisticsTable, UserActivityGraph, DeploymentInfo },
 };
 </script>
 
@@ -170,5 +155,52 @@ th {
 
 .funding-logo {
   margin: 10px;
+}
+
+.about-panel {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  margin-top: 1.5rem;
+  margin-bottom: 2rem;
+  background: #fff;
+  overflow: hidden;
+}
+
+.about-panel summary {
+  padding: 14px 20px;
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  user-select: none;
+  background: #f5f5f5;
+}
+
+.about-panel summary::-webkit-details-marker {
+  display: none;
+}
+
+.about-panel summary::before {
+  content: "\25B6";
+  font-size: 0.7em;
+  color: #666;
+  transition: transform 0.2s ease;
+}
+
+.about-panel[open] summary::before {
+  transform: rotate(90deg);
+}
+
+.about-panel summary:hover {
+  background: #efefef;
+}
+
+.about-panel summary h5 {
+  margin: 0;
+}
+
+.about-panel-content {
+  margin: 12px 20px 20px;
 }
 </style>

--- a/webapp/vue.config.js
+++ b/webapp/vue.config.js
@@ -1,8 +1,14 @@
-const { ProvidePlugin } = require("webpack");
+const { ProvidePlugin, NormalModuleReplacementPlugin } = require("webpack");
+const fs = require("fs");
+const path = require("path");
+
+const customAboutPath = path.resolve(__dirname, "public/custom/components/CustomAbout.vue");
 
 module.exports = {
   transpileDependencies: ["mermaid"],
   configureWebpack: (config) => {
+    config.resolve.symlinks = false;
+
     config.resolve.fallback = {
       stream: false,
       process: require.resolve("process/browser"),
@@ -23,12 +29,20 @@ module.exports = {
       include: /node_modules/,
       type: "javascript/auto",
     });
-    config.plugins = [
-      ...(config.plugins || []),
+    const plugins = [
       new ProvidePlugin({
         process: "process/browser",
       }),
     ];
+
+    // If a deployment provides a custom CustomAbout.vue, use it instead of the skeleton
+    if (fs.existsSync(customAboutPath)) {
+      plugins.push(
+        new NormalModuleReplacementPlugin(/\/components\/CustomAbout\.vue$/, customAboutPath),
+      );
+    }
+
+    config.plugins = [...(config.plugins || []), ...plugins];
   },
   chainWebpack: (config) => {
     config.plugin("html").tap((args) => {


### PR DESCRIPTION
Closes #1558 by:

- [x] Refactor about page into collapsible `<details>` panels for deployment info, about datalab, and an optional custom section
- [x] Add CustomAbout.vue skeleton component that deployments can override to display instance-specific branding and content
- [x] Use webpack NormalModuleReplacementPlugin to swap in a custom CustomAbout.vue from public/custom/components/ at build time
- [x] Support deployment-specific CSS overrides via public/custom/override.css, loaded from index.html with a graceful fallback (onerror="this.remove()") when not present
- [x] Add --custom-font-family CSS custom property so deployments can set a global font via their override stylesheet
- [x] Allow logo width to be customised via environment variables
- [x] Rename "Sample name" column header to "Name" and update corresponding Cypress component tests
- [x] Added "Branding and customisation" section to the deployment docs