### PR TITLE
Fixing duplication of parthood relationships for cells and samples 

### DIFF
--- a/pydatalab/src/pydatalab/models/cells.py
+++ b/pydatalab/src/pydatalab/models/cells.py
@@ -116,4 +116,11 @@ class Cell(Item):
                     relationship.refcode = relationship.refcode or refcode
                     relationship.item_id = relationship.item_id or item_id
 
+                # Register the relationship's identifiers in the index so a later
+                # constituent referencing the same entry matches it rather than
+                # appending a duplicate within this same validation pass.
+                for identifier in (relationship.refcode, relationship.item_id):
+                    if identifier:
+                        existing_parthood_relationships[identifier] = relationship
+
         return values

--- a/pydatalab/src/pydatalab/models/cells.py
+++ b/pydatalab/src/pydatalab/models/cells.py
@@ -77,30 +77,43 @@ class Cell(Item):
         """Add any missing sample synthesis constituents to parent relationships"""
         from pydatalab.models.relationships import RelationshipType, TypedRelationship
 
-        existing_parthood_relationship_ids = set()
+        existing_parthood_relationships = {}
         if values.get("relationships") is not None:
-            existing_parthood_relationship_ids = {
-                relationship.refcode or relationship.item_id
+            # Index by refcode *and* item_id so a stored relationship carrying an
+            # item_id still matches a refcode-enriched constituent (and vice-versa).
+            existing_parthood_relationships = {
+                identifier: relationship
                 for relationship in values["relationships"]
                 if relationship.relation == RelationshipType.PARTHOOD
+                for identifier in (relationship.refcode, relationship.item_id)
+                if identifier
             }
         else:
             values["relationships"] = []
 
         for component in ("positive_electrode", "negative_electrode", "electrolyte"):
             for constituent in values.get(component, []):
-                if (
-                    isinstance(constituent.item, EntryReference)
-                    and (constituent.item.refcode or constituent.item.item_id)
-                    not in existing_parthood_relationship_ids
-                ):
+                if not isinstance(constituent.item, EntryReference):
+                    continue
+
+                refcode = constituent.item.refcode
+                item_id = constituent.item.item_id
+
+                relationship = existing_parthood_relationships.get(
+                    refcode
+                ) or existing_parthood_relationships.get(item_id)
+                if relationship is None:
                     relationship = TypedRelationship(
                         relation=RelationshipType.PARTHOOD,
-                        refcode=constituent.item.refcode,
-                        item_id=constituent.item.item_id,
+                        refcode=refcode,
+                        item_id=item_id,
                         type=constituent.item.type,
                         description="Is a constituent of",
                     )
                     values["relationships"].append(relationship)
+                else:
+                    # Back-fill any identifier missing from the stored relationship
+                    relationship.refcode = relationship.refcode or refcode
+                    relationship.item_id = relationship.item_id or item_id
 
         return values

--- a/pydatalab/src/pydatalab/models/cells.py
+++ b/pydatalab/src/pydatalab/models/cells.py
@@ -74,7 +74,7 @@ class Cell(Item):
 
     @root_validator
     def add_missing_electrode_relationships(cls, values):
-        """Add any missing sample synthesis constituents to parent relationships"""
+        """Add any missing cell component constituents to parent relationships"""
         from pydatalab.models.relationships import RelationshipType, TypedRelationship
 
         existing_parthood_relationships = {}

--- a/pydatalab/src/pydatalab/models/traits.py
+++ b/pydatalab/src/pydatalab/models/traits.py
@@ -106,12 +106,16 @@ class HasSynthesisInfo(BaseModel):
 
         constituents_set = set()
         if values.get("synthesis_constituents") is not None:
-            existing_parent_relationship_ids = set()
+            existing_parent_relationships = {}
             if values.get("relationships") is not None:
-                existing_parent_relationship_ids = {
-                    relationship.refcode or relationship.item_id
+                # Index by refcode *and* item_id so a stored relationship carrying an
+                # item_id still matches a refcode-enriched constituent (and vice-versa).
+                existing_parent_relationships = {
+                    identifier: relationship
                     for relationship in values["relationships"]
                     if relationship.relation == RelationshipType.PARENT
+                    for identifier in (relationship.refcode, relationship.item_id)
+                    if identifier
                 }
             else:
                 values["relationships"] = []
@@ -121,20 +125,28 @@ class HasSynthesisInfo(BaseModel):
                 if isinstance(constituent.item, InlineSubstance):
                     continue
 
-                constituent_id = constituent.item.refcode or constituent.item.item_id
+                refcode = constituent.item.refcode
+                item_id = constituent.item.item_id
 
-                if constituent_id not in existing_parent_relationship_ids:
+                relationship = existing_parent_relationships.get(
+                    refcode
+                ) or existing_parent_relationships.get(item_id)
+                if relationship is None:
                     relationship = TypedRelationship(
                         relation=RelationshipType.PARENT,
-                        refcode=constituent.item.refcode,
-                        item_id=constituent.item.item_id,
+                        refcode=refcode,
+                        item_id=item_id,
                         type=constituent.item.type,
                         description="Is a constituent of",
                     )
                     values["relationships"].append(relationship)
+                else:
+                    # Back-fill any identifier missing from the stored relationship
+                    relationship.refcode = relationship.refcode or refcode
+                    relationship.item_id = relationship.item_id or item_id
 
                 # Accumulate all constituent IDs in a set to filter those that have been deleted
-                constituents_set.add(constituent_id)
+                constituents_set.update(i for i in (refcode, item_id) if i)
 
         # Finally, filter out any parent relationships with item that were removed
         # from the synthesis constituents
@@ -142,7 +154,8 @@ class HasSynthesisInfo(BaseModel):
             rel
             for rel in values["relationships"]
             if not (
-                (rel.refcode or rel.item_id) not in constituents_set
+                rel.refcode not in constituents_set
+                and rel.item_id not in constituents_set
                 and rel.relation == RelationshipType.PARENT
                 and rel.type in ("samples", "starting_materials")
             )

--- a/pydatalab/src/pydatalab/models/traits.py
+++ b/pydatalab/src/pydatalab/models/traits.py
@@ -145,6 +145,13 @@ class HasSynthesisInfo(BaseModel):
                     relationship.refcode = relationship.refcode or refcode
                     relationship.item_id = relationship.item_id or item_id
 
+                # Register the relationship's identifiers in the index so a later
+                # constituent referencing the same entry matches it rather than
+                # appending a duplicate within this same validation pass.
+                for identifier in (relationship.refcode, relationship.item_id):
+                    if identifier:
+                        existing_parent_relationships[identifier] = relationship
+
                 # Accumulate all constituent IDs in a set to filter those that have been deleted
                 constituents_set.update(i for i in (refcode, item_id) if i)
 

--- a/pydatalab/tests/test_models.py
+++ b/pydatalab/tests/test_models.py
@@ -324,6 +324,76 @@ def test_cell_with_inlined_reference():
     assert len(cell.relationships) == 1
 
 
+def test_cell_relationship_deduplication():
+    """Regression test for duplicated parthood relationships.
+
+    `entry_reference_lookup` enriches electrode constituents with their refcode
+    at read time but does not back-fill the stored `relationships` rows. The
+    dedup logic must therefore match a stored relationship that carries only an
+    item_id against a constituent enriched with a refcode (and vice-versa),
+    rather than appending a duplicate, and back-fill the missing identifier so
+    the surviving relationship carries both.
+    """
+    from pydatalab.models.cells import Cell
+
+    # Stored relationship has item_id only; constituent enriched with refcode.
+    cell = Cell(
+        item_id="abcd-1-2-3",
+        positive_electrode=[
+            {
+                "item": {
+                    "type": "samples",
+                    "item_id": "test_cathode",
+                    "refcode": "grey:ABCDEF",
+                },
+                "quantity": 1,
+            }
+        ],
+        relationships=[
+            {
+                "relation": "is_part_of",
+                "type": "samples",
+                "item_id": "test_cathode",
+                "description": "Is a constituent of",
+            }
+        ],
+    )
+    parthood = [r for r in cell.relationships if r.relation == RelationshipType.PARTHOOD]
+    assert len(parthood) == 1
+    # The refcode from the constituent is back-filled onto the stored relationship.
+    assert parthood[0].refcode == "grey:ABCDEF"
+    assert parthood[0].item_id == "test_cathode"
+
+    # Reverse asymmetry: stored relationship has refcode, constituent item_id only.
+    cell = Cell(
+        item_id="abcd-1-2-3",
+        positive_electrode=[
+            {"item": {"type": "samples", "item_id": "test_cathode"}, "quantity": 1}
+        ],
+        relationships=[
+            {
+                "relation": "is_part_of",
+                "type": "samples",
+                "item_id": "test_cathode",
+                "refcode": "grey:ABCDEF",
+                "description": "Is a constituent of",
+            }
+        ],
+    )
+    parthood = [r for r in cell.relationships if r.relation == RelationshipType.PARTHOOD]
+    assert len(parthood) == 1
+    # The item_id from the constituent is back-filled onto the stored relationship.
+    assert parthood[0].refcode == "grey:ABCDEF"
+    assert parthood[0].item_id == "test_cathode"
+
+    # Re-validating an already-clean cell must not grow the relationships list.
+    cell = Cell(**json.loads(cell.json()))
+    parthood = [r for r in cell.relationships if r.relation == RelationshipType.PARTHOOD]
+    assert len(parthood) == 1
+    assert parthood[0].refcode == "grey:ABCDEF"
+    assert parthood[0].item_id == "test_cathode"
+
+
 def test_molar_mass():
     import math
 

--- a/pydatalab/tests/test_models.py
+++ b/pydatalab/tests/test_models.py
@@ -18,9 +18,10 @@ from pydatalab.models.utils import HumanReadableIdentifier, Refcode
 
 
 def test_sample_with_inlined_reference():
+    from pydatalab.models.relationships import RelationshipType
     from pydatalab.models.samples import Sample
 
-    a = Sample(item_id="test_anode", chemform="C")
+    a = Sample(item_id="test_anode", refcode="test:ANODE", chemform="C")
 
     b = Sample(
         item_id="abcd-1-2-3",
@@ -31,6 +32,29 @@ def test_sample_with_inlined_reference():
 
     assert b
     assert len(b.relationships) == 1
+    # A constituent referenced by item_id alone produces a relationship keyed on item_id
+    assert b.relationships[0].item_id == a.item_id
+    assert b.relationships[0].refcode is None
+
+    # A constituent carrying both identifiers should propagate both onto the
+    # relationship, and re-validation must not duplicate it.
+    b_both = Sample(
+        item_id="abcd-1-2-3",
+        synthesis_constituents=[
+            {
+                "item": {"item_id": a.item_id, "refcode": a.refcode, "type": "samples"},
+                "quantity": None,
+            }
+        ],
+    )
+    parents = [r for r in b_both.relationships if r.relation == RelationshipType.PARENT]
+    assert len(parents) == 1
+    assert parents[0].item_id == a.item_id
+    assert parents[0].refcode == a.refcode
+
+    b_both = Sample(**json.loads(b_both.json()))
+    parents = [r for r in b_both.relationships if r.relation == RelationshipType.PARENT]
+    assert len(parents) == 1
 
     c = Sample(
         item_id="c-123",

--- a/pydatalab/tests/test_models.py
+++ b/pydatalab/tests/test_models.py
@@ -417,6 +417,101 @@ def test_cell_relationship_deduplication():
     assert parthood[0].refcode == "grey:ABCDEF"
     assert parthood[0].item_id == "test_cathode"
 
+    # Two constituents referencing the same entry (with a shared identifier) within
+    # a single pass must collapse to one relationship, not append a duplicate.
+    cell = Cell(
+        item_id="abcd-1-2-3",
+        positive_electrode=[
+            {"item": {"type": "samples", "item_id": "test_cathode"}, "quantity": 1},
+            {
+                "item": {
+                    "type": "samples",
+                    "item_id": "test_cathode",
+                    "refcode": "grey:ABCDEF",
+                },
+                "quantity": 1,
+            },
+        ],
+    )
+    parthood = [r for r in cell.relationships if r.relation == RelationshipType.PARTHOOD]
+    assert len(parthood) == 1
+    assert parthood[0].refcode == "grey:ABCDEF"
+    assert parthood[0].item_id == "test_cathode"
+
+
+def test_sample_synthesis_relationship_deduplication():
+    """Regression test for duplicated parent relationships on synthesis constituents.
+
+    Mirrors `test_cell_relationship_deduplication` for the
+    `add_missing_synthesis_relationships` validator: a stored relationship that
+    carries only one identifier must match a constituent enriched with the other
+    (in either direction), back-fill the missing identifier rather than appending
+    a duplicate, and remain idempotent on re-validation.
+    """
+    from pydatalab.models.samples import Sample
+
+    # Stored relationship has item_id only; constituent enriched with refcode.
+    sample = Sample(
+        item_id="abcd-1-2-3",
+        synthesis_constituents=[
+            {
+                "item": {
+                    "type": "starting_materials",
+                    "item_id": "sm_1",
+                    "refcode": "grey:ABCDEF",
+                },
+                "quantity": 1,
+            }
+        ],
+        relationships=[
+            {
+                "relation": "parent",
+                "type": "starting_materials",
+                "item_id": "sm_1",
+                "description": "Is a constituent of",
+            }
+        ],
+    )
+    parents = [r for r in sample.relationships if r.relation == RelationshipType.PARENT]
+    assert len(parents) == 1
+    assert parents[0].refcode == "grey:ABCDEF"
+    assert parents[0].item_id == "sm_1"
+
+    # Reverse asymmetry: stored relationship has refcode *only*; the constituent
+    # supplies the item_id, which must be back-filled onto the matched relationship.
+    sample = Sample(
+        item_id="abcd-1-2-3",
+        synthesis_constituents=[
+            {
+                "item": {
+                    "type": "starting_materials",
+                    "item_id": "sm_1",
+                    "refcode": "grey:ABCDEF",
+                },
+                "quantity": 1,
+            }
+        ],
+        relationships=[
+            {
+                "relation": "parent",
+                "type": "starting_materials",
+                "refcode": "grey:ABCDEF",
+                "description": "Is a constituent of",
+            }
+        ],
+    )
+    parents = [r for r in sample.relationships if r.relation == RelationshipType.PARENT]
+    assert len(parents) == 1
+    assert parents[0].refcode == "grey:ABCDEF"
+    assert parents[0].item_id == "sm_1"
+
+    # Re-validating an already-clean sample must not grow the relationships list.
+    sample = Sample(**json.loads(sample.json()))
+    parents = [r for r in sample.relationships if r.relation == RelationshipType.PARENT]
+    assert len(parents) == 1
+    assert parents[0].refcode == "grey:ABCDEF"
+    assert parents[0].item_id == "sm_1"
+
 
 def test_molar_mass():
     import math


### PR DESCRIPTION
Fix duplicated parthood relationships from refcode/item_id dedup mismatch

The `add_missing_electrode_relationships` and `add_missing_synthesis_relationships` validators deduplicated relationships against constituents using a single `refcode or item_id` token, evaluated independently on each side. Because `entry_reference_lookup` enriches constituents with their refcode at read time but leaves the stored `relationships` rows untouched, the stored side keys on `item_id` while the enriched side keys on `refcode` — the two never compare equal, so a duplicate parthood relationship is appended on every read and persisted on every write.

Both validators now index existing relationships by refcode *and* item_id (a dict `identifier -> relationship`), match a constituent if *either* identifier is found, and back-fill the missing identifier in place rather than appending a duplicate. This also fixes the latent reverse-asymmetry case and replaces the synthesis validator's create-then-delete back-fill side-effect with an explicit one.

Adds `test_cell_relationship_deduplication` covering the forward/reverse asymmetry and idempotency.