### PR TITLE
Hotfix Current units for echem plotting

### DIFF
--- a/pydatalab/src/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/src/pydatalab/apps/echem/blocks.py
@@ -294,18 +294,21 @@ class CycleBlock(DataBlock):
             "Time",
             "Voltage",
             "Capacity",
-            "Current",
+            "Current(mA)",
             "dqdv",
             "dvdq",
             "half cycle",
             "full cycle",
             "state",
         )
+        if "Current(mA)" not in raw_df.columns:
+            raw_df["Current(mA)"] = raw_df["Current"]
+
         keys_with_units = {
             "Time": "time (s)",
             "Voltage": "voltage (V)",
             "Capacity": "capacity (mAh)",
-            "Current": "current (mA)",
+            "Current(mA)": "current (mA)",
             "Charge Capacity": "charge capacity (mAh)",
             "Discharge Capacity": "discharge capacity (mAh)",
             "dqdv": "dQ/dV (mA/V)",


### PR DESCRIPTION
There seems to be some unit inconsistency from Neware software that we were not properly accounting for; this is a temporary hotfix to make sure `current (mA)` as a field name is preferred when plotting, if it is present, rather than `Current` which may be provided in A or mA at the moment. This only effects plotting and not the resulting data caches, so blocks will reload with the appropriate fix.