### PR TITLE
Fix item graph rendering

### DIFF
--- a/webapp/cypress/component/ItemGraphTest.cy.jsx
+++ b/webapp/cypress/component/ItemGraphTest.cy.jsx
@@ -1,0 +1,192 @@
+import ItemGraph from "@/components/ItemGraph.vue";
+import { createStore } from "vuex";
+
+// Minimal store to avoid errors from child components
+const store = createStore({
+  state: {
+    itemGraphData: null,
+    itemGraphIsLoading: false,
+  },
+});
+
+const singleNode = {
+  nodes: [{ data: { id: "SAMPLE1", name: "Test Sample", type: "samples", special: false } }],
+  edges: [],
+};
+
+const twoConnectedNodes = {
+  nodes: [
+    { data: { id: "SAMPLE1", name: "Test Sample", type: "samples", special: false } },
+    {
+      data: {
+        id: "SM1",
+        name: "Starting Material 1",
+        type: "starting_materials",
+        special: false,
+      },
+    },
+  ],
+  edges: [{ data: { id: "SM1->SAMPLE1", source: "SM1", target: "SAMPLE1", value: 1 } }],
+};
+
+const graphWithSpecialNode = {
+  nodes: [
+    { data: { id: "SAMPLE1", name: "Test Sample", type: "samples", special: true } },
+    { data: { id: "SAMPLE2", name: "Parent Sample", type: "samples", special: false } },
+  ],
+  edges: [{ data: { id: "SAMPLE2->SAMPLE1", source: "SAMPLE2", target: "SAMPLE1", value: 1 } }],
+};
+
+const disconnectedNodes = {
+  nodes: [
+    { data: { id: "SAMPLE1", name: "Sample A", type: "samples", special: false } },
+    { data: { id: "SAMPLE2", name: "Sample B", type: "samples", special: false } },
+    { data: { id: "SAMPLE3", name: "Sample C", type: "samples", special: false } },
+  ],
+  edges: [],
+};
+
+const mixedTypeGraph = {
+  nodes: [
+    { data: { id: "SAMPLE1", name: "My Sample", type: "samples", special: false } },
+    { data: { id: "CELL1", name: "My Cell", type: "cells", special: false } },
+    {
+      data: { id: "SM1", name: "Starting Material", type: "starting_materials", special: false },
+    },
+    { data: { id: "EQUIP1", name: "Furnace", type: "equipment", special: false } },
+  ],
+  edges: [
+    { data: { id: "SM1->SAMPLE1", source: "SM1", target: "SAMPLE1", value: 1 } },
+    { data: { id: "SAMPLE1->CELL1", source: "SAMPLE1", target: "CELL1", value: 1 } },
+  ],
+};
+
+const selfLoopGraph = {
+  nodes: [{ data: { id: "SAMPLE1", name: "Self-ref Sample", type: "samples", special: false } }],
+  edges: [{ data: { id: "SAMPLE1->SAMPLE1", source: "SAMPLE1", target: "SAMPLE1", value: 1 } }],
+};
+
+const danglingEdgeGraph = {
+  nodes: [{ data: { id: "SAMPLE1", name: "Test Sample", type: "samples", special: false } }],
+  edges: [{ data: { id: "MISSING->SAMPLE1", source: "MISSING", target: "SAMPLE1", value: 1 } }],
+};
+
+const mountGraph = (graphData, opts = {}) => {
+  cy.mount(ItemGraph, {
+    props: {
+      graphData,
+      showOptions: opts.showOptions ?? false,
+      defaultGraphStyle: opts.defaultGraphStyle ?? "elk-stress",
+    },
+    global: {
+      plugins: [store],
+    },
+  });
+};
+
+// Helper to access the cytoscape instance from the Vue component
+const getCyInstance = () => cy.wrap(null).then(() => Cypress.vueWrapper.vm.cy);
+
+describe("ItemGraph", () => {
+  it("renders a single node", () => {
+    mountGraph(singleNode);
+    getCyInstance().then((cyInstance) => {
+      expect(cyInstance.nodes().length).to.equal(1);
+      expect(cyInstance.edges().length).to.equal(0);
+      expect(cyInstance.nodes('[id="SAMPLE1"]').length).to.equal(1);
+    });
+  });
+
+  it("renders two connected nodes with an edge", () => {
+    mountGraph(twoConnectedNodes);
+    getCyInstance().then((cyInstance) => {
+      expect(cyInstance.nodes().length).to.equal(2);
+      expect(cyInstance.edges().length).to.equal(1);
+      expect(cyInstance.edges()[0].data("source")).to.equal("SM1");
+      expect(cyInstance.edges()[0].data("target")).to.equal("SAMPLE1");
+    });
+  });
+
+  it("renders disconnected nodes without errors", () => {
+    mountGraph(disconnectedNodes);
+    getCyInstance().then((cyInstance) => {
+      expect(cyInstance.nodes().length).to.equal(3);
+      expect(cyInstance.edges().length).to.equal(0);
+    });
+  });
+
+  it("renders a graph with mixed item types", () => {
+    mountGraph(mixedTypeGraph);
+    getCyInstance().then((cyInstance) => {
+      expect(cyInstance.nodes().length).to.equal(4);
+      expect(cyInstance.edges().length).to.equal(2);
+      expect(cyInstance.nodes('[type="samples"]').length).to.equal(1);
+      expect(cyInstance.nodes('[type="cells"]').length).to.equal(1);
+      expect(cyInstance.nodes('[type="starting_materials"]').length).to.equal(1);
+      expect(cyInstance.nodes('[type="equipment"]').length).to.equal(1);
+    });
+  });
+
+  it("renders a graph with a self-loop", () => {
+    mountGraph(selfLoopGraph);
+    getCyInstance().then((cyInstance) => {
+      expect(cyInstance.nodes().length).to.equal(1);
+      expect(cyInstance.edges().length).to.equal(1);
+      expect(cyInstance.edges()[0].data("source")).to.equal("SAMPLE1");
+      expect(cyInstance.edges()[0].data("target")).to.equal("SAMPLE1");
+    });
+  });
+
+  it("highlights the special node with a border", () => {
+    mountGraph(graphWithSpecialNode);
+    getCyInstance().then((cyInstance) => {
+      const specialNode = cyInstance.nodes('[id="SAMPLE1"]');
+      const normalNode = cyInstance.nodes('[id="SAMPLE2"]');
+      expect(specialNode.data("special")).to.equal(true);
+      expect(normalNode.data("special")).to.equal(false);
+      expect(specialNode.style("border-width")).to.not.equal("0px");
+      expect(normalNode.style("border-width")).to.equal("0px");
+    });
+  });
+
+  it("nodes have distinct colors per type", () => {
+    mountGraph(mixedTypeGraph);
+    getCyInstance().then((cyInstance) => {
+      const colors = new Set();
+      cyInstance.nodes().forEach((node) => {
+        colors.add(node.style("background-color"));
+      });
+      expect(colors.size).to.equal(4);
+    });
+  });
+
+  it("shows options panel when showOptions is true", () => {
+    mountGraph(twoConnectedNodes, { showOptions: true });
+    cy.contains("configure").should("be.visible");
+  });
+
+  it("hides options panel when showOptions is false", () => {
+    mountGraph(twoConnectedNodes, { showOptions: false });
+    cy.contains("configure").should("not.exist");
+  });
+
+  it("handles an edge referencing a non-existent node", () => {
+    mountGraph(danglingEdgeGraph);
+    getCyInstance().then((cyInstance) => {
+      // cytoscape silently drops edges with missing source/target
+      expect(cyInstance.nodes().length).to.equal(1);
+      expect(cyInstance.edges().length).to.equal(0);
+    });
+  });
+
+  it("renders with different layout algorithms", () => {
+    const layouts = ["euler", "cola", "fcose", "elk-stress", "elk-disco", "random"];
+    layouts.forEach((layout) => {
+      mountGraph(twoConnectedNodes, { defaultGraphStyle: layout });
+      getCyInstance().then((cyInstance) => {
+        expect(cyInstance.nodes().length).to.equal(2);
+        expect(cyInstance.edges().length).to.equal(1);
+      });
+    });
+  });
+});

--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -38,7 +38,7 @@ body {
 @import url("https://fonts.googleapis.com/css?family=Roboto+Mono");
 
 :root {
-  --font-primary: var(--custom-font-family), Figtree, Avenir, Arial, sans-serif;
+  --font-primary: var(--custom-font-family, Figtree), Figtree, Avenir, Arial, sans-serif;
   --font-monospace: "Roboto Mono", monospace;
 }
 

--- a/webapp/src/components/ItemGraph.vue
+++ b/webapp/src/components/ItemGraph.vue
@@ -110,7 +110,7 @@
       </div>
     </div>
   </div>
-  <div ref="cyContainer" v-bind="$attrs" />
+  <div id="cy" ref="cyContainer" v-bind="$attrs" />
 </template>
 
 <script>

--- a/webapp/src/components/ItemGraph.vue
+++ b/webapp/src/components/ItemGraph.vue
@@ -261,9 +261,13 @@ export default {
         console.warn("Cytoscape container not ready");
         return;
       }
+      const nodeIds = new Set((this.graphData.nodes || []).map((n) => n.data.id));
+      const validEdges = (this.graphData.edges || []).filter(
+        (e) => nodeIds.has(e.data.source) && nodeIds.has(e.data.target),
+      );
       this.cy = cytoscape({
         container: this.$refs.cyContainer,
-        elements: this.graphData,
+        elements: { nodes: this.graphData.nodes || [], edges: validEdges },
         userPanningEnabled: true,
         minZoom: 0.5,
         maxZoom: 1,


### PR DESCRIPTION
Fixes a recent bug introduced that prevented the cytoscape graph view from getting a height set properly.

Also filters the graph on the front-end as extra protection for deleted nodes, which needs to be fixed properly at the root cause.

Finally, claude helped write some component tests for the item graph, which seem to work really well and confirm both of these fixes.

TODO:

- [ ] Investigate problem with collection graph