### PR TITLE
Compute gravatar hashes server side

### DIFF
--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -525,6 +525,10 @@
           "type": "string",
           "format": "email"
         },
+        "gravatar_hash": {
+          "title": "Gravatar Hash",
+          "type": "string"
+        },
         "managers": {
           "title": "Managers",
           "type": "array",

--- a/pydatalab/schemas/equipment.json
+++ b/pydatalab/schemas/equipment.json
@@ -489,6 +489,10 @@
           "type": "string",
           "format": "email"
         },
+        "gravatar_hash": {
+          "title": "Gravatar Hash",
+          "type": "string"
+        },
         "managers": {
           "title": "Managers",
           "type": "array",

--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -582,6 +582,10 @@
           "type": "string",
           "format": "email"
         },
+        "gravatar_hash": {
+          "title": "Gravatar Hash",
+          "type": "string"
+        },
         "managers": {
           "title": "Managers",
           "type": "array",

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -635,6 +635,10 @@
           "type": "string",
           "format": "email"
         },
+        "gravatar_hash": {
+          "title": "Gravatar Hash",
+          "type": "string"
+        },
         "managers": {
           "title": "Managers",
           "type": "array",

--- a/pydatalab/src/pydatalab/main.py
+++ b/pydatalab/src/pydatalab/main.py
@@ -106,6 +106,7 @@ def create_app(
         extension.init_app(app)
 
     pydatalab.mongo.create_default_indices()
+    pydatalab.mongo.run_startup_migrations()
 
     if CONFIG.FILE_DIRECTORY is not None:
         pathlib.Path(CONFIG.FILE_DIRECTORY).mkdir(parents=False, exist_ok=True)

--- a/pydatalab/src/pydatalab/models/people.py
+++ b/pydatalab/src/pydatalab/models/people.py
@@ -164,6 +164,9 @@ class Person(Entry):
     contact_email: EmailStr | None = Field(None)
     """In the case of multiple *verified* email identities, this email will be used as the primary contact."""
 
+    gravatar_hash: str | None = Field(None)
+    """MD5 hash used by the frontend to fetch a Gravatar avatar without exposing the raw email."""
+
     managers: list[PyObjectId] | None = Field(None)
     """A list of user IDs that can manage this person's items."""
 
@@ -219,10 +222,13 @@ class Person(Entry):
         if use_contact_email and identity.identity_type is IdentityType.EMAIL:
             contact_email = identity.identifier
 
+        from pydatalab.mongo import gravatar_hash_for
+
         return Person(
             immutable_id=user_id,
             identities=[identity],
             display_name=display_name,
             contact_email=contact_email,
             account_status=account_status,
+            gravatar_hash=gravatar_hash_for(contact_email, display_name),
         )

--- a/pydatalab/src/pydatalab/mongo.py
+++ b/pydatalab/src/pydatalab/mongo.py
@@ -1,4 +1,5 @@
 import atexit
+import hashlib
 import re
 from functools import lru_cache
 from typing import Any
@@ -17,6 +18,8 @@ __all__ = (
     "create_default_indices",
     "_get_active_mongo_client",
     "insert_pydantic_model_fork_safe",
+    "gravatar_hash_for",
+    "run_startup_migrations",
     "ITEMS_FTS_FIELDS",
     "USERS_FTS_FIELDS",
     "COLLECTIONS_FTS_FIELDS",
@@ -368,3 +371,64 @@ def create_default_indices(
     )
 
     return ret
+
+
+def gravatar_hash_for(email: str | None, display_name: str | None = None) -> str | None:
+    """Return the MD5 hash used by the frontend to look up a Gravatar avatar.
+
+    Prefers the trimmed, lowercased contact email (which Gravatar indexes); falls
+    back to hashing the display name so a deterministic identicon can still be
+    rendered when no email is available. Returns ``None`` if neither is set.
+    """
+    payload = (str(email) if email else "").strip().lower() or (
+        str(display_name) if display_name else ""
+    ).strip()
+    if not payload:
+        return None
+    return hashlib.md5(payload.encode("utf-8"), usedforsecurity=False).hexdigest()
+
+
+def _backfill_user_gravatar_hashes(db) -> int:
+    """Populate `gravatar_hash` on any user doc that lacks it."""
+    updates: list[pymongo.UpdateOne] = []
+    for user in db.users.find(
+        {"gravatar_hash": {"$exists": False}},
+        {"_id": 1, "contact_email": 1, "display_name": 1},
+    ):
+        updates.append(
+            pymongo.UpdateOne(
+                {"_id": user["_id"]},
+                {
+                    "$set": {
+                        "gravatar_hash": gravatar_hash_for(
+                            user.get("contact_email"), user.get("display_name")
+                        )
+                    }
+                },
+            )
+        )
+    if updates:
+        db.users.bulk_write(updates, ordered=False)
+    return len(updates)
+
+
+STARTUP_MIGRATIONS = (_backfill_user_gravatar_hashes,)
+"""Idempotent one-shot DB fixups run at app startup, after index creation.
+
+Each entry takes a pymongo database handle and returns the number of documents
+updated. Keep migrations idempotent and cheap — they run on every boot.
+"""
+
+
+def run_startup_migrations(client: pymongo.MongoClient | None = None) -> dict[str, int]:
+    """Run each migration in :data:`STARTUP_MIGRATIONS` against the configured DB."""
+    if client is None:
+        client = _get_active_mongo_client()
+    db = client.get_database()
+    results: dict[str, int] = {}
+    for migration in STARTUP_MIGRATIONS:
+        count = migration(db)
+        results[migration.__name__] = count
+        if count:
+            LOGGER.info("Startup migration %s updated %d document(s)", migration.__name__, count)
+    return results

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -9,7 +9,6 @@ from deepdiff import DeepDiff
 from flask import Blueprint, jsonify, redirect, request
 from flask_login import current_user
 from pydantic import ValidationError
-from pymongo.command_cursor import CommandCursor
 from pymongo.errors import DuplicateKeyError
 from werkzeug.exceptions import BadRequest, Conflict, NotFound
 
@@ -125,7 +124,7 @@ def get_starting_materials():
 get_starting_materials.methods = ("GET",)  # type: ignore
 
 
-def get_items_summary(match: dict | None = None, project: dict | None = None) -> CommandCursor:
+def get_items_summary(match: dict | None = None, project: dict | None = None) -> list[dict]:
     """Return a summary of item entries that match some criteria.
 
     Parameters:
@@ -143,7 +142,7 @@ def get_items_summary(match: dict | None = None, project: dict | None = None) ->
         "blocks": {"blocktype": 1, "title": 1},
         "creators": {
             "display_name": 1,
-            "contact_email": 1,
+            "gravatar_hash": 1,
         },
         "groups": {
             "display_name": 1,
@@ -173,19 +172,21 @@ def get_items_summary(match: dict | None = None, project: dict | None = None) ->
             else:
                 _project[key] = 1
 
-    return flask_mongo.db.items.aggregate(
-        [
-            {"$match": match},
-            {"$lookup": creators_lookup()},
-            {"$lookup": groups_lookup()},
-            {"$lookup": collections_lookup()},
-            {"$project": _project},
-            {"$sort": {"date": -1}},
-        ]
+    return list(
+        flask_mongo.db.items.aggregate(
+            [
+                {"$match": match},
+                {"$lookup": creators_lookup()},
+                {"$lookup": groups_lookup()},
+                {"$lookup": collections_lookup()},
+                {"$project": _project},
+                {"$sort": {"date": -1}},
+            ]
+        )
     )
 
 
-def get_samples_summary(match: dict | None = None, project: dict | None = None) -> CommandCursor:
+def get_samples_summary(match: dict | None = None, project: dict | None = None) -> list[dict]:
     """Return a summary of samples/cells entries that match some criteria.
 
     Parameters:
@@ -204,7 +205,7 @@ def get_samples_summary(match: dict | None = None, project: dict | None = None) 
         "blocks": {"blocktype": 1, "title": 1},
         "creators": {
             "display_name": 1,
-            "contact_email": 1,
+            "gravatar_hash": 1,
         },
         "groups": {
             "display_name": 1,
@@ -234,15 +235,17 @@ def get_samples_summary(match: dict | None = None, project: dict | None = None) 
             else:
                 _project[key] = 1
 
-    return flask_mongo.db.items.aggregate(
-        [
-            {"$match": match},
-            {"$lookup": creators_lookup()},
-            {"$lookup": groups_lookup()},
-            {"$lookup": collections_lookup()},
-            {"$project": _project},
-            {"$sort": {"date": -1}},
-        ]
+    return list(
+        flask_mongo.db.items.aggregate(
+            [
+                {"$match": match},
+                {"$lookup": creators_lookup()},
+                {"$lookup": groups_lookup()},
+                {"$lookup": collections_lookup()},
+                {"$project": _project},
+                {"$sort": {"date": -1}},
+            ]
+        )
     )
 
 
@@ -254,7 +257,7 @@ def creators_lookup() -> dict:
             {"$match": {"$expr": {"$in": ["$_id", {"$ifNull": ["$$creator_ids", []]}]}}},
             {"$addFields": {"__order": {"$indexOfArray": ["$$creator_ids", "$_id"]}}},
             {"$sort": {"__order": 1}},
-            {"$project": {"_id": 1, "display_name": 1, "contact_email": 1}},
+            {"$project": {"_id": 1, "display_name": 1, "gravatar_hash": 1}},
         ],
         "as": "creators",
     }

--- a/pydatalab/src/pydatalab/routes/v0_1/users.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/users.py
@@ -11,7 +11,12 @@ from werkzeug.exceptions import BadRequest, Forbidden, Unauthorized
 from pydatalab.config import CONFIG
 from pydatalab.logger import LOGGER
 from pydatalab.models.people import AccountStatus, DisplayName, EmailStr, Person
-from pydatalab.mongo import USERS_FTS_FIELDS, build_search_pipeline, flask_mongo
+from pydatalab.mongo import (
+    USERS_FTS_FIELDS,
+    build_search_pipeline,
+    flask_mongo,
+    gravatar_hash_for,
+)
 from pydatalab.permissions import active_users_or_get_only
 from pydatalab.routes.v0_1.auth import _generate_and_store_token, _send_magic_link_email
 
@@ -60,6 +65,18 @@ def save_user(user_id):
 
     except ValueError:
         raise BadRequest(f"Invalid email address {contact_email!r} was passed")
+
+    if "contact_email" in update or "display_name" in update:
+        existing = (
+            flask_mongo.db.users.find_one(
+                {"_id": ObjectId(user_id)}, {"contact_email": 1, "display_name": 1}
+            )
+            or {}
+        )
+        update["gravatar_hash"] = gravatar_hash_for(
+            update.get("contact_email", existing.get("contact_email")),
+            update.get("display_name", existing.get("display_name")),
+        )
 
     trigger_email_verification = False
     if update.get("contact_email"):
@@ -198,14 +215,13 @@ def search_users():
         {
             "$project": {
                 "_id": 1,
-                "identities": 1,
                 "display_name": 1,
-                "contact_email": 1,
+                "gravatar_hash": 1,
             }
         }
     )
 
     cursor = flask_mongo.db.users.aggregate(pipeline)
     return jsonify(
-        {"status": "success", "users": list(json.loads(Person(**d).json()) for d in cursor)}
+        {"status": "success", "users": [json.loads(Person(**d).json()) for d in cursor]}
     ), 200

--- a/pydatalab/tests/server/test_users.py
+++ b/pydatalab/tests/server/test_users.py
@@ -130,6 +130,13 @@ def test_user_update(client, unauthenticated_client, database, user_id, admin_us
     assert resp.status_code == 200
     assert len(resp.json["users"]) == 5
 
+    # Search responses must not leak contact emails or identities of other users,
+    # and should instead expose a gravatar_hash for avatar rendering.
+    for returned_user in resp.json["users"]:
+        assert "contact_email" not in returned_user or returned_user["contact_email"] is None
+        assert "identities" not in returned_user or returned_user["identities"] == []
+        assert "gravatar_hash" in returned_user
+
     # Test that differing user auth can/cannot search for users
     resp = unauthenticated_client.get(endpoint + "?query='Test Person'")
     assert resp.status_code == 401

--- a/webapp/cypress/component/UserBubbleLoginTest.cy.jsx
+++ b/webapp/cypress/component/UserBubbleLoginTest.cy.jsx
@@ -1,11 +1,9 @@
 import { createStore } from "vuex";
 import UserBubbleLogin from "@/components/UserBubbleLogin.vue";
 import NotificationDot from "@/components/NotificationDot.vue";
-import { md5 } from "js-md5";
-
 describe("UserBubbleLogin", () => {
   const creator = {
-    contact_email: "test@contact.email",
+    gravatar_hash: "0123456789abcdef0123456789abcdef",
     display_name: "Test User",
   };
 
@@ -41,7 +39,7 @@ describe("UserBubbleLogin", () => {
         });
       });
 
-      it("renders the avatar image with correct gravatar URL based on contact_email", () => {
+      it("renders the avatar image with the server-provided gravatar_hash", () => {
         cy.mount(UserBubbleLogin, {
           global: {
             plugins: [store],
@@ -50,30 +48,9 @@ describe("UserBubbleLogin", () => {
             creator,
           },
         });
-        const expectedHash = md5(creator.contact_email);
         cy.get("img.avatar")
           .should("have.attr", "src")
-          .and("include", `https://www.gravatar.com/avatar/${expectedHash}`);
-      });
-
-      it("renders the avatar image with correct gravatar URL based on display_name when contact_email is not provided", () => {
-        const creatorWithoutEmail = {
-          display_name: "Test User",
-        };
-
-        cy.mount(UserBubbleLogin, {
-          global: {
-            plugins: [store],
-          },
-          props: {
-            creator: creatorWithoutEmail,
-          },
-        });
-
-        const expectedHash = md5(creatorWithoutEmail.display_name);
-        cy.get("img.avatar")
-          .should("have.attr", "src")
-          .and("include", `https://www.gravatar.com/avatar/${expectedHash}`);
+          .and("include", `https://www.gravatar.com/avatar/${creator.gravatar_hash}`);
       });
 
       it("uses the default size if not provided", () => {
@@ -219,11 +196,10 @@ describe("UserBubbleLogin", () => {
           },
         });
 
-        const expectedMd5 = md5(creator.contact_email || creator.display_name);
         cy.get("img.avatar")
           .should("have.attr", "src")
           .then((src) => {
-            const expectedUrl = `https://www.gravatar.com/avatar/${expectedMd5}?d=${
+            const expectedUrl = `https://www.gravatar.com/avatar/${creator.gravatar_hash}?d=${
               UserBubbleLogin.data().gravatar_style
             }`;
             expect(src).to.include(expectedUrl);

--- a/webapp/cypress/component/UserBubbleTest.cy.jsx
+++ b/webapp/cypress/component/UserBubbleTest.cy.jsx
@@ -1,9 +1,8 @@
 import UserBubble from "@/components/UserBubble.vue";
-import { md5 } from "js-md5";
 
 describe("UserBubble", () => {
   const creator = {
-    contact_email: "test@contact.email",
+    gravatar_hash: "0123456789abcdef0123456789abcdef",
     display_name: "Test User",
   };
 
@@ -11,24 +10,10 @@ describe("UserBubble", () => {
     cy.mount(<UserBubble creator={creator} />);
   });
 
-  it("renders the avatar image with correct gravatar URL based on contact_email", () => {
-    const expectedHash = md5(creator.contact_email);
+  it("renders the avatar image with the server-provided gravatar_hash", () => {
     cy.get("img.avatar")
       .should("have.attr", "src")
-      .and("include", `https://www.gravatar.com/avatar/${expectedHash}`);
-  });
-
-  it("renders the avatar image with correct gravatar URL based on display_name when contact_email is not provided", () => {
-    const creatorWithoutEmail = {
-      display_name: "Test User",
-    };
-
-    cy.mount(<UserBubble creator={creatorWithoutEmail} />);
-
-    const expectedHash = md5(creatorWithoutEmail.display_name);
-    cy.get("img.avatar")
-      .should("have.attr", "src")
-      .and("include", `https://www.gravatar.com/avatar/${expectedHash}`);
+      .and("include", `https://www.gravatar.com/avatar/${creator.gravatar_hash}`);
   });
 
   it("uses the default size if not provided", () => {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -49,7 +49,6 @@
     "cytoscape-fcose": "^2.2.0",
     "date-fns": "^2.29.3",
     "highlight.js": "^11.7.0",
-    "js-md5": "^0.8.3",
     "katex": "^0.16.22",
     "markdown-it": "^14.1.1",
     "mermaid": "^11.10.0",

--- a/webapp/src/components/UserBubble.vue
+++ b/webapp/src/components/UserBubble.vue
@@ -4,7 +4,7 @@
       <img
         :src="
           'https://www.gravatar.com/avatar/' +
-          md5(creator.contact_email || creator.display_name) +
+          (creator.gravatar_hash || '') +
           '?d=' +
           gravatar_style +
           '&s=' +
@@ -22,7 +22,6 @@
 </template>
 
 <script>
-import { md5 } from "js-md5";
 import { GRAVATAR_STYLE } from "@/resources.js";
 import StyledTooltip from "@/components/StyledTooltip";
 
@@ -45,11 +44,6 @@ export default {
     return {
       gravatar_style: GRAVATAR_STYLE,
     };
-  },
-  methods: {
-    md5(value) {
-      return md5(value);
-    },
   },
 };
 </script>

--- a/webapp/src/components/UserBubbleLogin.vue
+++ b/webapp/src/components/UserBubbleLogin.vue
@@ -6,7 +6,7 @@
         <img
           :src="
             'https://www.gravatar.com/avatar/' +
-            md5(creator.contact_email || creator.display_name) +
+            (creator.gravatar_hash || '') +
             '?d=' +
             gravatar_style
           "
@@ -27,7 +27,6 @@ import { GRAVATAR_STYLE } from "@/resources.js";
 import NotificationDot from "./NotificationDot.vue";
 import StyledTooltip from "@/components/StyledTooltip";
 import { getUsersList } from "@/server_fetch_utils.js";
-import { md5 } from "js-md5";
 
 export default {
   components: {
@@ -59,11 +58,6 @@ export default {
     if (this.creator.role == "admin") {
       getUsersList();
     }
-  },
-  methods: {
-    md5(value) {
-      return md5(value);
-    },
   },
 };
 </script>

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -6282,11 +6282,6 @@ js-cookie@^3.0.5:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
   integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
 
-js-md5@^0.8.3:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/js-md5/-/js-md5-0.8.3.tgz#921bab7efa95bfc9d62b87ee08a57f8fe4305b69"
-  integrity sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==
-
 js-message@1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/js-message/-/js-message-1.0.7.tgz#fbddd053c7a47021871bb8b2c95397cc17c20e47"


### PR DESCRIPTION
Closes #1685.

Removes the need for any JS crypto library and allows us to stop returning user identities/emails to other authenticated users in order to display their samples. The hash is computed on server startup if missing and does not need any migration.