### PR TITLE
Mark cached blocks as such and use sync processing for them

### DIFF
--- a/pydatalab/src/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/src/pydatalab/apps/echem/blocks.py
@@ -79,6 +79,8 @@ class CycleBlock(DataBlock):
         "derivative_mode": None,
     }
 
+    cached: bool = False
+
     def _get_characteristic_mass_g(self):
         # return {"characteristic_mass": 1000}
         doc = flask_mongo.db.items.find_one(
@@ -220,6 +222,8 @@ class CycleBlock(DataBlock):
 
         if parquet_path is not None:
             csv_path = self._save_bdf(raw_df, parquet_path, csv_path)
+
+        self.data["cached"] = True
         return raw_df, csv_path
 
     def _load_single(self, file_id: ObjectId, reload: bool) -> tuple[pd.DataFrame, Path | None]:

--- a/pydatalab/src/pydatalab/routes/v0_1/blocks.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/blocks.py
@@ -398,6 +398,13 @@ def update_block():
     )
     trigger_async = event_data and event_data.get("trigger_async", True) if event_data else True
 
+    if block.data.get("cached"):
+        use_async = False
+        LOGGER.info(
+            "Using synchronous processing for block %s because it is marked as cached",
+            block.block_id,
+        )
+
     if use_async and trigger_async:
         task_id = str(uuid.uuid4())
 


### PR DESCRIPTION
Incomplete, but think some kind of functionality to this end would be useful to avoid slow running queue jobs from choking up the fast. Likely needs a better way for the block to report when the cache has bene lost, and to request that it is resubmitted in async mode, but that feels like an awkward extra step for now.

One approach could be to invalidate the block cache whenever a file attached to the block changes (c.f. #1744).