### PR TITLE
Fix ability to filter by block type in the data table

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -95,7 +95,16 @@ def get_starting_materials():
                     "$project": {
                         "_id": 0,
                         "item_id": 1,
-                        "blocks": {"blocktype": 1, "title": 1},
+                        "blocks": {
+                            "$map": {
+                                "input": {"$objectToArray": {"$ifNull": ["$blocks_obj", {}]}},
+                                "as": "b",
+                                "in": {
+                                    "blocktype": "$$b.v.blocktype",
+                                    "title": "$$b.v.title",
+                                },
+                            }
+                        },
                         "nblocks": {"$size": "$display_order"},
                         "nfiles": {"$size": "$file_ObjectIds"},
                         "date": 1,
@@ -139,7 +148,16 @@ def get_items_summary(match: dict | None = None, project: dict | None = None) ->
 
     _project = {
         "_id": 0,
-        "blocks": {"blocktype": 1, "title": 1},
+        "blocks": {
+            "$map": {
+                "input": {"$objectToArray": {"$ifNull": ["$blocks_obj", {}]}},
+                "as": "b",
+                "in": {
+                    "blocktype": "$$b.v.blocktype",
+                    "title": "$$b.v.title",
+                },
+            }
+        },
         "creators": {
             "display_name": 1,
             "gravatar_hash": 1,
@@ -202,7 +220,16 @@ def get_samples_summary(match: dict | None = None, project: dict | None = None) 
 
     _project = {
         "_id": 0,
-        "blocks": {"blocktype": 1, "title": 1},
+        "blocks": {
+            "$map": {
+                "input": {"$objectToArray": {"$ifNull": ["$blocks_obj", {}]}},
+                "as": "b",
+                "in": {
+                    "blocktype": "$$b.v.blocktype",
+                    "title": "$$b.v.title",
+                },
+            }
+        },
         "creators": {
             "display_name": 1,
             "gravatar_hash": 1,

--- a/webapp/cypress/component/SampleTableTest.cy.jsx
+++ b/webapp/cypress/component/SampleTableTest.cy.jsx
@@ -33,7 +33,7 @@ describe("SampleTable Component Tests", () => {
               creators: [{ display_name: "Creator 1" }],
               nblocks: 1,
               nfiles: 1,
-              blocks: [{ title: "NMR" }],
+              blocks: [{ blocktype: "nmr", title: "NMR" }],
             },
             {
               item_id: "sample2",
@@ -46,7 +46,10 @@ describe("SampleTable Component Tests", () => {
               creators: [{ display_name: "Creator 2" }],
               nblocks: 2,
               nfiles: 2,
-              blocks: [{ title: "NMR" }, { title: "insitu" }],
+              blocks: [
+                { blocktype: "nmr", title: "NMR" },
+                { blocktype: "insitu", title: "NMR (in situ)" },
+              ],
             },
             {
               item_id: "sample3",
@@ -59,7 +62,11 @@ describe("SampleTable Component Tests", () => {
               creators: [{ display_name: "Creator 3" }],
               nblocks: 3,
               nfiles: 3,
-              blocks: [{ title: "NMR" }, { title: "insitu" }, { title: "FTIR" }],
+              blocks: [
+                { blocktype: "nmr", title: "NMR" },
+                { blocktype: "insitu", title: "NMR (in situ)" },
+                { blocktype: "ftir", title: "FTIR" },
+              ],
             },
             {
               item_id: "cell1",
@@ -72,7 +79,7 @@ describe("SampleTable Component Tests", () => {
               creators: [{ display_name: "Creator 1" }, { display_name: "Creator 2" }],
               nblocks: 1,
               nfiles: 0,
-              blocks: [{ title: "NMR" }],
+              blocks: [{ blocktype: "nmr", title: "NMR" }],
             },
             {
               item_id: "cell2",
@@ -85,7 +92,10 @@ describe("SampleTable Component Tests", () => {
               creators: [{ display_name: "Creator 1" }, { display_name: "Creator 2" }],
               nblocks: 2,
               nfiles: 1,
-              blocks: [{ title: "NMR" }, { title: "XRD" }],
+              blocks: [
+                { blocktype: "nmr", title: "NMR" },
+                { blocktype: "xrd", title: "XRD" },
+              ],
             },
             {
               item_id: "cell3",
@@ -106,7 +116,7 @@ describe("SampleTable Component Tests", () => {
               ],
               nblocks: 1,
               nfiles: 2,
-              blocks: [{ title: "NMR" }],
+              blocks: [{ blocktype: "nmr", title: "NMR" }],
             },
           ],
         };
@@ -824,7 +834,7 @@ describe("SampleTable Component Tests", () => {
   it("filters by Blocks correctly", () => {
     cy.get(".p-datatable-thead th").eq(9).find(".p-datatable-column-filter-button").click();
     cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("NMR").click();
+    cy.get(".p-multiselect-list-container").findByText("nmr").click();
     cy.get(".p-datatable-tbody tr").should("have.length", 6);
     cy.findByText("Clear").click();
 
@@ -836,25 +846,25 @@ describe("SampleTable Component Tests", () => {
 
     cy.get(".p-datatable-thead th").eq(9).find(".p-datatable-column-filter-button").click();
     cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("FTIR").click();
+    cy.get(".p-multiselect-list-container").findByText("ftir").click();
     cy.get(".p-datatable-tbody tr").should("have.length", 1);
     cy.findByText("Clear").click();
 
     cy.get(".p-datatable-thead th").eq(9).find(".p-datatable-column-filter-button").click();
     cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("XRD").click();
+    cy.get(".p-multiselect-list-container").findByText("xrd").click();
     cy.get(".p-datatable-tbody tr").should("have.length", 1);
     cy.findByText("Clear").click();
 
     cy.get(".p-datatable-thead th").eq(9).find(".p-datatable-column-filter-button").click();
     cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("NMR").click();
+    cy.get(".p-multiselect-list-container").findByText("nmr").click();
     cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
     cy.get(".p-multiselect-list-container").findByText("insitu").click();
     cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("FTIR").click();
+    cy.get(".p-multiselect-list-container").findByText("ftir").click();
     cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("XRD").click();
+    cy.get(".p-multiselect-list-container").findByText("xrd").click();
     cy.get(".p-datatable-tbody tr").should("have.length", 1);
     cy.get(".p-datatable-filter-operator").click();
     cy.get(".p-select-list-container").findByText("Match Any").click();

--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -5,7 +5,7 @@
 
 <script>
 import DialogContainer from "@/components/DialogContainer.vue";
-import { getApiConfig, loadItemSchemas } from "@/server_fetch_utils.js";
+import { getApiConfig, loadItemSchemas, getBlocksInfos } from "@/server_fetch_utils.js";
 
 export default {
   components: {
@@ -19,6 +19,7 @@ export default {
     if (this.$route.name === "files-redirect") return;
     await loadItemSchemas();
     await getApiConfig();
+    await getBlocksInfos();
   },
 };
 </script>

--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -215,7 +215,7 @@
           <MultiSelect
             v-model="filters[column.field].constraints[0].value"
             :options="uniqueBlockTypes"
-            option-label="type"
+            option-label="label"
             placeholder="Select block types"
             class="d-flex w-full"
             :filter="true"
@@ -223,7 +223,7 @@
           >
             <template #option="slotProps">
               <div class="flex items-center">
-                <span>{{ slotProps.option.title }}</span>
+                <span>{{ slotProps.option.label || slotProps.option.blocktype }}</span>
               </div>
             </template>
             <template #value="slotProps">
@@ -234,7 +234,7 @@
                     :key="index"
                     class="inline-flex items-center mr-2"
                   >
-                    {{ option.title }}
+                    {{ option.label || option.blocktype }}
                   </span>
                 </template>
                 <span v-else class="text-gray-400">Any</span>
@@ -572,14 +572,21 @@ export default {
     },
     uniqueBlockTypes() {
       const itemsWithBlocks = this.data.filter((item) => item.blocks && item.blocks.length > 0);
+      const blocksInfos = this.$store.state.blocksInfos || {};
 
       const blockTypesMap = new Map(
         itemsWithBlocks
           .flatMap((item) => item.blocks)
-          .map((block) => [block.title, { title: block.title }]),
+          .map((block) => [
+            block.blocktype,
+            {
+              blocktype: block.blocktype,
+              label: blocksInfos[block.blocktype]?.attributes?.name || block.blocktype,
+            },
+          ]),
       );
 
-      blockTypesMap.set("No blocks", { title: "No blocks" });
+      blockTypesMap.set("__no_blocks__", { blocktype: "__no_blocks__", label: "No blocks" });
 
       return Array.from(blockTypesMap.values());
     },
@@ -728,7 +735,7 @@ export default {
 
       if (
         Array.isArray(filterValue) &&
-        filterValue.some((filter) => filter.title === "No blocks")
+        filterValue.some((filter) => filter.blocktype === "__no_blocks__")
       ) {
         if (!value || !Array.isArray(value) || value.length === 0) {
           return true;
@@ -745,20 +752,20 @@ export default {
       if (Array.isArray(filterValue)) {
         if (isAnd) {
           return filterValue.every((filterBlock) =>
-            filterBlock.title === "No blocks"
+            filterBlock.blocktype === "__no_blocks__"
               ? !value || value.length === 0
-              : value.some((itemBlock) => itemBlock.title === filterBlock.title),
+              : value.some((itemBlock) => itemBlock.blocktype === filterBlock.blocktype),
           );
         } else {
           return filterValue.some((filterBlock) =>
-            filterBlock.title === "No blocks"
+            filterBlock.blocktype === "__no_blocks__"
               ? !value || value.length === 0
-              : value.some((itemBlock) => itemBlock.title === filterBlock.title),
+              : value.some((itemBlock) => itemBlock.blocktype === filterBlock.blocktype),
           );
         }
       }
 
-      return value.some((itemBlock) => itemBlock.title === filterValue.title);
+      return value.some((itemBlock) => itemBlock.blocktype === filterValue.blocktype);
     });
 
     FilterService.register("exactStatusMatch", (value, filterValue) => {


### PR DESCRIPTION
Noticed this was broken recently but did not raise an issue; bug caused by legacy data hanging around where we previously were saving block types in the database per item directly. This now needs to be reconstructed from `blocks_obj` at query time.