### PR TITLE
Add blocks as nodes to item graph and optimise rendering

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/graphs.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/graphs.py
@@ -49,7 +49,7 @@ def get_graph_cy_format(
             query = {}
         all_documents = flask_mongo.db.items.find(
             {**query, **get_default_permissions(user_only=False)},
-            projection={"item_id": 1, "name": 1, "type": 1, "relationships": 1},
+            projection={"item_id": 1, "name": 1, "type": 1, "relationships": 1, "blocks_obj": 1},
         )
         node_ids: set[str] = {document["item_id"] for document in all_documents}
         all_documents.rewind()
@@ -60,7 +60,7 @@ def get_graph_cy_format(
                 "item_id": item_id,
                 **get_default_permissions(user_only=False),
             },
-            projection={"item_id": 1, "name": 1, "type": 1, "relationships": 1},
+            projection={"item_id": 1, "name": 1, "type": 1, "relationships": 1, "blocks_obj": 1},
         )
 
         if not main_item:
@@ -95,7 +95,13 @@ def get_graph_cy_format(
                             "item_id": relationship["item_id"],
                             **get_default_permissions(user_only=False),
                         },
-                        projection={"item_id": 1, "name": 1, "type": 1, "relationships": 1},
+                        projection={
+                            "item_id": 1,
+                            "name": 1,
+                            "type": 1,
+                            "relationships": 1,
+                            "blocks_obj": 1,
+                        },
                     )
                     if related_item:
                         all_documents.append(related_item)
@@ -111,7 +117,13 @@ def get_graph_cy_format(
                         },
                         **get_default_permissions(user_only=False),
                     },
-                    projection={"item_id": 1, "name": 1, "type": 1, "relationships": 1},
+                    projection={
+                        "item_id": 1,
+                        "name": 1,
+                        "type": 1,
+                        "relationships": 1,
+                        "blocks_obj": 1,
+                    },
                 )
             )
 
@@ -212,6 +224,36 @@ def get_graph_cy_format(
                 }
             )
 
+        # Add block nodes and edges for this item
+        for block_id, block_data in (document.get("blocks_obj") or {}).items():
+            if block_id not in drawn_elements:
+                drawn_elements.add(block_id)
+                blocktype = block_data.get("blocktype", "unknown")
+                nodes.append(
+                    {
+                        "data": {
+                            "id": block_id,
+                            "name": blocktype,
+                            "type": "blocks",
+                            "shape": "rectangle",
+                            "parent_item_id": document["item_id"],
+                        }
+                    }
+                )
+            edge_id = f"{document['item_id']}->{block_id}"
+            if edge_id not in drawn_elements:
+                drawn_elements.add(edge_id)
+                edges.append(
+                    {
+                        "data": {
+                            "id": edge_id,
+                            "source": document["item_id"],
+                            "target": block_id,
+                            "value": 1,
+                        }
+                    }
+                )
+
     whitelist = {edge["data"]["source"] for edge in edges} | {
         edge["data"]["target"] for edge in edges
     }
@@ -221,7 +263,7 @@ def get_graph_cy_format(
     nodes = [
         node
         for node in nodes
-        if node["data"]["type"] in ("samples", "cells")
+        if node["data"]["type"] in ("samples", "cells", "blocks")
         or node["data"]["id"] in whitelist
         or node["data"]["id"].startswith("Collection:")
     ]

--- a/pydatalab/tests/server/test_graph.py
+++ b/pydatalab/tests/server/test_graph.py
@@ -158,3 +158,44 @@ def test_simple_graph(admin_client):
     graph = admin_client.get("/item-graph/parent").json
     assert len(graph["nodes"]) == 6
     assert len(graph["edges"]) == 5
+
+    # Add blocks to items and verify they appear in the graph
+    response = admin_client.post(
+        "/add-data-block/",
+        json={"block_type": "comment", "item_id": "parent", "index": 0},
+    )
+    assert response.status_code == 200
+    parent_block_id = response.json["new_block_obj"]["block_id"]
+
+    response = admin_client.post(
+        "/add-data-block/",
+        json={"block_type": "comment", "item_id": "child_1", "index": 0},
+    )
+    assert response.status_code == 200
+    child_1_block_id = response.json["new_block_obj"]["block_id"]
+
+    # Full graph should now include block nodes and edges
+    graph = admin_client.get("/item-graph").json
+    node_ids = {n["data"]["id"] for n in graph["nodes"]}
+    assert parent_block_id in node_ids
+    assert child_1_block_id in node_ids
+    block_nodes = [n for n in graph["nodes"] if n["data"]["type"] == "blocks"]
+    assert len(block_nodes) == 2
+    assert all(n["data"]["name"] == "comment" for n in block_nodes)
+    assert all(n["data"]["shape"] == "rectangle" for n in block_nodes)
+
+    # Block nodes should have edges connecting them to their parent items
+    block_edges = [
+        e for e in graph["edges"] if e["data"]["target"] in {parent_block_id, child_1_block_id}
+    ]
+    assert len(block_edges) == 2
+    block_edge_map = {e["data"]["target"]: e["data"]["source"] for e in block_edges}
+    assert block_edge_map[parent_block_id] == "parent"
+    assert block_edge_map[child_1_block_id] == "child_1"
+
+    # Item-specific graph should include that item's blocks
+    graph = admin_client.get("/item-graph/parent").json
+    node_ids = {n["data"]["id"] for n in graph["nodes"]}
+    assert parent_block_id in node_ids
+    # child_1's block should also appear since child_1 is in parent's graph
+    assert child_1_block_id in node_ids

--- a/webapp/src/components/ItemGraph.vue
+++ b/webapp/src/components/ItemGraph.vue
@@ -194,7 +194,7 @@ export default {
     },
     defaultShowBlocks: {
       type: Boolean,
-      default: true,
+      default: false,
     },
   },
   data() {

--- a/webapp/src/components/ItemGraph.vue
+++ b/webapp/src/components/ItemGraph.vue
@@ -108,6 +108,10 @@
           label samples/cells by name</label
         >
       </div>
+      <div class="form-group form-check mt-3">
+        <input id="show-blocks" v-model="showBlocks" class="form-check-input" type="checkbox" />
+        <label class="form-check-label" for="show-blocks"> show data blocks </label>
+      </div>
     </div>
   </div>
   <div id="cy" ref="cyContainer" v-bind="$attrs" />
@@ -182,6 +186,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    defaultShowBlocks: {
+      type: Boolean,
+      default: true,
+    },
   },
   data() {
     return {
@@ -192,6 +200,7 @@ export default {
       ignoreCollections: [],
       labelStartingMaterialsByName: true,
       labelItemsByName: false,
+      showBlocks: this.defaultShowBlocks,
       layoutIsRunning: true,
     };
   },
@@ -215,6 +224,18 @@ export default {
         .selector('node[type = "samples"], node[type = "cells"]')
         .style("label", this.labelItemsByName ? "data(name)" : "data(id)")
         .update();
+    },
+    showBlocks() {
+      const blockNodes = this.cy.$('node[type = "blocks"]');
+      const blockEdges = blockNodes.connectedEdges();
+      if (this.showBlocks) {
+        blockNodes.show();
+        blockEdges.show();
+      } else {
+        blockNodes.hide();
+        blockEdges.hide();
+      }
+      this.updateAndRunLayout();
     },
   },
   mounted() {
@@ -295,6 +316,15 @@ export default {
             },
           },
           {
+            selector: 'node[type = "blocks"]',
+            style: {
+              label: "data(name)",
+              shape: "rectangle",
+              width: 20,
+              height: 20,
+            },
+          },
+          {
             selector: "edge",
             style: {
               width: 4,
@@ -310,16 +340,24 @@ export default {
 
       // set colors of each of the nodes by type
       this.cy.nodes().each(function (element) {
-        element.style(
-          "background-color",
-          element.data("special") == 1
-            ? itemTypes[element.data("type")].lightColor
-            : itemTypes[element.data("type")].navbarColor,
-        );
+        const type = element.data("type");
+        if (type && itemTypes[type]) {
+          element.style(
+            "background-color",
+            element.data("special") == 1 ? itemTypes[type].lightColor : itemTypes[type].navbarColor,
+          );
+        }
         element.style("border-width", element.data("special") == 1 ? 2 : 0);
         element.style("border-color", "grey");
         (element.style("shape"), element.data("shape") == "triangle" ? "triangle" : "ellipse");
       });
+
+      // Toggle hide block nodes
+      if (!this.showBlocks) {
+        const blockNodes = this.cy.$('node[type = "blocks"]');
+        blockNodes.hide();
+        blockNodes.connectedEdges().hide();
+      }
 
       this.cy.on("layoutstart", () => {
         this.layoutIsRunning = true;
@@ -343,10 +381,21 @@ export default {
         node.style("border-width", node.data("special") == 1 ? 2 : 0);
         node.style("border-color", "grey");
       });
+      // Re-run layout when a node is dragged, locking the dragged node in place
+      // so the rest of the graph adjusts around it
+      this.cy.on("dragfree", "node", (evt) => {
+        var node = evt.target;
+        node.lock();
+        this.updateAndRunLayout();
+        node.unlock();
+      });
+
       this.cy.on("click", "node", function (evt) {
         var node = evt.target;
         if (node.data("type") == "collections") {
           window.open(`/collections/${node.data("id").replace("Collection: ", "")}`, "_blank");
+        } else if (node.data("type") == "blocks") {
+          window.open(`/edit/${node.data("parent_item_id")}`, "_blank");
         } else {
           window.open(`/edit/${node.data("id")}`, "_blank");
         }

--- a/webapp/src/components/ItemGraph.vue
+++ b/webapp/src/components/ItemGraph.vue
@@ -135,7 +135,8 @@ cytoscape.use(fcose);
 const layoutOptions = {
   "elk-disco": {
     name: "elk",
-    animate: true,
+    animate: "end",
+    animationDuration: 1000,
     elk: {
       algorithm: "disco",
     },
@@ -145,23 +146,28 @@ const layoutOptions = {
   },
   "elk-stress": {
     name: "elk",
+    animate: "end",
+    animationDuration: 300,
     elk: {
       algorithm: "stress",
     },
   },
   cola: {
     name: "cola",
-    animate: true,
+    animate: "end",
+    animationDuration: 300,
     centerGraph: false,
   },
   euler: {
     name: "euler",
-    animate: true,
+    animate: "end",
+    animationDuration: 300,
     pull: 0.002,
   },
   fcose: {
     name: "fcose",
-    animate: true,
+    animate: "end",
+    animationDuration: 300,
     randomize: false,
     packComponents: true,
   },
@@ -415,7 +421,7 @@ export default {
 
 #cy {
   width: 100%;
-  height: 90vh;
+  height: 80vh;
   /* display: block;*/
 }
 </style>

--- a/webapp/src/components/ItemRelationshipVisualization.vue
+++ b/webapp/src/components/ItemRelationshipVisualization.vue
@@ -23,7 +23,7 @@
       style="height: 200px; width: 100%; border: 1px solid transparent; border-radius: 5px"
       :default-graph-style="'elk-stress'"
       :show-options="false"
-      :default-show-blocks="true"
+      :default-show-blocks="false"
     />
   </div>
 </template>

--- a/webapp/src/components/ItemRelationshipVisualization.vue
+++ b/webapp/src/components/ItemRelationshipVisualization.vue
@@ -23,6 +23,7 @@
       style="height: 200px; width: 100%; border: 1px solid transparent; border-radius: 5px"
       :default-graph-style="'elk-stress'"
       :show-options="false"
+      :default-show-blocks="true"
     />
   </div>
 </template>

--- a/webapp/src/resources.js
+++ b/webapp/src/resources.js
@@ -132,6 +132,13 @@ export const itemTypes = {
     labelColor: "#c77c02",
     display: "equipment",
   },
+  blocks: {
+    navbarColor: "#9C2007",
+    navbarName: "Block",
+    lightColor: "#9C2007",
+    labelColor: "#9C2007",
+    display: "block",
+  },
 };
 
 export const SAMPLE_TABLE_TYPES = ["samples", "cells"];


### PR DESCRIPTION
Closes #1083 

Adds blocks to the item graph, toggleable

Also changes the way animations work for the graph -- instead the layout is computed and only then is it displayed, rather than animating each frame.

This PR got missed a few weeks ago before the release -- as well as introducing the blocks to the graph (now disabled by default) it also adds significant performance improvements by "giving up" at computing complex layouts after a timeout.