### PR TITLE
Use BDF parquet files when caching parsed echem

### DIFF
--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -68,6 +68,7 @@ apps = [
     "nmrglue ~= 0.12",
     # Electrochemistry
     "navani ~=0.1.16",
+    "pyarrow ~= 23.0.1",
     # Raman
     "pybaselines ~= 1.1",
     "renishawwire >= 0.1.16",

--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -137,6 +137,7 @@ dev = [
 
 [tool.uv.sources]
 datalab-app-plugin-insitu = { git = "https://github.com/datalab-org/datalab-app-plugin-insitu.git", rev = "v0.4.0" }
+navani = { git = "https://github.com/be-smith/navani.git", rev = "ml-evs/excel-tweaks" }
 nmrglue = { git = "https://github.com/jjhelmus/nmrglue.git", rev = "b6408751bf18801a0a4ce084acf4d31335e2b02a" }  # TODO: Update when new release is made
 
 [tool.pytest.ini_options]

--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -67,7 +67,7 @@ apps = [
     # NMR
     "nmrglue ~= 0.12",
     # Electrochemistry
-    "navani ~=0.1.16",
+    "navani ~=0.1.17",
     "pyarrow ~= 23.0.1",
     # Raman
     "pybaselines ~= 1.1",

--- a/pydatalab/src/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/src/pydatalab/apps/echem/blocks.py
@@ -109,54 +109,16 @@ class CycleBlock(DataBlock):
             )
         return ext
 
-    def _try_export_bdf(self, raw_df: pd.DataFrame, bdf_path: Path) -> Path | None:
-        """Attempt to export a navani DataFrame to BDF format, returning the path on success or
-        None on failure."""
-        try:
-            export_to_bdf(raw_df, save=True, filepath=bdf_path)
-            return bdf_path
-        except Exception as exc:
-            LOGGER.warning("Failed to export BDF file: %s", exc)
-            LOGGER.debug("Exception details for failed BDF export", exc_info=True)
-            return None
-
-    def _load_and_cache_echem(
-        self,
-        location: Path,
-        bdf_path: Path | None,
-        reload: bool,
-        locations: list[Path] | None = None,
-    ) -> tuple[pd.DataFrame, Path | None]:
-        """Load echem data from file(s) with pickle and BDF caching.
-
-        For a single file, `location` is the source file path and `locations` is None.
-        For multi-file stitching, `location` is the merged cache path (used to derive the
-        pickle path) and `locations` contains all source file paths to stitch.
+    def _parse_echem_files(self, location: Path, locations: list[Path] | None) -> pd.DataFrame:
+        """Parse echem source file(s) via navani and return the raw DataFrame.
 
         Parameters:
-            location: Path to the source file (single) or the merged cache base path (multi).
-            bdf_path: Desired path for the BDF export, or None to skip export.
-            reload: If True, bypass the pickle cache and re-parse from source.
-            locations: For multi-file mode, the list of all source file paths to stitch.
-
-        Returns:
-            A tuple of (raw_df, bdf_path) where bdf_path may be None if export was skipped
-            or failed.
+            location: Path to the single source file.
+            locations: For multi-file mode, all source paths to stitch together.
         """
-        pickle_path = location.with_suffix(".RAW_PARSED.pkl")
-
-        if not reload and pickle_path.exists():
-            raw_df = pd.read_pickle(pickle_path)  # noqa: S301
-            # Regenerate BDF if it was deleted or previously failed
-            if bdf_path is not None and not bdf_path.exists():
-                bdf_path = self._try_export_bdf(raw_df, bdf_path)
-            return raw_df, bdf_path
-
         if locations is not None:
-            # Multi-file: stitch all source files together
             try:
                 LOGGER.debug("Loading multiple echem files with navani: %s", locations)
-                # Suppress the navani warning when stitching files with differing capacity columns
                 with warnings.catch_warnings():
                     warnings.filterwarnings(
                         "ignore",
@@ -167,23 +129,85 @@ class CycleBlock(DataBlock):
                         ),
                         category=UserWarning,
                     )
-
-                    raw_df = ec.multi_echem_file_loader([str(loc) for loc in locations])
+                    return ec.multi_echem_file_loader([str(loc) for loc in locations])
             except Exception as exc:
                 raise RuntimeError(
                     f"Navani raised an error when parsing multiple files: {exc}"
                 ) from exc
         else:
-            # Single file
             try:
-                raw_df = ec.echem_file_loader(str(location))
+                return ec.echem_file_loader(str(location))
             except Exception as exc:
                 raise RuntimeError(f"Navani raised an error when parsing: {exc}") from exc
 
-        raw_df.to_pickle(pickle_path)
-        if bdf_path is not None:
-            bdf_path = self._try_export_bdf(raw_df, bdf_path)
-        return raw_df, bdf_path
+    def _load_echem_from_cache(self, parquet_path: Path) -> pd.DataFrame:
+        """Load a previously cached echem DataFrame from a ``.bdf.parquet`` file."""
+        return ec.echem_file_loader(str(parquet_path))
+
+    def _save_bdf(
+        self, raw_df: pd.DataFrame, parquet_path: Path, csv_path: Path | None
+    ) -> Path | None:
+        """Save a navani DataFrame as ``.bdf.parquet`` (cache) and optionally ``.bdf.csv`` (download).
+
+        Parameters:
+            raw_df: The navani-parsed DataFrame to export.
+            parquet_path: Destination path for the parquet cache.
+            csv_path: Destination path for the CSV download, or None to skip writing CSV.
+
+        Returns the CSV path if written, or None otherwise.
+        """
+        try:
+            bdf_df = export_to_bdf(raw_df)
+            if csv_path is not None:
+                bdf_df.to_csv(csv_path, index=False)
+        except Exception as exc:
+            LOGGER.warning("Failed to export BDF file: %s", exc)
+            LOGGER.debug("Exception details for failed BDF export", exc_info=True)
+            return None
+        try:
+            # Parquet requires homogeneous column types; cast mixed-type object columns to str
+            for col in bdf_df.select_dtypes(include="object").columns:
+                bdf_df[col] = bdf_df[col].astype(str)
+            bdf_df.to_parquet(parquet_path, index=False)
+        except Exception as exc:
+            LOGGER.warning("Failed to export BDF parquet file: %s", exc)
+            LOGGER.debug("Exception details for failed BDF parquet export", exc_info=True)
+        return csv_path
+
+    def _load_and_cache_echem(
+        self,
+        location: Path,
+        parquet_path: Path | None,
+        csv_path: Path | None,
+        reload: bool,
+        locations: list[Path] | None = None,
+    ) -> tuple[pd.DataFrame, Path | None]:
+        """Load echem data, using the ``.bdf.parquet`` cache when available.
+
+        On a cache miss (or when ``reload=True``), parses the source file(s) via navani and
+        writes a ``.bdf.parquet`` cache and (when ``csv_path`` is provided) a ``.bdf.csv``
+        download file. Returns the ``.bdf.csv`` path for use as a download URL, or None if
+        no CSV path was given, caching was not requested, or export failed.
+
+        Parameters:
+            location: Path to the source file (single) or the merged cache base path (multi).
+            parquet_path: Path for the ``.bdf.parquet`` cache file, or None to skip caching.
+            csv_path: Path for the ``.bdf.csv`` download file, or None to skip writing CSV.
+            reload: If True, bypass the cache and re-parse from source.
+            locations: For multi-file mode, the list of all source file paths to stitch.
+        """
+        if not reload and parquet_path is not None and parquet_path.exists():
+            raw_df = self._load_echem_from_cache(parquet_path)
+            # Regenerate CSV if it was deleted
+            if csv_path is not None and not csv_path.exists():
+                self._save_bdf(raw_df, parquet_path, csv_path)
+            return raw_df, csv_path
+
+        raw_df = self._parse_echem_files(location, locations)
+
+        if parquet_path is not None:
+            csv_path = self._save_bdf(raw_df, parquet_path, csv_path)
+        return raw_df, csv_path
 
     def _load_single(self, file_id: ObjectId, reload: bool) -> tuple[pd.DataFrame, Path | None]:
         """Parse a single echem file using navani, with pickle caching.
@@ -199,11 +223,21 @@ class CycleBlock(DataBlock):
 
         ext = self._get_file_extension(filename)
         location = Path(file_info["location"])
-        # If the source is already BDF, no export needed (avoids e.g. file.bdf.csv -> file.bdf.csv.bdf.csv)
-        bdf_path = (
-            None if ext.startswith(".bdf") else location.with_name(f"{location.stem}.bdf.csv")
-        )
-        return self._load_and_cache_echem(location, bdf_path, reload)
+        bare_stem = Path(filename).stem.removesuffix(".bdf")
+        if ext == ".bdf.parquet":
+            # Source is already parquet: generate a .bdf.csv for download alongside it.
+            # The parquet cache uses a _cached suffix to avoid overwriting the source.
+            parquet_path = location.with_name(f"{bare_stem}_cached.bdf.parquet")
+            csv_path = location.with_name(f"{bare_stem}.bdf.csv")
+            return self._load_and_cache_echem(location, parquet_path, csv_path, reload)
+        if ext.startswith(".bdf"):
+            # Other BDF formats: cache to parquet but don't write a redundant .bdf.csv.
+            # bdf_url will fall back to linking the source file directly.
+            parquet_path = location.with_name(f"{bare_stem}_cached.bdf.parquet")
+            return self._load_and_cache_echem(location, parquet_path, None, reload)
+        parquet_path = location.with_name(f"{location.stem}_cached.bdf.parquet")
+        csv_path = location.with_name(f"{location.stem}.bdf.csv")
+        return self._load_and_cache_echem(location, parquet_path, csv_path, reload)
 
     def _load_multi(
         self, file_ids: list[ObjectId], reload: bool
@@ -223,8 +257,11 @@ class CycleBlock(DataBlock):
         ).hexdigest()[:8]
         # Cache files sit alongside the first file, named by the hash of the file ID combination
         cache_location = locations[0].parent / f"merged_{cache_key}"
-        bdf_path: Path | None = cache_location.with_name(cache_location.name + ".bdf.csv")
-        return self._load_and_cache_echem(cache_location, bdf_path, reload, locations=locations)
+        parquet_path = cache_location.with_name(cache_location.name + "_cached.bdf.parquet")
+        csv_path = cache_location.with_name(cache_location.name + ".bdf.csv")
+        return self._load_and_cache_echem(
+            cache_location, parquet_path, csv_path, reload, locations=locations
+        )
 
     @staticmethod
     def process_raw_echem_df(

--- a/pydatalab/src/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/src/pydatalab/apps/echem/blocks.py
@@ -367,8 +367,8 @@ class CycleBlock(DataBlock):
         """Plots the electrochemical cycling data from the file ID provided in the request."""
         # Legacy support for when file_id was used
         if self.data.get("file_id") is not None and not self.data.get("file_ids"):
-            LOGGER.info("Legacy file upload detected, using file_id")
             file_ids = [self.data["file_id"]]
+            self.data["file_ids"] = file_ids
 
         else:
             if "file_ids" not in self.data:
@@ -402,6 +402,9 @@ class CycleBlock(DataBlock):
 
         raw_dfs = {}
         cycle_summary_dfs = {}
+
+        if self.data.get("mode") is None:
+            self.data["mode"] = "single"
 
         # Single/multi mode gets a single dataframe - returned as a dict for consistency
         if self.data.get("mode") == "multi" or self.data.get("mode") == "single":
@@ -439,9 +442,6 @@ class CycleBlock(DataBlock):
             elif self.data.get("mode") == "single":
                 raw_dfs[filename] = raw_df
                 cycle_summary_dfs[filename] = cycle_summary_df
-
-        else:
-            raise ValueError(f"Invalid mode {self.data.get('mode')}")
 
         # Load comparison files if provided
         comparison_file_ids = self.data.get("comparison_file_ids", [])

--- a/pydatalab/src/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/src/pydatalab/apps/echem/blocks.py
@@ -165,8 +165,10 @@ class CycleBlock(DataBlock):
             LOGGER.debug("Exception details for failed BDF export", exc_info=True)
             return None
         try:
-            # Parquet requires homogeneous column types; cast mixed-type object columns to str
-            for col in bdf_df.select_dtypes(include="object").columns:
+            # Parquet requires homogeneous column types; cast mixed-type object and category
+            # columns to str. The navani `state` column is category dtype with mixed int/str
+            # values (0, 1, 'R') which pyarrow cannot serialise directly.
+            for col in bdf_df.select_dtypes(include=["object", "category"]).columns:
                 bdf_df[col] = bdf_df[col].astype(str)
             bdf_df.to_parquet(parquet_path, index=False)
         except Exception as exc:
@@ -197,11 +199,22 @@ class CycleBlock(DataBlock):
             locations: For multi-file mode, the list of all source file paths to stitch.
         """
         if not reload and parquet_path is not None and parquet_path.exists():
+            LOGGER.debug("Cache hit: loading parsed data from parquet %s", parquet_path)
             raw_df = self._load_echem_from_cache(parquet_path)
             # Regenerate CSV if it was deleted
             if csv_path is not None and not csv_path.exists():
+                LOGGER.debug("CSV cache missing, regenerating at %s", csv_path)
                 csv_path = self._save_bdf(raw_df, parquet_path, csv_path)
             return raw_df, csv_path
+
+        if reload and parquet_path is not None and parquet_path.exists():
+            LOGGER.debug(
+                "Cache bypass: reload=True, re-parsing despite cache existing at %s", parquet_path
+            )
+        elif parquet_path is None or not parquet_path.exists():
+            LOGGER.debug(
+                "Cache miss: no parquet cache found at %s, parsing from source", parquet_path
+            )
 
         raw_df = self._parse_echem_files(location, locations)
 
@@ -219,6 +232,7 @@ class CycleBlock(DataBlock):
         filename = file_info["name"]
 
         if file_info.get("is_live"):
+            LOGGER.debug("File %s is live, forcing reload=True", filename)
             reload = True
 
         ext = self._get_file_extension(filename)
@@ -393,7 +407,9 @@ class CycleBlock(DataBlock):
         if self.data.get("mode") == "multi" or self.data.get("mode") == "single":
             file_info = get_file_info_by_id(file_ids[0], update_if_live=True)
             filename = file_info["name"]
-            raw_df, cycle_summary_df, bdf_path, first_file_id = self._load(file_ids=file_ids)
+            raw_df, cycle_summary_df, bdf_path, first_file_id = self._load(
+                file_ids=file_ids, reload=False
+            )
             if bdf_path is not None and bdf_path.exists():
                 self.data["bdf_url"] = f"/files/{first_file_id}/{bdf_path.name}"
             elif bdf_path is None and len(file_ids) == 1:

--- a/pydatalab/src/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/src/pydatalab/apps/echem/blocks.py
@@ -200,7 +200,7 @@ class CycleBlock(DataBlock):
             raw_df = self._load_echem_from_cache(parquet_path)
             # Regenerate CSV if it was deleted
             if csv_path is not None and not csv_path.exists():
-                self._save_bdf(raw_df, parquet_path, csv_path)
+                csv_path = self._save_bdf(raw_df, parquet_path, csv_path)
             return raw_df, csv_path
 
         raw_df = self._parse_echem_files(location, locations)

--- a/pydatalab/tests/apps/test_echem_block.py
+++ b/pydatalab/tests/apps/test_echem_block.py
@@ -202,3 +202,49 @@ def test_save_bdf_exception_logs_warning_and_returns_none(tmp_path, caplog):
     assert not parquet_path.exists()
     assert not csv_path.exists()
     assert "Failed to export BDF file" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "state_dtype",
+    [
+        # object dtype: what most navani parsers (e.g. Biologic .mpr) actually produce
+        "object",
+        # category dtype: produced by some navani pathways; pyarrow rejects mixed-type categories
+        "category",
+    ],
+)
+def test_save_bdf_mixed_type_state_column(tmp_path, state_dtype):
+    """Test that _save_bdf handles a mixed int/str state column (0, 1, 'R') for both
+    object and category dtypes.
+
+    navani produces a `state` column with values 0 (charge), 1 (discharge), and 'R' (rest).
+    Most parsers (e.g. Biologic .mpr) produce object dtype; some pathways produce category dtype.
+    The category case has heterogeneous category values that pyarrow cannot serialise directly.
+    The fix casts both object and category columns to str before writing parquet.
+    """
+    import pandas as pd
+
+    block = CycleBlock(item_id="test")
+    parquet_path = tmp_path / "test_cached.bdf.parquet"
+    csv_path = tmp_path / "test.bdf.csv"
+
+    raw_values = [0, 1, "R", 0, 1]
+    state = pd.Categorical(raw_values) if state_dtype == "category" else raw_values
+    raw_df = pd.DataFrame(
+        {
+            "Time": [0.0, 1.0, 2.0, 3.0, 4.0],
+            "Voltage": [3.0, 3.5, 3.5, 3.5, 3.0],
+            "Current": [1.0, -1.0, 0.0, 1.0, -1.0],
+            "Capacity": [0.1, 0.1, 0.0, 0.1, 0.1],
+            "state": state,
+            "half cycle": [0, 1, 1, 2, 3],
+            "full cycle": [0, 0, 0, 1, 1],
+        }
+    )
+
+    result = block._save_bdf(raw_df, parquet_path, csv_path)
+
+    assert result == csv_path
+    assert parquet_path.exists(), "Parquet cache was not written"
+    cached = pd.read_parquet(parquet_path)
+    assert len(cached) == len(raw_df)

--- a/pydatalab/tests/apps/test_echem_block.py
+++ b/pydatalab/tests/apps/test_echem_block.py
@@ -22,7 +22,7 @@ def echem_dataframe(tmp_path):
 
     src = Path(shutil.copy(MPR_FILE, tmp_path / MPR_FILE.name))
     block = CycleBlock(item_id="test")
-    raw_df, _ = block._load_and_cache_echem(src, None, reload=True)
+    raw_df, _ = block._load_and_cache_echem(src, None, None, reload=True)
     df, _ = CycleBlock.process_raw_echem_df(raw_df, None)
     return df
 
@@ -74,66 +74,105 @@ def test_plot(reduced_echem_dataframe):
     assert layout
 
 
-def test_load_and_cache_mpr_exports_bdf_csv(tmp_path):
-    """Test that loading an .mpr file generates a .bdf.csv export alongside the pickle cache."""
+def test_load_and_cache_mpr_exports_bdf_csv_and_parquet(tmp_path):
+    """Test that loading an .mpr file generates both a .bdf.csv download and .bdf.parquet cache."""
     import shutil
 
+    import pandas as pd
+
     block = CycleBlock(item_id="test")
-    # Copy the source file to tmp_path so cache files don't pollute the example_data directory
     src = shutil.copy(MPR_FILE, tmp_path / MPR_FILE.name)
     location = Path(src)
-    bdf_path = location.with_name(location.stem + ".bdf.csv")
+    parquet_path = location.with_name(location.stem + "_cached.bdf.parquet")
+    csv_path = location.with_name(location.stem + ".bdf.csv")
 
-    raw_df, returned_bdf_path = block._load_and_cache_echem(location, bdf_path, reload=True)
+    raw_df, returned_csv_path = block._load_and_cache_echem(
+        location, parquet_path, csv_path, reload=True
+    )
 
-    assert returned_bdf_path is not None
-    assert returned_bdf_path.exists()
-    assert BDF_REQUIRED_COLUMNS.issubset(set(returned_bdf_path.open().readline().split(",")))
-    assert location.with_suffix(".RAW_PARSED.pkl").exists()
+    assert returned_csv_path is not None
+    assert returned_csv_path.exists()
+    assert BDF_REQUIRED_COLUMNS.issubset(set(returned_csv_path.open().readline().split(",")))
+
+    assert parquet_path.exists()
+    cached = pd.read_parquet(parquet_path)
+    assert BDF_REQUIRED_COLUMNS.issubset(set(cached.columns))
+
+    assert not location.with_suffix(".RAW_PARSED.pkl").exists()
     assert len(raw_df) > 0
 
 
-def test_load_and_cache_bdf_csv_source_skips_export(tmp_path):
-    """Test that loading a .bdf.csv source file skips BDF export (bdf_path=None)."""
+def test_load_and_cache_reads_from_bdf_parquet(tmp_path):
+    """Test that a second load uses the .bdf.parquet cache instead of re-parsing."""
     import shutil
 
     block = CycleBlock(item_id="test")
-    src = shutil.copy(BDF_CSV_FILE, tmp_path / BDF_CSV_FILE.name)
+    src = shutil.copy(MPR_FILE, tmp_path / MPR_FILE.name)
     location = Path(src)
+    parquet_path = location.with_name(location.stem + "_cached.bdf.parquet")
+    csv_path = location.with_name(location.stem + ".bdf.csv")
 
-    # bdf_path=None signals that the source is already BDF - no export should be attempted
-    raw_df, returned_bdf_path = block._load_and_cache_echem(location, None, reload=True)
+    # First load: parse and cache
+    raw_df_first, _ = block._load_and_cache_echem(location, parquet_path, csv_path, reload=True)
 
-    assert returned_bdf_path is None
+    # Remove the source file to prove the second load uses the parquet cache
+    location.unlink()
+    raw_df_cached, returned_csv_path = block._load_and_cache_echem(
+        location, parquet_path, csv_path, reload=False
+    )
+
+    assert returned_csv_path is not None
+    assert len(raw_df_cached) == len(raw_df_first)
+
+
+def test_load_and_cache_bdf_csv_source_caches_parquet_but_skips_csv(tmp_path):
+    """Test that loading a .bdf.csv source writes a .bdf.parquet cache but no redundant .bdf.csv."""
+    import shutil
+
+    block = CycleBlock(item_id="test")
+    src = Path(shutil.copy(BDF_CSV_FILE, tmp_path / BDF_CSV_FILE.name))
+    bare_stem = Path(BDF_CSV_FILE.name).stem.removesuffix(".bdf")
+    parquet_path = src.with_name(f"{bare_stem}_cached.bdf.parquet")
+
+    raw_df, returned_csv_path = block._load_and_cache_echem(src, parquet_path, None, reload=True)
+
+    assert returned_csv_path is None
+    assert parquet_path.exists()
     assert len(raw_df) > 0
 
 
 def test_load_and_cache_multi_file_stitch(tmp_path):
-    """Test that stitching an .mpr and a .bdf.csv produces a merged pickle and .bdf.csv export."""
+    """Test that stitching an .mpr and a .bdf.csv produces a merged .bdf.csv and .bdf.parquet."""
     import shutil
+
+    import pandas as pd
 
     block = CycleBlock(item_id="test")
     mpr_src = Path(shutil.copy(MPR_FILE, tmp_path / MPR_FILE.name))
     bdf_src = Path(shutil.copy(BDF_CSV_FILE, tmp_path / BDF_CSV_FILE.name))
 
     cache_location = tmp_path / "merged_test"
-    bdf_path: Path | None = cache_location.with_name(cache_location.name + ".bdf.csv")
+    parquet_path = cache_location.with_name(cache_location.name + "_cached.bdf.parquet")
+    csv_path = cache_location.with_name(cache_location.name + ".bdf.csv")
 
-    raw_df, returned_bdf_path = block._load_and_cache_echem(
-        cache_location, bdf_path, reload=True, locations=[mpr_src, bdf_src]
+    raw_df, returned_csv_path = block._load_and_cache_echem(
+        cache_location, parquet_path, csv_path, reload=True, locations=[mpr_src, bdf_src]
     )
 
-    assert returned_bdf_path is not None
-    assert returned_bdf_path.exists()
+    assert returned_csv_path is not None
+    assert returned_csv_path.exists()
+    assert BDF_REQUIRED_COLUMNS.issubset(set(returned_csv_path.open().readline().split(",")))
+
+    assert parquet_path.exists()
+    cached = pd.read_parquet(parquet_path)
+    assert BDF_REQUIRED_COLUMNS.issubset(set(cached.columns))
+
     assert len(raw_df) > 0
-    # Pickle should also have been created
-    assert cache_location.with_suffix(".RAW_PARSED.pkl").exists()
+    assert not cache_location.with_suffix(".RAW_PARSED.pkl").exists()
 
 
-def test_try_export_bdf_exception_logs_warning_and_returns_none(tmp_path, caplog):
-    """Test that _try_export_bdf catches export exceptions, logs a warning,
-    returns None, and does not write a file.
-    """
+def test_save_bdf_exception_logs_warning_and_returns_none(tmp_path, caplog):
+    """Test that _save_bdf catches export exceptions, logs a warning, and returns None."""
     import logging
     from unittest.mock import patch
 
@@ -142,11 +181,10 @@ def test_try_export_bdf_exception_logs_warning_and_returns_none(tmp_path, caplog
     from pydatalab.logger import LOGGER
 
     block = CycleBlock(item_id="test")
-    bdf_path = tmp_path / "dummy.bdf.csv"
+    parquet_path = tmp_path / "dummy.bdf.parquet"
+    csv_path = tmp_path / "dummy.bdf.csv"
     dummy_df = pd.DataFrame({"Time": [0, 1], "Voltage": [3.0, 3.5], "Current": [1.0, 1.0]})
 
-    # pydatalab's LOGGER has propagate=False, so caplog can't capture via root logger.
-    # Temporarily attach caplog's handler directly to the pydatalab logger.
     LOGGER.addHandler(caplog.handler)
     try:
         with (
@@ -156,10 +194,11 @@ def test_try_export_bdf_exception_logs_warning_and_returns_none(tmp_path, caplog
                 side_effect=Exception("export failed"),
             ),
         ):
-            result = block._try_export_bdf(dummy_df, bdf_path)
+            result = block._save_bdf(dummy_df, parquet_path, csv_path)
     finally:
         LOGGER.removeHandler(caplog.handler)
 
     assert result is None
-    assert not bdf_path.exists()
+    assert not parquet_path.exists()
+    assert not csv_path.exists()
     assert "Failed to export BDF file" in caplog.text

--- a/pydatalab/uv.lock
+++ b/pydatalab/uv.lock
@@ -697,7 +697,7 @@ requires-dist = [
     { name = "langchain-openai", marker = "extra == 'chat'", specifier = "~=0.1" },
     { name = "matador-db", marker = "extra == 'apps'", specifier = ">=0.11.2" },
     { name = "matplotlib", specifier = "~=3.8" },
-    { name = "navani", marker = "extra == 'apps'", specifier = "~=0.1.17" },
+    { name = "navani", marker = "extra == 'apps'", git = "https://github.com/be-smith/navani.git?rev=ml-evs%2Fexcel-tweaks" },
     { name = "nmrglue", marker = "extra == 'apps'", git = "https://github.com/jjhelmus/nmrglue.git?rev=b6408751bf18801a0a4ce084acf4d31335e2b02a" },
     { name = "pandas", extras = ["excel"], specifier = "~=2.2" },
     { name = "periodictable", specifier = "~=1.7" },
@@ -1841,8 +1841,8 @@ wheels = [
 
 [[package]]
 name = "navani"
-version = "0.1.17"
-source = { registry = "https://pypi.org/simple" }
+version = "0.1.17.post2+g076eff5"
+source = { git = "https://github.com/be-smith/navani.git?rev=ml-evs%2Fexcel-tweaks#076eff54bfdba60fe77cd92c00e37b5645d5fe9f" }
 dependencies = [
     { name = "datalab-org-galvani" },
     { name = "matplotlib" },
@@ -1852,10 +1852,6 @@ dependencies = [
     { name = "requests" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/7d/c1bb8e9b9436a6214b590c3585bd50ff9ef26d062c71084924f7987555ec/navani-0.1.17.tar.gz", hash = "sha256:63a70cc754d1a23a437a82d211b43fdc61b8ece7ebb0c06e0c6097a31a7343d6", size = 7055911, upload-time = "2026-03-30T12:07:03.917Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/4f/d472fbb51165a9d914adc468907135b092462c2e5761eaff4b946b8092e9/navani-0.1.17-py3-none-any.whl", hash = "sha256:2196dfff5e86574b1ff19e3ab63aa79e9d04e0818e59e4b64b45b6dc560f8f10", size = 20234, upload-time = "2026-03-30T12:07:02.49Z" },
 ]
 
 [[package]]

--- a/pydatalab/uv.lock
+++ b/pydatalab/uv.lock
@@ -607,6 +607,7 @@ all = [
     { name = "nmrglue" },
     { name = "pillow" },
     { name = "psutil" },
+    { name = "pyarrow" },
     { name = "pybaselines" },
     { name = "pyjwt" },
     { name = "python-dateutil" },
@@ -626,6 +627,7 @@ apps = [
     { name = "navani" },
     { name = "nmrglue" },
     { name = "psutil" },
+    { name = "pyarrow" },
     { name = "pybaselines" },
     { name = "python-dateutil" },
     { name = "renishawwire" },
@@ -702,6 +704,7 @@ requires-dist = [
     { name = "pillow", marker = "extra == 'server'", specifier = "~=11.0" },
     { name = "pint", specifier = "~=0.24" },
     { name = "psutil", marker = "extra == 'apps'", specifier = ">=7.0.0" },
+    { name = "pyarrow", marker = "extra == 'apps'", specifier = "~=23.0.1" },
     { name = "pybaselines", marker = "extra == 'apps'", specifier = "~=1.1" },
     { name = "pydantic", extras = ["dotenv", "email"], specifier = "<2.0" },
     { name = "pyjwt", marker = "extra == 'server'", specifier = "~=2.9" },
@@ -1064,6 +1067,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/92/db/b4c12cff13ebac2786f4f217f06588bccd8b53d260453404ef22b121fc3a/greenlet-3.2.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:1afd685acd5597349ee6d7a88a8bec83ce13c106ac78c196ee9dde7c04fe87be", size = 268977, upload-time = "2025-06-05T16:10:24.001Z" },
     { url = "https://files.pythonhosted.org/packages/52/61/75b4abd8147f13f70986df2801bf93735c1bd87ea780d70e3b3ecda8c165/greenlet-3.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:761917cac215c61e9dc7324b2606107b3b292a8349bdebb31503ab4de3f559ac", size = 627351, upload-time = "2025-06-05T16:38:50.685Z" },
     { url = "https://files.pythonhosted.org/packages/35/aa/6894ae299d059d26254779a5088632874b80ee8cf89a88bca00b0709d22f/greenlet-3.2.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a433dbc54e4a37e4fff90ef34f25a8c00aed99b06856f0119dcf09fbafa16392", size = 638599, upload-time = "2025-06-05T16:41:34.057Z" },
+    { url = "https://files.pythonhosted.org/packages/30/64/e01a8261d13c47f3c082519a5e9dbf9e143cc0498ed20c911d04e54d526c/greenlet-3.2.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:72e77ed69312bab0434d7292316d5afd6896192ac4327d44f3d613ecb85b037c", size = 634482, upload-time = "2025-06-05T16:48:16.26Z" },
     { url = "https://files.pythonhosted.org/packages/47/48/ff9ca8ba9772d083a4f5221f7b4f0ebe8978131a9ae0909cf202f94cd879/greenlet-3.2.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:68671180e3849b963649254a882cd544a3c75bfcd2c527346ad8bb53494444db", size = 633284, upload-time = "2025-06-05T16:13:01.599Z" },
     { url = "https://files.pythonhosted.org/packages/e9/45/626e974948713bc15775b696adb3eb0bd708bec267d6d2d5c47bb47a6119/greenlet-3.2.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49c8cfb18fb419b3d08e011228ef8a25882397f3a859b9fe1436946140b6756b", size = 582206, upload-time = "2025-06-05T16:12:48.51Z" },
     { url = "https://files.pythonhosted.org/packages/b1/8e/8b6f42c67d5df7db35b8c55c9a850ea045219741bb14416255616808c690/greenlet-3.2.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:efc6dc8a792243c31f2f5674b670b3a95d46fa1c6a912b8e310d6f542e7b0712", size = 1111412, upload-time = "2025-06-05T16:36:45.479Z" },
@@ -1072,6 +1076,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/2e/d4fcb2978f826358b673f779f78fa8a32ee37df11920dc2bb5589cbeecef/greenlet-3.2.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:784ae58bba89fa1fa5733d170d42486580cab9decda3484779f4759345b29822", size = 270219, upload-time = "2025-06-05T16:10:10.414Z" },
     { url = "https://files.pythonhosted.org/packages/16/24/929f853e0202130e4fe163bc1d05a671ce8dcd604f790e14896adac43a52/greenlet-3.2.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0921ac4ea42a5315d3446120ad48f90c3a6b9bb93dd9b3cf4e4d84a66e42de83", size = 630383, upload-time = "2025-06-05T16:38:51.785Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b2/0320715eb61ae70c25ceca2f1d5ae620477d246692d9cc284c13242ec31c/greenlet-3.2.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:d2971d93bb99e05f8c2c0c2f4aa9484a18d98c4c3bd3c62b65b7e6ae33dfcfaf", size = 642422, upload-time = "2025-06-05T16:41:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/49/445fd1a210f4747fedf77615d941444349c6a3a4a1135bba9701337cd966/greenlet-3.2.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c667c0bf9d406b77a15c924ef3285e1e05250948001220368e039b6aa5b5034b", size = 638375, upload-time = "2025-06-05T16:48:18.235Z" },
     { url = "https://files.pythonhosted.org/packages/7e/c8/ca19760cf6eae75fa8dc32b487e963d863b3ee04a7637da77b616703bc37/greenlet-3.2.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:592c12fb1165be74592f5de0d70f82bc5ba552ac44800d632214b76089945147", size = 637627, upload-time = "2025-06-05T16:13:02.858Z" },
     { url = "https://files.pythonhosted.org/packages/65/89/77acf9e3da38e9bcfca881e43b02ed467c1dedc387021fc4d9bd9928afb8/greenlet-3.2.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29e184536ba333003540790ba29829ac14bb645514fbd7e32af331e8202a62a5", size = 585502, upload-time = "2025-06-05T16:12:49.642Z" },
     { url = "https://files.pythonhosted.org/packages/97/c6/ae244d7c95b23b7130136e07a9cc5aadd60d59b5951180dc7dc7e8edaba7/greenlet-3.2.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:93c0bb79844a367782ec4f429d07589417052e621aa39a5ac1fb99c5aa308edc", size = 1114498, upload-time = "2025-06-05T16:36:46.598Z" },
@@ -2225,6 +2230,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
     { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
     { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "23.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336, upload-time = "2026-02-16T10:14:12.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/a8/24e5dc6855f50a62936ceb004e6e9645e4219a8065f304145d7fb8a79d5d/pyarrow-23.0.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:3fab8f82571844eb3c460f90a75583801d14ca0cc32b1acc8c361650e006fd56", size = 34307390, upload-time = "2026-02-16T10:08:08.654Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/8e/4be5617b4aaae0287f621ad31c6036e5f63118cfca0dc57d42121ff49b51/pyarrow-23.0.1-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:3f91c038b95f71ddfc865f11d5876c42f343b4495535bd262c7b321b0b94507c", size = 35853761, upload-time = "2026-02-16T10:08:17.811Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/08/3e56a18819462210432ae37d10f5c8eed3828be1d6c751b6e6a2e93c286a/pyarrow-23.0.1-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d0744403adabef53c985a7f8a082b502a368510c40d184df349a0a8754533258", size = 44493116, upload-time = "2026-02-16T10:08:25.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/82/c40b68001dbec8a3faa4c08cd8c200798ac732d2854537c5449dc859f55a/pyarrow-23.0.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:c33b5bf406284fd0bba436ed6f6c3ebe8e311722b441d89397c54f871c6863a2", size = 47564532, upload-time = "2026-02-16T10:08:34.27Z" },
+    { url = "https://files.pythonhosted.org/packages/20/bc/73f611989116b6f53347581b02177f9f620efdf3cd3f405d0e83cdf53a83/pyarrow-23.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ddf743e82f69dcd6dbbcb63628895d7161e04e56794ef80550ac6f3315eeb1d5", size = 48183685, upload-time = "2026-02-16T10:08:42.889Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/6c6b3ecdae2a8c3aced99956187e8302fc954cc2cca2a37cf2111dad16ce/pyarrow-23.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e052a211c5ac9848ae15d5ec875ed0943c0221e2fcfe69eee80b604b4e703222", size = 50605582, upload-time = "2026-02-16T10:08:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/94/d359e708672878d7638a04a0448edf7c707f9e5606cee11e15aaa5c7535a/pyarrow-23.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:5abde149bb3ce524782d838eb67ac095cd3fd6090eba051130589793f1a7f76d", size = 27521148, upload-time = "2026-02-16T10:08:58.077Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/41/8e6b6ef7e225d4ceead8459427a52afdc23379768f54dd3566014d7618c1/pyarrow-23.0.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:6f0147ee9e0386f519c952cc670eb4a8b05caa594eeffe01af0e25f699e4e9bb", size = 34302230, upload-time = "2026-02-16T10:09:03.859Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/4a/1472c00392f521fea03ae93408bf445cc7bfa1ab81683faf9bc188e36629/pyarrow-23.0.1-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:0ae6e17c828455b6265d590100c295193f93cc5675eb0af59e49dbd00d2de350", size = 35850050, upload-time = "2026-02-16T10:09:11.877Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b2/bd1f2f05ded56af7f54d702c8364c9c43cd6abb91b0e9933f3d77b4f4132/pyarrow-23.0.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:fed7020203e9ef273360b9e45be52a2a47d3103caf156a30ace5247ffb51bdbd", size = 44491918, upload-time = "2026-02-16T10:09:18.144Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/62/96459ef5b67957eac38a90f541d1c28833d1b367f014a482cb63f3b7cd2d/pyarrow-23.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:26d50dee49d741ac0e82185033488d28d35be4d763ae6f321f97d1140eb7a0e9", size = 47562811, upload-time = "2026-02-16T10:09:25.792Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/94/1170e235add1f5f45a954e26cd0e906e7e74e23392dcb560de471f7366ec/pyarrow-23.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3c30143b17161310f151f4a2bcfe41b5ff744238c1039338779424e38579d701", size = 48183766, upload-time = "2026-02-16T10:09:34.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/2d/39a42af4570377b99774cdb47f63ee6c7da7616bd55b3d5001aa18edfe4f/pyarrow-23.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db2190fa79c80a23fdd29fef4b8992893f024ae7c17d2f5f4db7171fa30c2c78", size = 50607669, upload-time = "2026-02-16T10:09:44.153Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ca/db94101c187f3df742133ac837e93b1f269ebdac49427f8310ee40b6a58f/pyarrow-23.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:f00f993a8179e0e1c9713bcc0baf6d6c01326a406a9c23495ec1ba9c9ebf2919", size = 27527698, upload-time = "2026-02-16T10:09:50.263Z" },
 ]
 
 [[package]]

--- a/pydatalab/uv.lock
+++ b/pydatalab/uv.lock
@@ -697,7 +697,7 @@ requires-dist = [
     { name = "langchain-openai", marker = "extra == 'chat'", specifier = "~=0.1" },
     { name = "matador-db", marker = "extra == 'apps'", specifier = ">=0.11.2" },
     { name = "matplotlib", specifier = "~=3.8" },
-    { name = "navani", marker = "extra == 'apps'", specifier = "~=0.1.16" },
+    { name = "navani", marker = "extra == 'apps'", specifier = "~=0.1.17" },
     { name = "nmrglue", marker = "extra == 'apps'", git = "https://github.com/jjhelmus/nmrglue.git?rev=b6408751bf18801a0a4ce084acf4d31335e2b02a" },
     { name = "pandas", extras = ["excel"], specifier = "~=2.2" },
     { name = "periodictable", specifier = "~=1.7" },
@@ -1841,7 +1841,7 @@ wheels = [
 
 [[package]]
 name = "navani"
-version = "0.1.16"
+version = "0.1.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "datalab-org-galvani" },
@@ -1853,9 +1853,9 @@ dependencies = [
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/46/222b40e617f5de74110c4fc71deabe891cdc140b806d32141a2d208a6801/navani-0.1.16.tar.gz", hash = "sha256:7b42f6db406fdbb15efa9021477afc0f8fd59142ff0dd1d56359c53d6f4ed2e9", size = 7054495, upload-time = "2026-02-25T13:06:20.175Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/7d/c1bb8e9b9436a6214b590c3585bd50ff9ef26d062c71084924f7987555ec/navani-0.1.17.tar.gz", hash = "sha256:63a70cc754d1a23a437a82d211b43fdc61b8ece7ebb0c06e0c6097a31a7343d6", size = 7055911, upload-time = "2026-03-30T12:07:03.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/34/3b5dd4441a3c7eb86f9fa7c466131841ea8110b975ea73dc1b44693f65c8/navani-0.1.16-py3-none-any.whl", hash = "sha256:513e313cbaf49d1e9a0cc849a5c9657c0a74a01ca8e2774966506652163109c7", size = 18369, upload-time = "2026-02-25T13:06:18.586Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/4f/d472fbb51165a9d914adc468907135b092462c2e5761eaff4b946b8092e9/navani-0.1.17-py3-none-any.whl", hash = "sha256:2196dfff5e86574b1ff19e3ab63aa79e9d04e0818e59e4b64b45b6dc560f8f10", size = 20234, upload-time = "2026-03-30T12:07:02.49Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Changes the echem cacheing file from a .pkl to a .bdf.parquet file.

Fixes a bug where the cache wasn't being loaded for the single file mode, instead reloading from the raw file each time.

Also bumps navani to v0.1.17 so neware excel files are supported by the echem block