### PR TITLE
Use SPA navigation between table and edit pages and lazy-load schemas

### DIFF
--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -12,9 +12,6 @@ export default {
     DialogContainer,
   },
   async created() {
-    // Wait for the router to resolve the initial route before loading schemas,
-    // so that redirect-only routes (e.g., /files/*) can navigate away
-    // without triggering unnecessary API requests.
     await this.$router.isReady();
     if (this.$route.name === "files-redirect") return;
     await loadItemSchemas();

--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -1259,12 +1259,12 @@ export default {
       }
 
       if (window.Cypress) {
-        window.location.href = `/${this.editPageRoutePrefix}/${row_id}`;
+        this.$router.push(`/${this.editPageRoutePrefix}/${row_id}`);
       } else {
         if (event.originalEvent.ctrlKey || event.originalEvent.metaKey) {
           window.open(`/${this.editPageRoutePrefix}/${row_id}`, "_blank");
         } else {
-          window.location.href = `/${this.editPageRoutePrefix}/${row_id}`;
+          this.$router.push(`/${this.editPageRoutePrefix}/${row_id}`);
         }
       }
     },

--- a/webapp/src/components/FormattedCollectionName.vue
+++ b/webapp/src/components/FormattedCollectionName.vue
@@ -6,6 +6,7 @@
     @click.exact="enableClick ? openEditPageInSameTab() : null"
     @click.meta.stop="enableModifiedClick ? openEditPageInNewTab() : null"
     @click.ctrl.stop="enableModifiedClick ? openEditPageInNewTab() : null"
+    @auxclick.middle.stop="enableModifiedClick ? openEditPageInNewTab() : null"
   >
     {{ collection_id }}
   </span>

--- a/webapp/src/components/FormattedItemName.vue
+++ b/webapp/src/components/FormattedItemName.vue
@@ -7,6 +7,7 @@
       @click.exact="enableClick ? openEditPageInSameTab() : null"
       @click.meta.stop="enableModifiedClick ? openEditPageInNewTab() : null"
       @click.ctrl.stop="enableModifiedClick ? openEditPageInNewTab() : null"
+      @auxclick.middle.stop="enableModifiedClick ? openEditPageInNewTab() : null"
     >
       {{ item_id }}
     </span>
@@ -79,7 +80,7 @@ export default {
       if (window.Cypress && window.location.href.includes("__cypress")) {
         return;
       }
-      window.location.href = `/edit/${this.item_id}`;
+      this.$router.push(`/edit/${this.item_id}`);
     },
     openEditPageInNewTab() {
       this.$emit("itemIdClicked");

--- a/webapp/src/components/FormattedRefcode.vue
+++ b/webapp/src/components/FormattedRefcode.vue
@@ -13,6 +13,7 @@
     @click.exact="enableClick ? openEditPageInNewTab() : null"
     @click.meta.stop="enableModifiedClick ? openEditPageInNewTab() : null"
     @click.ctrl.stop="enableModifiedClick ? openEditPageInNewTab() : null"
+    @auxclick.middle.stop="enableModifiedClick ? openEditPageInNewTab() : null"
   >
     {{ refcode }}
   </span>

--- a/webapp/src/components/LoginDetails.vue
+++ b/webapp/src/components/LoginDetails.vue
@@ -70,7 +70,6 @@
 </template>
 
 <script>
-import { API_URL } from "@/resources.js";
 import UserBubbleLogin from "@/components/UserBubbleLogin.vue";
 import { getUserInfo, getInfo } from "@/server_fetch_utils.js";
 import UserDropdown from "@/components/UserDropdown.vue";
@@ -89,7 +88,6 @@ export default {
     return {
       isLoginDropdownVisible: false,
       isUserDropdownVisible: false,
-      apiUrl: API_URL,
       user: null,
       isUserLoaded: false,
     };
@@ -125,12 +123,6 @@ export default {
   },
   methods: {
     async getUser() {
-      // Need to reload the page if this is a magic-link login
-      let token = this.$route.query.token;
-      if (token != null) {
-        window.location.href = this.apiUrl + "/login/email?token=" + token;
-      }
-
       this.user = await getUserInfo();
       this.isUserLoaded = true;
       if (this.user != null) {

--- a/webapp/src/router/index.js
+++ b/webapp/src/router/index.js
@@ -113,6 +113,11 @@ const router = createRouter({
 });
 
 router.beforeEach(async (to, from, next) => {
+  if (to.query.token) {
+    window.location.href = API_URL + "/login/email?token=" + to.query.token;
+    return;
+  }
+
   if (to.path === "/" || (to.name === "samples" && from.path === "/")) {
     const { getUserInfo } = await import("@/server_fetch_utils.js");
     const user = await getUserInfo();

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -1290,19 +1290,24 @@ export async function getSchema(type) {
     });
 }
 
+export async function ensureItemSchema(type) {
+  // Fetch the schema for a given item type only if it isn't already in the
+  // Vuex store.
+  if (!type || store.state.schemas[type]) return;
+  try {
+    const schema = await getSchema(type);
+    store.commit("setSchema", { type, schema });
+  } catch (error) {
+    console.error(`Failed to load schema for ${type}:`, error);
+  }
+}
+
 export async function loadItemSchemas() {
-  // Load schemas for all item types and store them in the Vuex store
+  // Load schemas for every supported item type, skipping any already cached
+  // in the Vuex store.
   try {
     const supportedTypes = await getSupportedSchemasList();
-
-    for (const typeInfo of supportedTypes) {
-      try {
-        const schema = await getSchema(typeInfo.id);
-        store.commit("setSchema", { type: typeInfo.id, schema });
-      } catch (error) {
-        console.error(`Failed to load schema for ${typeInfo.id}:`, error);
-      }
-    }
+    await Promise.all(supportedTypes.map((typeInfo) => ensureItemSchema(typeInfo.id)));
   } catch (error) {
     console.error("Failed to get supported schemas list:", error);
   }

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -347,6 +347,14 @@ export default {
         window.removeEventListener("beforeunload", this.leavePageWarningListener, true);
       }
     },
+    // Re-load when the user navigates between edit pages via router.push.
+    // Without this, a route param change would leave stale item data on screen.
+    "$route.params.id"(newId, oldId) {
+      if (newId && newId !== oldId) this.reloadForRoute();
+    },
+    "$route.params.refcode"(newRefcode, oldRefcode) {
+      if (newRefcode && newRefcode !== oldRefcode) this.reloadForRoute();
+    },
   },
   created() {
     this.getBlocksInfo();
@@ -473,6 +481,13 @@ export default {
         await getBlocksInfos();
       }
       this.blockInfoLoaded = true;
+    },
+    reloadForRoute() {
+      this.item_id = this.$route.params?.id || null;
+      this.refcode = this.$route.params?.refcode || null;
+      this.itemDataLoaded = false;
+      this.blocksLoaded = false;
+      this.getSampleData();
     },
     leavePageWarningListener(event) {
       event.preventDefault;


### PR DESCRIPTION
This PR reintroduces SPA navigation between sample pages without requiring full page reload. It also forces schema load when loading the app, rather than on every item page. Finally it fixes an auth bug where the app would not correctly redirect when logging in via an email magic link (closes #1640).