### PR TITLE
Add item reference lookup when patching rather than just retrieval

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -687,6 +687,9 @@ def _create_sample(
     # Set creation timestamp to now if not provided
     new_sample["date"] = new_sample.get("date", datetime.datetime.now(tz=datetime.timezone.utc))
 
+    # Check on relationship fields and prefill
+    new_sample = entry_reference_lookup(new_sample)
+
     # Try to deserialize the item data into the appropriate model
     try:
         data_model: Item = model(**new_sample)
@@ -1656,6 +1659,7 @@ def save_item():
     original_relationships = item.get("relationships", []) if preserve_relationships else None
 
     item.update(updated_data)
+    item = entry_reference_lookup(item)
 
     try:
         item = ITEM_MODELS[item_type](**item).dict()

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -363,7 +363,14 @@ def entry_reference_lookup(item_doc: dict) -> dict:
             if ref:
                 deref = flask_mongo.db.items.find_one(
                     {**ref, **get_default_permissions()},
-                    projection={"name": 1, "item_id": 1, "refcode": 1, "chemform": 1, "type": 1},
+                    projection={
+                        "name": 1,
+                        "item_id": 1,
+                        "refcode": 1,
+                        "chemform": 1,
+                        "type": 1,
+                        "_id": 0,
+                    },
                 )
             # If the source item has been deleted, is inlined or is inaccessible, use the original subitem data
             if not ref or not deref:

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import json
 import secrets
@@ -18,7 +19,7 @@ from pydatalab.logger import LOGGER
 from pydatalab.models import ITEM_MODELS, ItemVersion
 from pydatalab.models.items import Item
 from pydatalab.models.relationships import RelationshipType
-from pydatalab.models.utils import generate_unique_refcode
+from pydatalab.models.utils import InlineSubstance, generate_unique_refcode
 from pydatalab.models.versions import (
     CompareVersionsQuery,
     RestoreVersionRequest,
@@ -324,6 +325,8 @@ def groups_lookup() -> dict:
 def entry_reference_lookup(item_doc: dict) -> dict:
     """Looks up any field that contains an entry reference and resolves it to the item data."""
 
+    from pydatalab.models.utils import Constituent
+
     # TODO (v0.8): We hard-code this for now but should extract this from pydantic v2 schemas instead
     # Each field contains a reference like {"item": {"item_id": ..., "refcode": ..., "type": ...}},
     # or simply an inlined {"item": {"name": ..., "chemform": ...}} object without reference fields.
@@ -347,17 +350,14 @@ def entry_reference_lookup(item_doc: dict) -> dict:
         dereferenced_fields[field] = []
 
         for subitem in item_doc.get(field, []):
-            refcode = subitem.get("item", {}).get("refcode", None)
-            if refcode:
-                preferred_refs.append({"refcode": refcode})
-                continue
-            item_id = subitem.get("item", {}).get("item_id", None)
-            if item_id:
-                preferred_refs.append({"item_id": item_id})
-                continue
-
-            # If no refcode or item_id, this is an inlined item, so no lookup needed
-            preferred_refs.append(None)
+            constituent = Constituent(**copy.deepcopy(subitem))
+            if isinstance(constituent.item, InlineSubstance):
+                # If no refcode or item_id, this is an inlined item, so no lookup needed
+                preferred_refs.append(None)
+            elif constituent.item.refcode:
+                preferred_refs.append({"refcode": constituent.item.refcode})
+            elif constituent.item.item_id:
+                preferred_refs.append({"item_id": constituent.item.item_id})
 
         for ind, ref in enumerate(preferred_refs):
             if ref:

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -350,7 +350,19 @@ def entry_reference_lookup(item_doc: dict) -> dict:
         dereferenced_fields[field] = []
 
         for subitem in item_doc.get(field, []):
-            constituent = Constituent(**copy.deepcopy(subitem))
+            try:
+                constituent = Constituent(**copy.deepcopy(subitem))
+            except ValidationError as exc:
+                # Enrichment is opportunistic — if a stored subitem can't be parsed,
+                # skip the lookup and leave it untouched so the caller can still see
+                # and repair it.
+                LOGGER.warning(
+                    "Skipping entry reference lookup for unparseable subitem in %s: %s",
+                    field,
+                    exc,
+                )
+                preferred_refs.append(None)
+                continue
             if isinstance(constituent.item, InlineSubstance):
                 # If no refcode or item_id, this is an inlined item, so no lookup needed
                 preferred_refs.append(None)
@@ -687,11 +699,11 @@ def _create_sample(
     # Set creation timestamp to now if not provided
     new_sample["date"] = new_sample.get("date", datetime.datetime.now(tz=datetime.timezone.utc))
 
-    # Check on relationship fields and prefill
-    new_sample = entry_reference_lookup(new_sample)
-
     # Try to deserialize the item data into the appropriate model
     try:
+        # Check on relationship fields and prefill
+        new_sample = entry_reference_lookup(new_sample)
+
         data_model: Item = model(**new_sample)
 
     except ValidationError as error:
@@ -1137,8 +1149,6 @@ def get_item_data(
             404,
         )
 
-    doc = entry_reference_lookup(doc)
-
     # determine the item type and validate according to the appropriate schema
     try:
         ItemModel = ITEM_MODELS[doc["type"]]
@@ -1148,7 +1158,29 @@ def get_item_data(
         else:
             raise BadRequest(f"Item {item_id=} has no type field in document.")
 
-    doc = ItemModel(**doc)
+    try:
+        doc = entry_reference_lookup(doc)
+        doc = ItemModel(**doc)
+    except ValidationError as error:
+        # The stored document doesn't validate against its declared schema.
+        # This is a server-side data integrity problem, not a bad request,
+        # so surface it as a 500 with a clear message rather than blaming the caller.
+        LOGGER.error(
+            "Stored item %s failed to validate against schema for type %s: %s",
+            item_id,
+            doc["type"],
+            error,
+        )
+        return (
+            jsonify(
+                status="error",
+                message=(
+                    f"Item {item_id=} is stored in a state that does not validate "
+                    f"against the expected schema for its type {doc['type']}: {error}"
+                ),
+            ),
+            500,
+        )
 
     # find any documents with relationships that mention this document
     relationships_query_results = flask_mongo.db.items.find(
@@ -1659,9 +1691,9 @@ def save_item():
     original_relationships = item.get("relationships", []) if preserve_relationships else None
 
     item.update(updated_data)
-    item = entry_reference_lookup(item)
 
     try:
+        item = entry_reference_lookup(item)
         item = ITEM_MODELS[item_type](**item).dict()
     except ValidationError as exc:
         return (

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -1167,3 +1167,67 @@ def test_collections_permissions(client, admin_client, default_sample_dict, defa
     response = admin_client.get(f"/items/{refcode}?sudo=1")
     assert response.json["item_data"]["description"] == "Updated description"
     assert len(response.json["item_data"]["relationships"]) == 1
+
+
+def test_new_sample_with_malformed_constituent_returns_400(client, default_sample_dict):
+    """A POST to /new-sample/ with a constituent that has no refcode, item_id,
+    or name should be rejected with a 400 rather than crashing in
+    entry_reference_lookup."""
+    bad_sample = copy.deepcopy(default_sample_dict)
+    bad_sample["item_id"] = "bad_constituent_sample"
+    bad_sample["synthesis_constituents"] = [
+        {"item": {"type": "starting_materials"}, "quantity": 1, "unit": "g"}
+    ]
+
+    response = client.post("/new-sample/", json=bad_sample)
+    assert response.status_code == 400, response.json
+
+
+def test_save_item_with_malformed_constituent_returns_400(client, default_sample_dict):
+    """A POST to /save-item/ that introduces a malformed constituent should be
+    rejected with a 400 rather than crashing in entry_reference_lookup."""
+    sample = copy.deepcopy(default_sample_dict)
+    sample["item_id"] = "save_bad_constituent_sample"
+    response = client.post("/new-sample/", json=sample)
+    assert response.status_code == 201, response.json
+
+    response = client.post(
+        "/save-item/",
+        json={
+            "item_id": sample["item_id"],
+            "data": {
+                "synthesis_constituents": [
+                    {"item": {"type": "starting_materials"}, "quantity": 1, "unit": "g"}
+                ]
+            },
+        },
+    )
+    assert response.status_code == 400, response.json
+    assert response.json["status"] == "error"
+
+
+def test_get_item_with_malformed_stored_constituent_returns_500(client, database, user_id):
+    """If an item with a malformed constituent ended up in the database (e.g.
+    from an older write path), GET should surface it as a server-side
+    data-integrity error (500) rather than blaming the caller with a 400."""
+    from pydatalab.models.utils import generate_unique_refcode
+
+    bad_doc = {
+        "item_id": "stored_bad_constituent_sample",
+        "refcode": generate_unique_refcode(),
+        "type": "samples",
+        "name": "bad",
+        "date": datetime.datetime(1970, 2, 1, tzinfo=datetime.timezone.utc),
+        "creator_ids": [user_id],
+        "synthesis_constituents": [
+            {"item": {"type": "starting_materials"}, "quantity": 1, "unit": "g"}
+        ],
+    }
+    database.items.insert_one(bad_doc)
+
+    try:
+        response = client.get(f"/get-item-data/{bad_doc['item_id']}")
+        assert response.status_code == 500, response.json
+        assert response.json["status"] == "error"
+    finally:
+        database.items.delete_one({"item_id": bad_doc["item_id"]})

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -378,7 +378,9 @@ def test_new_sample_with_relationships(
 
 
 @pytest.mark.dependency(depends=["test_new_sample_with_relationships"])
-def test_saved_sample_has_new_relationships(client, default_sample_dict, complicated_sample):
+def test_saved_sample_has_new_relationships(
+    client, default_sample_dict, complicated_sample, database
+):
     """Create a sample, add a constituent and save it, then make sure
     it appears in relationship searches, without manually using the Sample
     model to populate them.
@@ -415,7 +417,19 @@ def test_saved_sample_has_new_relationships(client, default_sample_dict, complic
         f"/get-item-data/{default_sample_dict['item_id']}",
     )
 
+    complicated_sample_refcode = database.items.find_one({"item_id": complicated_sample.item_id})[
+        "refcode"
+    ]
+
     assert complicated_sample.item_id in response.json["parent_items"]
+    assert (
+        response.json["item_data"]["synthesis_constituents"][0]["item"]["item_id"]
+        == complicated_sample.item_id
+    )
+    assert (
+        response.json["item_data"]["synthesis_constituents"][0]["item"]["refcode"]
+        == complicated_sample_refcode
+    )
 
     response = client.get(
         f"/get-item-data/{complicated_sample.item_id}",


### PR DESCRIPTION
Closes #1173

Item referencing now excludes the `_id` field which was being inappropriately returned, and the item look up now occurs at creation and save time (rather than just when retrieving the item). This improves consistency of the database versus what is actually returned after lookup.