### PR TITLE
Add collections, supplier and location info to StartingMaterialTable

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -91,6 +91,7 @@ def get_starting_materials():
                         **get_default_permissions(user_only=False, inherit_from_collections=False),
                     }
                 },
+                {"$lookup": collections_lookup()},
                 {
                     "$project": {
                         "_id": 0,
@@ -104,6 +105,10 @@ def get_starting_materials():
                                     "title": "$$b.v.title",
                                 },
                             }
+                        },
+                        "collections": {
+                            "collection_id": 1,
+                            "title": 1,
                         },
                         "nblocks": {"$size": "$display_order"},
                         "nfiles": {"$size": "$file_ObjectIds"},

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -108,7 +108,6 @@ def get_starting_materials():
                         },
                         "collections": {
                             "collection_id": 1,
-                            "title": 1,
                         },
                         "nblocks": {"$size": "$display_order"},
                         "nfiles": {"$size": "$file_ObjectIds"},

--- a/pydatalab/tests/server/test_starting_materials.py
+++ b/pydatalab/tests/server/test_starting_materials.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 
 import pytest
 
@@ -128,6 +129,33 @@ def test_save_good_starting_material(client, default_starting_material_dict):
 
 
 @pytest.mark.dependency(depends=["test_save_good_starting_material"])
+def test_starting_materials_list_includes_collections(
+    client, default_starting_material_dict, default_collection
+):
+    """GET /starting-materials/ should include a collections array with collection_id for each item."""
+    collection_data = json.loads(default_collection.json())
+    collection_data["starting_members"] = [{"item_id": default_starting_material_dict["item_id"]}]
+    response = client.put("/collections", json={"data": collection_data})
+    assert response.status_code == 201, response.json
+
+    response = client.get("/starting-materials/")
+    assert response.status_code == 200
+    items = response.json["items"]
+    matching = [
+        item for item in items if item["item_id"] == default_starting_material_dict["item_id"]
+    ]
+    assert len(matching) == 1
+    item = matching[0]
+
+    assert "collections" in item, "collections key missing from /starting-materials/ response"
+    assert len(item["collections"]) == 1
+    assert item["collections"][0]["collection_id"] == default_collection.collection_id
+
+    # Clean up the collection so later tests are unaffected
+    client.delete(f"/collections/{default_collection.collection_id}")
+
+
+@pytest.mark.dependency(depends=["test_starting_materials_list_includes_collections"])
 def test_delete_starting_material(admin_client, default_starting_material_dict):
     response = admin_client.post(
         "/delete-sample/",

--- a/webapp/cypress/component/StartingMaterialTableTest.cy.jsx
+++ b/webapp/cypress/component/StartingMaterialTableTest.cy.jsx
@@ -97,7 +97,7 @@ describe("StartingMaterialTable Component Tests", () => {
   });
 
   it("displays data from the Vuex store", () => {
-    cy.getColumnIndices({ checkbox: 0, barcode: 3, nblocks: 8, nfiles: 9 }).then(
+    cy.getColumnIndices({ checkbox: 0, barcode: 3, nblocks: 9, nfiles: 10 }).then(
       (columnIndices) => {
         // First row - material1
         cy.get(".p-datatable-tbody")
@@ -127,7 +127,7 @@ describe("StartingMaterialTable Component Tests", () => {
   });
 
   it("renders the component FormattedItemName", () => {
-    cy.getColumnIndices({ checkbox: 0, barcode: 3, nblocks: 8, nfiles: 9 }).then(
+    cy.getColumnIndices({ checkbox: 0, barcode: 3, nblocks: 9, nfiles: 10 }).then(
       (columnIndices) => {
         cy.get(".p-datatable-tbody tr")
           .eq(0)
@@ -144,7 +144,7 @@ describe("StartingMaterialTable Component Tests", () => {
   });
 
   it("renders the component FormattedBarcode", () => {
-    cy.getColumnIndices({ checkbox: 0, barcode: 3, nblocks: 8, nfiles: 9 }).then(
+    cy.getColumnIndices({ checkbox: 0, barcode: 3, nblocks: 9, nfiles: 10 }).then(
       (columnIndices) => {
         cy.get(".p-datatable-tbody tr")
           .eq(0)

--- a/webapp/cypress/component/StartingMaterialTableTest.cy.jsx
+++ b/webapp/cypress/component/StartingMaterialTableTest.cy.jsx
@@ -85,6 +85,7 @@ describe("StartingMaterialTable Component Tests", () => {
       "Formula",
       "Date",
       "Collections",
+      "Supplier",
       "Location",
       "", // nblocks
       "", //nfiles
@@ -97,7 +98,7 @@ describe("StartingMaterialTable Component Tests", () => {
   });
 
   it("displays data from the Vuex store", () => {
-    cy.getColumnIndices({ checkbox: 0, barcode: 3, nblocks: 9, nfiles: 10 }).then(
+    cy.getColumnIndices({ checkbox: 0, barcode: 3, nblocks: 10, nfiles: 11 }).then(
       (columnIndices) => {
         // First row - material1
         cy.get(".p-datatable-tbody")
@@ -127,7 +128,7 @@ describe("StartingMaterialTable Component Tests", () => {
   });
 
   it("renders the component FormattedItemName", () => {
-    cy.getColumnIndices({ checkbox: 0, barcode: 3, nblocks: 9, nfiles: 10 }).then(
+    cy.getColumnIndices({ checkbox: 0, barcode: 3, nblocks: 10, nfiles: 11 }).then(
       (columnIndices) => {
         cy.get(".p-datatable-tbody tr")
           .eq(0)
@@ -144,7 +145,7 @@ describe("StartingMaterialTable Component Tests", () => {
   });
 
   it("renders the component FormattedBarcode", () => {
-    cy.getColumnIndices({ checkbox: 0, barcode: 3, nblocks: 9, nfiles: 10 }).then(
+    cy.getColumnIndices({ checkbox: 0, barcode: 3, nblocks: 10, nfiles: 11 }).then(
       (columnIndices) => {
         cy.get(".p-datatable-tbody tr")
           .eq(0)

--- a/webapp/cypress/component/StartingMaterialTableTest.cy.jsx
+++ b/webapp/cypress/component/StartingMaterialTableTest.cy.jsx
@@ -84,6 +84,7 @@ describe("StartingMaterialTable Component Tests", () => {
       "Name",
       "Formula",
       "Date",
+      "Collections",
       "Location",
       "", // nblocks
       "", //nfiles

--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -290,35 +290,13 @@
           </MultiSelect>
         </template>
 
-        <template v-else-if="column.filter && column.field === 'location'" #filter="">
+        <template
+          v-else-if="column.filter && ['location', 'supplier'].includes(column.field)"
+          #filter=""
+        >
           <MultiSelect
             v-model="filters[column.field].constraints[0].value"
-            :options="uniqueLocations"
-            placeholder="Any"
-            class="d-flex w-full"
-            :filter="true"
-            @click.stop
-          >
-            <template #value="slotProps">
-              <div class="flex flex-wrap gap-1 items-center">
-                <template v-if="slotProps.value && slotProps.value.length">
-                  <span
-                    v-for="(option, index) in slotProps.value"
-                    :key="index"
-                    class="inline-flex items-center mr-2"
-                    >{{ option }}</span
-                  >
-                </template>
-                <span v-else class="text-gray-400">Any</span>
-              </div>
-            </template>
-          </MultiSelect>
-        </template>
-
-        <template v-else-if="column.filter && column.field === 'supplier'" #filter="">
-          <MultiSelect
-            v-model="filters[column.field].constraints[0].value"
-            :options="uniqueSuppliers"
+            :options="uniqueStringValues[column.field]"
             placeholder="Any"
             class="d-flex w-full"
             :filter="true"
@@ -911,15 +889,16 @@ export default {
 
       return Array.from(blockTypesMap.values());
     },
-    uniqueLocations() {
-      return Array.from(
-        new Set(this.data.filter((item) => item.location).map((item) => item.location)),
-      ).sort();
-    },
-    uniqueSuppliers() {
-      return Array.from(
-        new Set(this.data.filter((item) => item.supplier).map((item) => item.supplier)),
-      ).sort();
+    uniqueStringValues() {
+      const fields = ["location", "supplier"];
+      return Object.fromEntries(
+        fields.map((field) => [
+          field,
+          Array.from(
+            new Set(this.data.filter((item) => item[field]).map((item) => item[field])),
+          ).sort(),
+        ]),
+      );
     },
     uniqueStatus() {
       return Array.from(
@@ -1154,25 +1133,14 @@ export default {
       return value.some((itemBlock) => itemBlock.blocktype === filterValue.blocktype);
     });
 
-    FilterService.register("exactLocationMatch", (value, filterValue) => {
+    const exactStringMatch = (value, filterValue) => {
       if (!filterValue || (Array.isArray(filterValue) && filterValue.length === 0)) {
         return true;
       }
-      if (Array.isArray(filterValue)) {
-        return filterValue.includes(value);
-      }
-      return filterValue === value;
-    });
-
-    FilterService.register("exactSupplierMatch", (value, filterValue) => {
-      if (!filterValue || (Array.isArray(filterValue) && filterValue.length === 0)) {
-        return true;
-      }
-      if (Array.isArray(filterValue)) {
-        return filterValue.includes(value);
-      }
-      return filterValue === value;
-    });
+      return Array.isArray(filterValue) ? filterValue.includes(value) : filterValue === value;
+    };
+    FilterService.register("exactLocationMatch", exactStringMatch);
+    FilterService.register("exactSupplierMatch", exactStringMatch);
 
     FilterService.register("exactStatusMatch", (value, filterValue) => {
       if (!filterValue || (Array.isArray(filterValue) && filterValue.length === 0)) {

--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -290,6 +290,56 @@
           </MultiSelect>
         </template>
 
+        <template v-else-if="column.filter && column.field === 'location'" #filter="">
+          <MultiSelect
+            v-model="filters[column.field].constraints[0].value"
+            :options="uniqueLocations"
+            placeholder="Any"
+            class="d-flex w-full"
+            :filter="true"
+            @click.stop
+          >
+            <template #value="slotProps">
+              <div class="flex flex-wrap gap-1 items-center">
+                <template v-if="slotProps.value && slotProps.value.length">
+                  <span
+                    v-for="(option, index) in slotProps.value"
+                    :key="index"
+                    class="inline-flex items-center mr-2"
+                    >{{ option }}</span
+                  >
+                </template>
+                <span v-else class="text-gray-400">Any</span>
+              </div>
+            </template>
+          </MultiSelect>
+        </template>
+
+        <template v-else-if="column.filter && column.field === 'supplier'" #filter="">
+          <MultiSelect
+            v-model="filters[column.field].constraints[0].value"
+            :options="uniqueSuppliers"
+            placeholder="Any"
+            class="d-flex w-full"
+            :filter="true"
+            @click.stop
+          >
+            <template #value="slotProps">
+              <div class="flex flex-wrap gap-1 items-center">
+                <template v-if="slotProps.value && slotProps.value.length">
+                  <span
+                    v-for="(option, index) in slotProps.value"
+                    :key="index"
+                    class="inline-flex items-center mr-2"
+                    >{{ option }}</span
+                  >
+                </template>
+                <span v-else class="text-gray-400">Any</span>
+              </div>
+            </template>
+          </MultiSelect>
+        </template>
+
         <template v-else-if="column.filter && column.field === 'date'" #filter="{ filterModel }">
           <div style="display: flex; flex-direction: column; gap: 0.5rem" @click.stop>
             <Select
@@ -697,7 +747,11 @@ export default {
         },
         location: {
           operator: FilterOperator.AND,
-          constraints: [{ value: null, matchMode: FilterMatchMode.CONTAINS }],
+          constraints: [{ value: null, matchMode: "exactLocationMatch" }],
+        },
+        supplier: {
+          operator: FilterOperator.AND,
+          constraints: [{ value: null, matchMode: "exactSupplierMatch" }],
         },
         collections: {
           operator: FilterOperator.AND,
@@ -856,6 +910,16 @@ export default {
       blockTypesMap.set("__no_blocks__", { blocktype: "__no_blocks__", label: "No blocks" });
 
       return Array.from(blockTypesMap.values());
+    },
+    uniqueLocations() {
+      return Array.from(
+        new Set(this.data.filter((item) => item.location).map((item) => item.location)),
+      ).sort();
+    },
+    uniqueSuppliers() {
+      return Array.from(
+        new Set(this.data.filter((item) => item.supplier).map((item) => item.supplier)),
+      ).sort();
     },
     uniqueStatus() {
       return Array.from(
@@ -1088,6 +1152,26 @@ export default {
       }
 
       return value.some((itemBlock) => itemBlock.blocktype === filterValue.blocktype);
+    });
+
+    FilterService.register("exactLocationMatch", (value, filterValue) => {
+      if (!filterValue || (Array.isArray(filterValue) && filterValue.length === 0)) {
+        return true;
+      }
+      if (Array.isArray(filterValue)) {
+        return filterValue.includes(value);
+      }
+      return filterValue === value;
+    });
+
+    FilterService.register("exactSupplierMatch", (value, filterValue) => {
+      if (!filterValue || (Array.isArray(filterValue) && filterValue.length === 0)) {
+        return true;
+      }
+      if (Array.isArray(filterValue)) {
+        return filterValue.includes(value);
+      }
+      return filterValue === value;
     });
 
     FilterService.register("exactStatusMatch", (value, filterValue) => {

--- a/webapp/src/components/EquipmentInformation.vue
+++ b/webapp/src/components/EquipmentInformation.vue
@@ -36,6 +36,7 @@
         <label for="equip-location" class="mr-2">Location</label>
         <AutoComplete
           v-model="Location"
+          input-id="equip-location"
           :suggestions="filteredLocations"
           class="form-control p-0 border-0"
           input-class="form-control"

--- a/webapp/src/components/EquipmentInformation.vue
+++ b/webapp/src/components/EquipmentInformation.vue
@@ -34,7 +34,13 @@
       </div>
       <div class="form-group col-md-5">
         <label for="equip-location" class="mr-2">Location</label>
-        <input id="equip-location" v-model="Location" class="form-control" />
+        <AutoComplete
+          v-model="Location"
+          :suggestions="filteredLocations"
+          class="form-control p-0 border-0"
+          input-class="form-control"
+          @complete="filterLocations"
+        />
       </div>
     </div>
     <div class="form-row">
@@ -73,6 +79,8 @@
 </template>
 
 <script>
+import AutoComplete from "primevue/autocomplete";
+import { getStartingMaterialList, getEquipmentList } from "@/server_fetch_utils.js";
 import { createComputedSetterForItemField } from "@/field_utils.js";
 import TiptapInline from "@/components/TiptapInline";
 import TableOfContents from "@/components/TableOfContents";
@@ -83,6 +91,7 @@ import ToggleableItemStatusFormGroup from "@/components/ToggleableItemStatusForm
 
 export default {
   components: {
+    AutoComplete,
     TiptapInline,
     CollectionList,
     TableOfContents,
@@ -95,6 +104,7 @@ export default {
   },
   data() {
     return {
+      filteredLocations: [],
       tableOfContentsSections: [
         { title: "Equipment Information", targetID: "equipment-information" },
         { title: "Table of Contents", targetID: "table-of-contents" },
@@ -121,6 +131,32 @@ export default {
     },
     possibleItemStatuses() {
       return this.schema?.attributes?.schema?.definitions?.EquipmentStatus?.enum;
+    },
+    uniqueLocations() {
+      return [
+        ...new Set(
+          [
+            ...(this.$store.state.starting_material_list || []),
+            ...(this.$store.state.equipment_list || []),
+          ]
+            .map((item) => item.location)
+            .filter(Boolean),
+        ),
+      ].sort();
+    },
+  },
+  created() {
+    if (this.$store.state.starting_material_list === null) {
+      getStartingMaterialList();
+    }
+    if (this.$store.state.equipment_list === null) {
+      getEquipmentList();
+    }
+  },
+  methods: {
+    filterLocations(event) {
+      const query = event.query.toLowerCase();
+      this.filteredLocations = this.uniqueLocations.filter((l) => l.toLowerCase().includes(query));
     },
   },
 };

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -47,13 +47,29 @@
         <div class="form-row">
           <div class="form-group col-lg-12 col-sm-12">
             <label for="startmat-location">Location</label>
-            <StyledInput id="startmat-location" v-model="Location" :readonly="!isEditable" />
+            <AutoComplete
+              v-if="isEditable"
+              v-model="Location"
+              :suggestions="filteredLocations"
+              class="form-control p-0 border-0"
+              input-class="form-control"
+              @complete="filterLocations"
+            />
+            <StyledInput v-else id="startmat-location" v-model="Location" :readonly="true" />
           </div>
         </div>
         <div class="form-row">
           <div class="form-group col-lg-3 col-sm-4">
             <label for="startmat-supplier">Supplier</label>
-            <StyledInput id="startmat-supplier" v-model="Supplier" :readonly="!isEditable" />
+            <AutoComplete
+              v-if="isEditable"
+              v-model="Supplier"
+              :suggestions="filteredSuppliers"
+              class="form-control p-0 border-0"
+              input-class="form-control"
+              @complete="filterSuppliers"
+            />
+            <StyledInput v-else id="startmat-supplier" v-model="Supplier" :readonly="true" />
           </div>
           <div class="form-group col-lg-3 col-sm-4">
             <label for="startmat-purity">Chemical purity</label>
@@ -117,10 +133,13 @@ import SynthesisInformation from "@/components/SynthesisInformation";
 import ItemRelationshipVisualization from "@/components/ItemRelationshipVisualization";
 import GHSHazardInformation from "@/components/GHSHazardInformation";
 
+import AutoComplete from "primevue/autocomplete";
+import { getStartingMaterialList, getEquipmentList } from "@/server_fetch_utils.js";
 import { EDITABLE_INVENTORY } from "@/resources.js";
 
 export default {
   components: {
+    AutoComplete,
     StyledInput,
     ChemicalFormula,
     ChemFormulaInput,
@@ -139,6 +158,8 @@ export default {
   },
   data() {
     return {
+      filteredSuppliers: [],
+      filteredLocations: [],
       tableOfContentsSections: [
         { title: "Starting Material Information", targetID: "starting-material-information" },
         { title: "Table of Contents", targetID: "table-of-contents" },
@@ -171,9 +192,46 @@ export default {
       return this.schema?.attributes?.schema?.definitions?.StartingMaterialsStatus?.enum;
     },
     Barcode: createComputedSetterForItemField("barcode"),
+    uniqueSuppliers() {
+      return [
+        ...new Set(
+          (this.$store.state.starting_material_list || [])
+            .map((item) => item.supplier)
+            .filter(Boolean),
+        ),
+      ].sort();
+    },
+    uniqueLocations() {
+      return [
+        ...new Set(
+          [
+            ...(this.$store.state.starting_material_list || []),
+            ...(this.$store.state.equipment_list || []),
+          ]
+            .map((item) => item.location)
+            .filter(Boolean),
+        ),
+      ].sort();
+    },
   },
   created() {
     this.isEditable = EDITABLE_INVENTORY;
+    if (this.$store.state.starting_material_list === null) {
+      getStartingMaterialList();
+    }
+    if (this.$store.state.equipment_list === null) {
+      getEquipmentList();
+    }
+  },
+  methods: {
+    filterSuppliers(event) {
+      const query = event.query.toLowerCase();
+      this.filteredSuppliers = this.uniqueSuppliers.filter((s) => s.toLowerCase().includes(query));
+    },
+    filterLocations(event) {
+      const query = event.query.toLowerCase();
+      this.filteredLocations = this.uniqueLocations.filter((l) => l.toLowerCase().includes(query));
+    },
   },
 };
 </script>

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -50,6 +50,7 @@
             <AutoComplete
               v-if="isEditable"
               v-model="Location"
+              input-id="startmat-location"
               :suggestions="filteredLocations"
               class="form-control p-0 border-0"
               input-class="form-control"
@@ -64,6 +65,7 @@
             <AutoComplete
               v-if="isEditable"
               v-model="Supplier"
+              input-id="startmat-supplier"
               :suggestions="filteredSuppliers"
               class="form-control p-0 border-0"
               input-class="form-control"

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -48,30 +48,28 @@
           <div class="form-group col-lg-12 col-sm-12">
             <label for="startmat-location">Location</label>
             <AutoComplete
-              v-if="isEditable"
               v-model="Location"
               input-id="startmat-location"
               :suggestions="filteredLocations"
+              :disabled="!isEditable"
               class="form-control p-0 border-0"
               input-class="form-control"
               @complete="filterLocations"
             />
-            <StyledInput v-else id="startmat-location" v-model="Location" :readonly="true" />
           </div>
         </div>
         <div class="form-row">
           <div class="form-group col-lg-3 col-sm-4">
             <label for="startmat-supplier">Supplier</label>
             <AutoComplete
-              v-if="isEditable"
               v-model="Supplier"
               input-id="startmat-supplier"
               :suggestions="filteredSuppliers"
+              :disabled="!isEditable"
               class="form-control p-0 border-0"
               input-class="form-control"
               @complete="filterSuppliers"
             />
-            <StyledInput v-else id="startmat-supplier" v-model="Supplier" :readonly="true" />
           </div>
           <div class="form-group col-lg-3 col-sm-4">
             <label for="startmat-purity">Chemical purity</label>

--- a/webapp/src/components/StartingMaterialTable.vue
+++ b/webapp/src/components/StartingMaterialTable.vue
@@ -75,12 +75,7 @@ export default {
         return null;
       }
 
-      return this.$store.state.starting_material_list.map((item) => ({
-        ...item,
-        collectionsList: (item.collections || [])
-          .map((collection) => collection.collection_id)
-          .join(", "),
-      }));
+      return this.$store.state.starting_material_list;
     },
   },
   mounted() {

--- a/webapp/src/components/StartingMaterialTable.vue
+++ b/webapp/src/components/StartingMaterialTable.vue
@@ -43,6 +43,13 @@ export default {
         { field: "name", header: "Name", label: "Name" },
         { field: "chemform", header: "Formula", body: "ChemicalFormula", label: "Formula" },
         { field: "date", header: "Date", label: "Date" },
+        {
+          field: "collections",
+          header: "Collections",
+          body: "CollectionList",
+          filter: true,
+          label: "Collections",
+        },
         { field: "location", header: "Location", label: "Location", filter: true },
         {
           field: "blocks",
@@ -68,7 +75,12 @@ export default {
         return null;
       }
 
-      return this.$store.state.starting_material_list;
+      return this.$store.state.starting_material_list.map((item) => ({
+        ...item,
+        collectionsList: (item.collections || [])
+          .map((collection) => collection.collection_id)
+          .join(", "),
+      }));
     },
   },
   mounted() {

--- a/webapp/src/components/StartingMaterialTable.vue
+++ b/webapp/src/components/StartingMaterialTable.vue
@@ -50,6 +50,7 @@ export default {
           filter: true,
           label: "Collections",
         },
+        { field: "supplier", header: "Supplier", label: "Supplier", filter: true },
         { field: "location", header: "Location", label: "Location", filter: true },
         {
           field: "blocks",


### PR DESCRIPTION
This pull request introduces several enhancements to both backend and frontend related to starting materials, focusing on improved handling and filtering of `location`, `supplier`, and `collections` fields. The backend now includes collection information in starting materials API responses, while the frontend adds advanced filtering and auto-complete features for `location` and `supplier` fields, and updates the UI and tests to reflect these changes.