### PR TITLE
Update echem block to better handle bdf exports and caching

### DIFF
--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -66,7 +66,7 @@ apps = [
     # NMR
     "nmrglue ~= 0.12",
     # Electrochemistry
-    "navani >= 0.1.19",
+    "navani >= 0.1.20",
     "pyarrow ~= 23.0.1",
     # Raman
     "pybaselines ~= 1.1",

--- a/pydatalab/src/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/src/pydatalab/apps/echem/blocks.py
@@ -7,7 +7,7 @@ import bokeh
 import pandas as pd
 from bson import ObjectId
 from navani import echem as ec
-from navani.bdf import export_to_bdf
+from navani.bdf import build_bdf_df, save_bdf
 
 from pydatalab import bokeh_plots
 from pydatalab.blocks.base import DataBlock
@@ -157,17 +157,26 @@ class CycleBlock(DataBlock):
         Returns the CSV path if written, or None otherwise.
         """
         try:
-            export_to_bdf(raw_df, filepath=parquet_path, save_parquet=True)
+            bdf_df = build_bdf_df(raw_df)
         except Exception as exc:
-            LOGGER.warning("Failed to export parquet cache: %s", exc)
-            LOGGER.debug("Exception details for failed parquet export", exc_info=True)
+            LOGGER.warning("Failed to build BDF DataFrame: %s", exc)
+            LOGGER.debug("Exception details for failed BDF build", exc_info=True)
+            return None
 
         try:
-            if csv_path is not None:
-                export_to_bdf(raw_df, filepath=csv_path, save_csv=True)
+            save_bdf(bdf_df, parquet_path=parquet_path)
         except Exception as exc:
-            LOGGER.warning("Failed to export BDF csv file: %s", exc)
-            LOGGER.debug("Exception details for failed BDF export", exc_info=True)
+            LOGGER.warning("Failed to save parquet cache at %s: %s", parquet_path, exc)
+            LOGGER.debug("Exception details for failed parquet save", exc_info=True)
+
+        if csv_path is None:
+            return None
+
+        try:
+            save_bdf(bdf_df, csv_path=csv_path)
+        except Exception as exc:
+            LOGGER.warning("Failed to save BDF CSV at %s: %s", csv_path, exc)
+            LOGGER.debug("Exception details for failed CSV save", exc_info=True)
             return None
 
         return csv_path
@@ -197,10 +206,15 @@ class CycleBlock(DataBlock):
         if not reload and parquet_path is not None and parquet_path.exists():
             LOGGER.debug("Cache hit: loading parsed data from parquet %s", parquet_path)
             raw_df = self._load_echem_from_cache(parquet_path)
-            # Regenerate CSV if it was deleted
+            # Regenerate CSV if it was deleted — read parquet directly, no raw DataFrame rebuild needed
             if csv_path is not None and not csv_path.exists():
                 LOGGER.debug("CSV cache missing, regenerating at %s", csv_path)
-                csv_path = self._save_bdf(raw_df, parquet_path, csv_path)
+                try:
+                    bdf_df = pd.read_parquet(parquet_path)
+                    save_bdf(bdf_df, csv_path=csv_path)
+                except Exception as exc:
+                    LOGGER.warning("Failed to regenerate CSV from parquet cache: %s", exc)
+                    csv_path = None
             return raw_df, csv_path
 
         if reload and parquet_path is not None and parquet_path.exists():

--- a/pydatalab/src/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/src/pydatalab/apps/echem/blocks.py
@@ -213,6 +213,11 @@ class CycleBlock(DataBlock):
                     bdf_df = pd.read_parquet(parquet_path)
                     save_bdf(bdf_df, csv_path=csv_path)
                 except Exception as exc:
+                    LOGGER.debug(
+                        "CSV regeneration from parquet cache failed for %s",
+                        parquet_path,
+                        exc_info=True,
+                    )
                     LOGGER.warning("Failed to regenerate CSV from parquet cache: %s", exc)
                     csv_path = None
             return raw_df, csv_path

--- a/pydatalab/tests/apps/test_echem_block.py
+++ b/pydatalab/tests/apps/test_echem_block.py
@@ -177,8 +177,8 @@ def test_load_and_cache_multi_file_stitch(tmp_path):
     assert not cache_location.with_suffix(".RAW_PARSED.pkl").exists()
 
 
-def test_save_bdf_exception_logs_warning_and_returns_none(tmp_path, caplog):
-    """Test that _save_bdf catches export exceptions, logs a warning, and returns None."""
+def test_save_bdf_build_failure_logs_warning_and_returns_none(tmp_path, caplog):
+    """Test that _save_bdf returns None and logs a warning when build_bdf_df fails."""
     import logging
     from unittest.mock import patch
 
@@ -196,8 +196,8 @@ def test_save_bdf_exception_logs_warning_and_returns_none(tmp_path, caplog):
         with (
             caplog.at_level(logging.WARNING, logger="pydatalab"),
             patch(
-                "pydatalab.apps.echem.blocks.export_to_bdf",
-                side_effect=Exception("export failed"),
+                "pydatalab.apps.echem.blocks.build_bdf_df",
+                side_effect=Exception("build failed"),
             ),
         ):
             result = block._save_bdf(dummy_df, parquet_path, csv_path)
@@ -207,7 +207,100 @@ def test_save_bdf_exception_logs_warning_and_returns_none(tmp_path, caplog):
     assert result is None
     assert not parquet_path.exists()
     assert not csv_path.exists()
-    assert "Failed to export BDF csv file" in caplog.text
+    assert "Failed to build BDF DataFrame" in caplog.text
+
+
+def test_save_bdf_parquet_failure_still_writes_csv(tmp_path, caplog):
+    """Test that a parquet save failure is logged but CSV is still written."""
+    import logging
+    from unittest.mock import patch
+
+    import pandas as pd
+
+    from pydatalab.logger import LOGGER
+
+    block = CycleBlock(item_id="test")
+    parquet_path = tmp_path / "dummy.bdf.parquet"
+    csv_path = tmp_path / "dummy.bdf.csv"
+    dummy_df = pd.DataFrame(
+        {
+            "Time": [0, 1],
+            "Voltage": [3.0, 3.5],
+            "Current": [1.0, 1.0],
+            "full cycle": [1, 1],
+            "half cycle": [1, 1],
+            "state": [0, 0],
+            "Capacity": [0.1, 0.2],
+        }
+    )
+
+    original_save_bdf = __import__("pydatalab.apps.echem.blocks", fromlist=["save_bdf"]).save_bdf
+
+    def save_bdf_parquet_fails(bdf_df, parquet_path=None, csv_path=None, **kwargs):
+        if parquet_path is not None:
+            raise Exception("parquet write failed")
+        return original_save_bdf(bdf_df, csv_path=csv_path, **kwargs)
+
+    LOGGER.addHandler(caplog.handler)
+    try:
+        with (
+            caplog.at_level(logging.WARNING, logger="pydatalab"),
+            patch("pydatalab.apps.echem.blocks.save_bdf", side_effect=save_bdf_parquet_fails),
+        ):
+            result = block._save_bdf(dummy_df, parquet_path, csv_path)
+    finally:
+        LOGGER.removeHandler(caplog.handler)
+
+    assert result == csv_path
+    assert csv_path.exists()
+    assert not parquet_path.exists()
+    assert "Failed to save parquet cache" in caplog.text
+
+
+def test_save_bdf_csv_failure_logs_warning_and_returns_none(tmp_path, caplog):
+    """Test that a CSV save failure is logged and None is returned."""
+    import logging
+    from unittest.mock import patch
+
+    import pandas as pd
+
+    from pydatalab.logger import LOGGER
+
+    block = CycleBlock(item_id="test")
+    parquet_path = tmp_path / "dummy.bdf.parquet"
+    csv_path = tmp_path / "dummy.bdf.csv"
+    dummy_df = pd.DataFrame(
+        {
+            "Time": [0, 1],
+            "Voltage": [3.0, 3.5],
+            "Current": [1.0, 1.0],
+            "full cycle": [1, 1],
+            "half cycle": [1, 1],
+            "state": [0, 0],
+            "Capacity": [0.1, 0.2],
+        }
+    )
+
+    original_save_bdf = __import__("pydatalab.apps.echem.blocks", fromlist=["save_bdf"]).save_bdf
+
+    def save_bdf_csv_fails(bdf_df, parquet_path=None, csv_path=None, **kwargs):
+        if csv_path is not None:
+            raise Exception("csv write failed")
+        return original_save_bdf(bdf_df, parquet_path=parquet_path, **kwargs)
+
+    LOGGER.addHandler(caplog.handler)
+    try:
+        with (
+            caplog.at_level(logging.WARNING, logger="pydatalab"),
+            patch("pydatalab.apps.echem.blocks.save_bdf", side_effect=save_bdf_csv_fails),
+        ):
+            result = block._save_bdf(dummy_df, parquet_path, csv_path)
+    finally:
+        LOGGER.removeHandler(caplog.handler)
+
+    assert result is None
+    assert not csv_path.exists()
+    assert "Failed to save BDF CSV" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/pydatalab/tests/apps/test_echem_block.py
+++ b/pydatalab/tests/apps/test_echem_block.py
@@ -128,6 +128,40 @@ def test_load_and_cache_reads_from_bdf_parquet(tmp_path):
     assert len(raw_df_cached) == len(raw_df_first)
 
 
+def test_load_and_cache_regenerates_missing_csv_from_parquet(tmp_path):
+    """Test that a missing CSV is regenerated from the parquet cache without invoking build_bdf_df."""
+    import shutil
+    from unittest.mock import patch
+
+    import pandas as pd
+
+    block = CycleBlock(item_id="test")
+    src = shutil.copy(MPR_FILE, tmp_path / MPR_FILE.name)
+    location = Path(src)
+    parquet_path = location.with_name(location.stem + "_cached.bdf.parquet")
+    csv_path = location.with_name(location.stem + ".bdf.csv")
+
+    # First load: parse and write both cache files
+    block._load_and_cache_echem(location, parquet_path, csv_path, reload=True)
+    assert parquet_path.exists()
+    assert csv_path.exists()
+
+    # Delete the CSV to simulate it being missing
+    csv_path.unlink()
+
+    with patch("pydatalab.apps.echem.blocks.build_bdf_df") as mock_build:
+        raw_df, returned_csv_path = block._load_and_cache_echem(
+            location, parquet_path, csv_path, reload=False
+        )
+
+    mock_build.assert_not_called()
+    assert returned_csv_path == csv_path
+    assert csv_path.exists()
+    regen_cols = set(pd.read_csv(csv_path).columns)
+    assert BDF_REQUIRED_COLUMNS.issubset(regen_cols)
+    assert len(raw_df) > 0
+
+
 def test_load_and_cache_bdf_csv_source_caches_parquet_but_skips_csv(tmp_path):
     """Test that loading a .bdf.csv source writes a .bdf.parquet cache but no redundant .bdf.csv."""
     import shutil
@@ -234,12 +268,14 @@ def test_save_bdf_parquet_failure_still_writes_csv(tmp_path, caplog):
         }
     )
 
-    original_save_bdf = __import__("pydatalab.apps.echem.blocks", fromlist=["save_bdf"]).save_bdf
+    import pydatalab.apps.echem.blocks as echem_blocks
+
+    real_save_bdf = echem_blocks.save_bdf
 
     def save_bdf_parquet_fails(bdf_df, parquet_path=None, csv_path=None, **kwargs):
         if parquet_path is not None:
             raise Exception("parquet write failed")
-        return original_save_bdf(bdf_df, csv_path=csv_path, **kwargs)
+        return real_save_bdf(bdf_df, csv_path=csv_path, **kwargs)
 
     LOGGER.addHandler(caplog.handler)
     try:
@@ -281,12 +317,14 @@ def test_save_bdf_csv_failure_logs_warning_and_returns_none(tmp_path, caplog):
         }
     )
 
-    original_save_bdf = __import__("pydatalab.apps.echem.blocks", fromlist=["save_bdf"]).save_bdf
+    import pydatalab.apps.echem.blocks as echem_blocks
+
+    real_save_bdf = echem_blocks.save_bdf
 
     def save_bdf_csv_fails(bdf_df, parquet_path=None, csv_path=None, **kwargs):
         if csv_path is not None:
             raise Exception("csv write failed")
-        return original_save_bdf(bdf_df, parquet_path=parquet_path, **kwargs)
+        return real_save_bdf(bdf_df, parquet_path=parquet_path, **kwargs)
 
     LOGGER.addHandler(caplog.handler)
     try:

--- a/pydatalab/tests/apps/test_echem_block.py
+++ b/pydatalab/tests/apps/test_echem_block.py
@@ -300,6 +300,7 @@ def test_save_bdf_csv_failure_logs_warning_and_returns_none(tmp_path, caplog):
 
     assert result is None
     assert not csv_path.exists()
+    assert parquet_path.exists()
     assert "Failed to save BDF CSV" in caplog.text
 
 

--- a/pydatalab/uv.lock
+++ b/pydatalab/uv.lock
@@ -737,7 +737,7 @@ requires-dist = [
     { name = "langchain-openai", marker = "extra == 'chat'", specifier = "~=0.1" },
     { name = "matador-db", marker = "extra == 'apps'", specifier = ">=0.11.2" },
     { name = "matplotlib", specifier = "~=3.8" },
-    { name = "navani", marker = "extra == 'apps'", specifier = ">=0.1.19" },
+    { name = "navani", marker = "extra == 'apps'", specifier = ">=0.1.20" },
     { name = "nmrglue", marker = "extra == 'apps'", git = "https://github.com/jjhelmus/nmrglue.git?rev=b6408751bf18801a0a4ce084acf4d31335e2b02a" },
     { name = "pandas", extras = ["excel"], specifier = "~=2.2" },
     { name = "periodictable", specifier = "~=1.7" },
@@ -1108,7 +1108,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/92/db/b4c12cff13ebac2786f4f217f06588bccd8b53d260453404ef22b121fc3a/greenlet-3.2.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:1afd685acd5597349ee6d7a88a8bec83ce13c106ac78c196ee9dde7c04fe87be", size = 268977, upload-time = "2025-06-05T16:10:24.001Z" },
     { url = "https://files.pythonhosted.org/packages/52/61/75b4abd8147f13f70986df2801bf93735c1bd87ea780d70e3b3ecda8c165/greenlet-3.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:761917cac215c61e9dc7324b2606107b3b292a8349bdebb31503ab4de3f559ac", size = 627351, upload-time = "2025-06-05T16:38:50.685Z" },
     { url = "https://files.pythonhosted.org/packages/35/aa/6894ae299d059d26254779a5088632874b80ee8cf89a88bca00b0709d22f/greenlet-3.2.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a433dbc54e4a37e4fff90ef34f25a8c00aed99b06856f0119dcf09fbafa16392", size = 638599, upload-time = "2025-06-05T16:41:34.057Z" },
-    { url = "https://files.pythonhosted.org/packages/30/64/e01a8261d13c47f3c082519a5e9dbf9e143cc0498ed20c911d04e54d526c/greenlet-3.2.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:72e77ed69312bab0434d7292316d5afd6896192ac4327d44f3d613ecb85b037c", size = 634482, upload-time = "2025-06-05T16:48:16.26Z" },
     { url = "https://files.pythonhosted.org/packages/47/48/ff9ca8ba9772d083a4f5221f7b4f0ebe8978131a9ae0909cf202f94cd879/greenlet-3.2.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:68671180e3849b963649254a882cd544a3c75bfcd2c527346ad8bb53494444db", size = 633284, upload-time = "2025-06-05T16:13:01.599Z" },
     { url = "https://files.pythonhosted.org/packages/e9/45/626e974948713bc15775b696adb3eb0bd708bec267d6d2d5c47bb47a6119/greenlet-3.2.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49c8cfb18fb419b3d08e011228ef8a25882397f3a859b9fe1436946140b6756b", size = 582206, upload-time = "2025-06-05T16:12:48.51Z" },
     { url = "https://files.pythonhosted.org/packages/b1/8e/8b6f42c67d5df7db35b8c55c9a850ea045219741bb14416255616808c690/greenlet-3.2.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:efc6dc8a792243c31f2f5674b670b3a95d46fa1c6a912b8e310d6f542e7b0712", size = 1111412, upload-time = "2025-06-05T16:36:45.479Z" },
@@ -1117,7 +1116,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/2e/d4fcb2978f826358b673f779f78fa8a32ee37df11920dc2bb5589cbeecef/greenlet-3.2.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:784ae58bba89fa1fa5733d170d42486580cab9decda3484779f4759345b29822", size = 270219, upload-time = "2025-06-05T16:10:10.414Z" },
     { url = "https://files.pythonhosted.org/packages/16/24/929f853e0202130e4fe163bc1d05a671ce8dcd604f790e14896adac43a52/greenlet-3.2.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0921ac4ea42a5315d3446120ad48f90c3a6b9bb93dd9b3cf4e4d84a66e42de83", size = 630383, upload-time = "2025-06-05T16:38:51.785Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b2/0320715eb61ae70c25ceca2f1d5ae620477d246692d9cc284c13242ec31c/greenlet-3.2.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:d2971d93bb99e05f8c2c0c2f4aa9484a18d98c4c3bd3c62b65b7e6ae33dfcfaf", size = 642422, upload-time = "2025-06-05T16:41:35.259Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/49/445fd1a210f4747fedf77615d941444349c6a3a4a1135bba9701337cd966/greenlet-3.2.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c667c0bf9d406b77a15c924ef3285e1e05250948001220368e039b6aa5b5034b", size = 638375, upload-time = "2025-06-05T16:48:18.235Z" },
     { url = "https://files.pythonhosted.org/packages/7e/c8/ca19760cf6eae75fa8dc32b487e963d863b3ee04a7637da77b616703bc37/greenlet-3.2.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:592c12fb1165be74592f5de0d70f82bc5ba552ac44800d632214b76089945147", size = 637627, upload-time = "2025-06-05T16:13:02.858Z" },
     { url = "https://files.pythonhosted.org/packages/65/89/77acf9e3da38e9bcfca881e43b02ed467c1dedc387021fc4d9bd9928afb8/greenlet-3.2.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29e184536ba333003540790ba29829ac14bb645514fbd7e32af331e8202a62a5", size = 585502, upload-time = "2025-06-05T16:12:49.642Z" },
     { url = "https://files.pythonhosted.org/packages/97/c6/ae244d7c95b23b7130136e07a9cc5aadd60d59b5951180dc7dc7e8edaba7/greenlet-3.2.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:93c0bb79844a367782ec4f429d07589417052e621aa39a5ac1fb99c5aa308edc", size = 1114498, upload-time = "2025-06-05T16:36:46.598Z" },
@@ -1893,7 +1891,7 @@ wheels = [
 
 [[package]]
 name = "navani"
-version = "0.1.19"
+version = "0.1.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "datalab-org-galvani" },
@@ -1905,9 +1903,9 @@ dependencies = [
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.16.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/67/1aeff64498396bacddfebffce6caf471d71dc74720e7dd263dca5a4cdee8/navani-0.1.19.tar.gz", hash = "sha256:1835276c30ec80416d0f074759b67eba80b8acc9b8308c30db1c66e872e04158", size = 7057699, upload-time = "2026-05-14T17:43:07.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/23/0ff68f7663a8642dc387a2773b65acc713f22377a20fcd17cb906964e8e8/navani-0.1.20.tar.gz", hash = "sha256:2a3baa847fdf06ae11f9590e203358fcd978c7b0162be1a6629394df682e4d6d", size = 7058591, upload-time = "2026-05-21T17:04:40.289Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/10/01e25bef7aecb02142ad47d4d10c3965ab48d8fb63b8666e38ed79631eb1/navani-0.1.19-py3-none-any.whl", hash = "sha256:9fb2332b1d50fd7ecfb7b64a999fad5ec33a00a6794eae6b9d20b67ddcbb2868", size = 21412, upload-time = "2026-05-14T17:43:05.14Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c4/864832bde32e9752ec6a9a31bfdeacb2e64701c58eb29ae4b7fb06668586/navani-0.1.20-py3-none-any.whl", hash = "sha256:81950188eb9c29f407e9f1eb8aac980138176f6e6b36bc8a891667c192edb60f", size = 21789, upload-time = "2026-05-21T17:04:38.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
  Updated navani to 0.1.20
  
  - Bumped navani to 0.1.20
  - BDF export is now split into `build_bdf_df` (DataFrame construction and downcasting) and `save_bdf` (file writing). Previously export_to_bdf was called twice to write both parquet and CSV, doing the full
   DataFrame processing twice — now build_bdf_df is called once and both files are written in two separate save_bdf calls (to isolate an error to either call without preventing saving the other file)
  - CSV regeneration from a parquet cache hit no longer re-processes the raw DataFrame — it reads the parquet directly and calls save_bdf
  - Parquet and CSV save failures are now handled independently, so a parquet write failure no longer suppresses the CSV download link
  - Updated tests to cover each failure mode separately and test build_bdf_df/save_bdf directly

Currently cache is only regenerated for live streaming files, or if there is no cache.