### PR TITLE
Return gravatar hashes instead of contact emails from more endpoints

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/admin.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/admin.py
@@ -329,7 +329,7 @@ def get_groups():
                 "$project": {
                     "_id": 1,
                     "display_name": 1,
-                    "contact_email": 1,
+                    "gravatar_hash": 1,
                 }
             },
         ],
@@ -346,7 +346,7 @@ def get_groups():
                 "$project": {
                     "_id": 1,
                     "display_name": 1,
-                    "contact_email": 1,
+                    "gravatar_hash": 1,
                 }
             },
         ],

--- a/pydatalab/src/pydatalab/routes/v0_1/collections.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/collections.py
@@ -122,7 +122,7 @@ def create_collection():
         data["creators"] = [
             {
                 "display_name": current_user.person.display_name,
-                "contact_email": current_user.person.contact_email,
+                "gravatar_hash": current_user.person.gravatar_hash,
             }
         ]
 

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -637,7 +637,7 @@ def _create_sample(
         new_sample["creators"] = [
             {
                 "display_name": current_user.person.display_name,
-                "contact_email": current_user.person.contact_email,
+                "gravatar_hash": current_user.person.gravatar_hash,
             }
         ]
 
@@ -1730,12 +1730,12 @@ def get_access_token_info(refcode: str):
         user_info = None
         if existing_token.get("user"):
             user_doc = flask_mongo.db.users.find_one(
-                {"_id": existing_token["user"]}, {"display_name": 1, "contact_email": 1}
+                {"_id": existing_token["user"]}, {"display_name": 1, "gravatar_hash": 1}
             )
             if user_doc:
                 user_info = {
                     "display_name": user_doc.get("display_name"),
-                    "contact_email": user_doc.get("contact_email"),
+                    "gravatar_hash": user_doc.get("gravatar_hash"),
                 }
 
         return jsonify(


### PR DESCRIPTION
Continuing the work in #1686, removing any leftover `contact_email` projections and making `gravatar_hash` available on demand.