### PR TITLE
Better mobile support for navbar

### DIFF
--- a/webapp/cypress/e2e/collectionPage.cy.js
+++ b/webapp/cypress/e2e/collectionPage.cy.js
@@ -1,0 +1,63 @@
+// Smoke test for the collection page (CollectionPage.vue) and its responsive navbar.
+// Needs the dev server (:8080) and API (:5001) running, like the other e2e specs.
+
+const collectionId = "test_collection_smoke";
+
+let consoleSpy; // tracks anything written to console.error during the test
+Cypress.on("window:before:load", (win) => {
+  consoleSpy = cy.spy(win.console, "error");
+});
+
+before(() => {
+  cy.loginViaTestMagicLink("test-user@example.com", "user");
+  cy.visit("/collections");
+  cy.removeAllTestCollections([collectionId], false);
+  cy.createCollection(collectionId, "Smoke test collection");
+});
+
+after(() => {
+  cy.loginViaTestMagicLink("test-user@example.com", "user");
+  cy.visit("/collections");
+  cy.removeAllTestCollections([collectionId], false);
+});
+
+describe("Collection page", () => {
+  beforeEach(() => {
+    cy.loginViaTestMagicLink("test-user@example.com", "user");
+  });
+
+  it("loads the collection page and navbar without console errors", () => {
+    cy.visit(`/collections/${collectionId}`);
+
+    cy.get("nav.editor-navbar").should("be.visible");
+    // brand shows the collection we navigated to
+    cy.get(".navbar-brand-name").should("contain", collectionId);
+
+    // navbar actions are present (labels stay in the DOM even when the
+    // icon-only tier hides them visually)
+    cy.get("nav.editor-navbar").within(() => {
+      cy.findByText("Home").should("exist");
+      cy.findByText("Export").should("exist");
+      cy.findByText("Share").should("exist");
+      cy.findByText("View JSON").should("exist");
+    });
+
+    cy.contains("Server Error").should("not.exist");
+    cy.then(() => {
+      expect(consoleSpy).not.to.be.called;
+    });
+  });
+
+  it("collapses to a hamburger and toggles the menu on mobile", () => {
+    cy.viewport(390, 800);
+    cy.visit(`/collections/${collectionId}`);
+
+    // collapsed by default: the menu is hidden and the toggler is shown
+    cy.get(".navbar-toggler").should("be.visible");
+    cy.get("nav.editor-navbar").findByText("Home").should("not.be.visible");
+
+    // opening the hamburger reveals the menu
+    cy.get(".navbar-toggler").click();
+    cy.get("nav.editor-navbar").findByText("Home").should("be.visible");
+  });
+});

--- a/webapp/cypress/e2e/navbarResponsive.cy.js
+++ b/webapp/cypress/e2e/navbarResponsive.cy.js
@@ -1,0 +1,61 @@
+// Visual check for the EditPage navbar across screen sizes.
+// Screenshots land in cypress/screenshots/navbarResponsive.cy.js/.
+// Run headed to watch it live:  npx cypress open --e2e   (pick this spec)
+// Or headless for the screenshots: npx cypress run --spec cypress/e2e/navbarResponsive.cy.js
+// Needs the dev server (:8080) and API (:5001) running, like the other e2e specs.
+
+const itemId = "navbar_responsive_demo";
+// A deliberately long name so the brand has something to truncate.
+const longName = "A deliberately very long sample name to exercise navbar truncation";
+
+// width -> short label, ordered small to large. Covers each breakpoint we care about:
+// 575.98 (sm), 767.98 (md/hamburger), 768-991 (icon-only tier), 991.98/992 (lg, type appears).
+const widths = [360, 480, 576, 700, 768, 880, 960, 992, 1100, 1280, 1440];
+const height = 800;
+
+describe("EditPage navbar — responsive", () => {
+  before(() => {
+    cy.loginViaTestMagicLink("test-user@example.com", "user");
+    cy.visit("/");
+    cy.removeAllTestSamples([itemId], false);
+    cy.createSample(itemId, longName);
+  });
+
+  after(() => {
+    cy.visit("/");
+    cy.removeAllTestSamples([itemId], false);
+  });
+
+  beforeEach(() => {
+    cy.loginViaTestMagicLink("test-user@example.com", "user");
+    cy.visit(`/edit/${itemId}`);
+    // wait until the navbar has rendered the item before measuring/snapping
+    cy.get("nav.editor-navbar").should("be.visible");
+  });
+
+  widths.forEach((w) => {
+    it(`renders at ${w}px wide`, () => {
+      cy.viewport(w, height);
+
+      // The item type prefix should only appear at >= xl (1200px),
+      // and the item name must always be present.
+      cy.get(".navbar-brand-name").should("be.visible");
+      if (w >= 1200) {
+        cy.get(".navbar-brand-type").should("be.visible");
+      } else {
+        cy.get(".navbar-brand-type").should("not.be.visible");
+      }
+
+      cy.get("nav.editor-navbar").screenshot(`navbar-${String(w).padStart(4, "0")}`);
+    });
+  });
+
+  it("add-a-block dropdown closes on outside click (desktop)", () => {
+    cy.viewport(1280, height);
+    cy.get('[data-testid="add-block-button-top"]').click();
+    cy.get('[data-testid="add-block-dropdown"]').should("be.visible");
+    // click away from the dropdown
+    cy.get("#topScrollPoint").click({ force: true });
+    cy.get('[data-testid="add-block-dropdown"]').should("not.be.visible");
+  });
+});

--- a/webapp/cypress/support/commands.js
+++ b/webapp/cypress/support/commands.js
@@ -305,6 +305,17 @@ Cypress.Commands.add("removeAllTestCollections", (collection_ids, check_collecti
   }
 });
 
+// Creates a collection via the "Create new collection" modal. Assumes the
+// caller is already on the /collections page.
+Cypress.Commands.add("createCollection", (collection_id, title = null) => {
+  cy.get('[data-testid="add-collection-button"]').click();
+  cy.get("#collection-id").type(collection_id);
+  if (title) {
+    cy.get("#title").type(title);
+  }
+  cy.get(".modal-footer input[type=submit]:visible").click();
+});
+
 Cypress.Commands.add("createStartingMaterial", (item_id, name = null, date = null) => {
   cy.findByText("Add a starting material").click();
 

--- a/webapp/src/components/AddBlockDropdown.vue
+++ b/webapp/src/components/AddBlockDropdown.vue
@@ -2,6 +2,7 @@
   <div ref="root" :class="rootClass">
     <button
       v-if="variant === 'button'"
+      :id="triggerId"
       type="button"
       class="btn btn-primary dropdown-toggle"
       :data-testid="triggerTestid"
@@ -13,6 +14,7 @@
     </button>
     <a
       v-else
+      :id="triggerId"
       class="nav-link dropdown-toggle"
       role="button"
       title="Add a block"
@@ -23,7 +25,12 @@
     >
       <font-awesome-icon icon="cubes" fixed-width /> Add a block
     </a>
-    <div class="dropdown-menu" :class="{ show: isOpen }" :data-testid="menuTestid">
+    <div
+      class="dropdown-menu"
+      :class="{ show: isOpen }"
+      :data-testid="menuTestid"
+      :aria-labelledby="triggerId"
+    >
       <h6 v-if="suggestedBlockTypes.length > 0" class="dropdown-header">
         Suggested based on your files
       </h6>
@@ -78,6 +85,11 @@ export default {
       default: "down",
     },
     triggerTestid: {
+      type: String,
+      default: null,
+    },
+    // DOM id for the trigger (kept for existing selectors / aria-labelledby)
+    triggerId: {
       type: String,
       default: null,
     },

--- a/webapp/src/components/AddBlockDropdown.vue
+++ b/webapp/src/components/AddBlockDropdown.vue
@@ -1,0 +1,179 @@
+<template>
+  <div ref="root" :class="rootClass">
+    <button
+      v-if="variant === 'button'"
+      type="button"
+      class="btn btn-primary dropdown-toggle"
+      :data-testid="triggerTestid"
+      aria-haspopup="true"
+      :aria-expanded="isOpen"
+      @click="toggle"
+    >
+      <font-awesome-icon icon="cubes" fixed-width /> Add a block
+    </button>
+    <a
+      v-else
+      class="nav-link dropdown-toggle"
+      role="button"
+      title="Add a block"
+      :data-testid="triggerTestid"
+      aria-haspopup="true"
+      :aria-expanded="isOpen"
+      @click="toggle"
+    >
+      <font-awesome-icon icon="cubes" fixed-width /> Add a block
+    </a>
+    <div class="dropdown-menu" :class="{ show: isOpen }" :data-testid="menuTestid">
+      <h6 v-if="suggestedBlockTypes.length > 0" class="dropdown-header">
+        Suggested based on your files
+      </h6>
+      <span
+        v-for="blockInfo in suggestedBlockTypes"
+        :key="keyPrefix + '-suggested-' + blockInfo.id"
+        @click="onSelect(blockInfo.id)"
+      >
+        <BlockTooltip :block-info="blockInfo.attributes" />
+      </span>
+      <div
+        v-if="suggestedBlockTypes.length > 0 && allBlockTypes.length > 0"
+        class="dropdown-divider"
+      ></div>
+      <h6 v-if="allBlockTypes.length > 0" class="dropdown-header">All block types</h6>
+      <span
+        v-for="blockInfo in allBlockTypes"
+        :key="keyPrefix + '-all-' + blockInfo.id"
+        @click="onSelect(blockInfo.id)"
+      >
+        <BlockTooltip :block-info="blockInfo.attributes" />
+      </span>
+    </div>
+  </div>
+</template>
+
+<script>
+import BlockTooltip from "@/components/BlockTooltip";
+
+export default {
+  name: "AddBlockDropdown",
+  components: {
+    BlockTooltip,
+  },
+  props: {
+    suggestedBlockTypes: {
+      type: Array,
+      default: () => [],
+    },
+    allBlockTypes: {
+      type: Array,
+      default: () => [],
+    },
+    // "navlink" renders a navbar nav-link trigger; "button" renders a btn-primary trigger
+    variant: {
+      type: String,
+      default: "navlink",
+    },
+    // "down" (default) or "up" for a dropup
+    direction: {
+      type: String,
+      default: "down",
+    },
+    triggerTestid: {
+      type: String,
+      default: null,
+    },
+    menuTestid: {
+      type: String,
+      default: null,
+    },
+    // disambiguates v-for keys when several instances are mounted at once
+    keyPrefix: {
+      type: String,
+      default: "block",
+    },
+  },
+  emits: ["select"],
+  data() {
+    return {
+      isOpen: false,
+    };
+  },
+  computed: {
+    rootClass() {
+      const base = this.variant === "button" ? ["d-inline-block"] : ["nav-item"];
+      base.push(this.direction === "up" ? "dropup" : "dropdown");
+      return base;
+    },
+  },
+  mounted() {
+    document.addEventListener("mousedown", this.handleClickOutside);
+    document.addEventListener("keydown", this.handleEscape);
+  },
+  beforeUnmount() {
+    document.removeEventListener("mousedown", this.handleClickOutside);
+    document.removeEventListener("keydown", this.handleEscape);
+  },
+  methods: {
+    toggle() {
+      this.isOpen = !this.isOpen;
+    },
+    close() {
+      this.isOpen = false;
+    },
+    onSelect(blockId) {
+      this.$emit("select", blockId);
+      this.close();
+    },
+    handleClickOutside(event) {
+      if (this.isOpen && this.$refs.root && !this.$refs.root.contains(event.target)) {
+        this.close();
+      }
+    },
+    handleEscape(event) {
+      if (event.key === "Escape") {
+        this.close();
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.dropdown-menu {
+  cursor: pointer;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.dropdown-header {
+  font-weight: 600;
+  color: #495057;
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Inside the collapsed mobile navbar, render the menu inline instead of as an overlay */
+@media (max-width: 767.98px) {
+  .nav-item .dropdown-menu {
+    position: static;
+    float: none;
+    width: 100%;
+    border: 0;
+    margin: 0;
+    padding-left: 0.5rem;
+    background-color: rgba(0, 0, 0, 0.15);
+  }
+  /* The dark inline background needs light text for the headers and block names
+     (the latter are .dropdown-item rendered inside BlockTooltip, hence ::v-deep). */
+  .nav-item .dropdown-header {
+    color: rgba(255, 255, 255, 0.6);
+  }
+  .nav-item .dropdown-menu ::v-deep(.dropdown-item) {
+    color: rgba(255, 255, 255, 0.85);
+  }
+  .nav-item .dropdown-menu ::v-deep(.dropdown-item:hover) {
+    color: white;
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+}
+</style>

--- a/webapp/src/components/ExportDropdown.vue
+++ b/webapp/src/components/ExportDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-  <a class="nav-item nav-link" @click="handleExport">
+  <a class="nav-item nav-link" title="Export" @click="handleExport">
     <font-awesome-icon icon="file-export" fixed-width /> Export
   </a>
   <ExportButton

--- a/webapp/src/main.js
+++ b/webapp/src/main.js
@@ -12,6 +12,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import {
   faBarcode,
   faBars,
+  faHome,
   faSave,
   faCloudUploadAlt,
   faRedo,
@@ -82,6 +83,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 library.add(
   faBarcode,
   faBars,
+  faHome,
   faSave,
   faPen,
   faRedo,

--- a/webapp/src/main.js
+++ b/webapp/src/main.js
@@ -11,6 +11,7 @@ import router from "./router";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import {
   faBarcode,
+  faBars,
   faSave,
   faCloudUploadAlt,
   faRedo,
@@ -80,6 +81,7 @@ import { faGithub, faOrcid, faGoogle, faMicrosoft } from "@fortawesome/free-bran
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 library.add(
   faBarcode,
+  faBars,
   faSave,
   faPen,
   faRedo,

--- a/webapp/src/views/CollectionPage.vue
+++ b/webapp/src/views/CollectionPage.vue
@@ -1,42 +1,78 @@
 <template>
   <div id="topScrollPoint"></div>
   <nav
-    class="navbar navbar-expand sticky-top navbar-dark py-0 editor-navbar"
+    class="navbar navbar-expand-md sticky-top navbar-dark py-0 editor-navbar"
     :style="{ backgroundColor: navbarColor }"
   >
-    <span class="navbar-brand" @click="scrollToID($event, 'topScrollPoint')">
-      {{ itemTypeEntry?.navbarName || "loading..." }}&nbsp;&nbsp;|&nbsp;&nbsp;
-      <FormattedItemName :item_id="collection_id" item-type="collections" />
-    </span>
-    <div class="navbar-nav">
-      <a class="nav-item nav-link" href="/">Home</a>
-      <ExportDropdown :collection-id="collection_id" item-type="collections" />
-      <a
-        v-if="data_loaded"
-        class="nav-item nav-link"
-        href="#"
-        title="Share this collection"
-        @click.prevent="isSharingModalVisible = true"
+    <span class="navbar-brand clickable" @click="scrollToID($event, 'topScrollPoint')">
+      <span class="navbar-brand-type"
+        >{{ itemTypeEntry?.navbarName || "loading..." }}&nbsp;&nbsp;|&nbsp;&nbsp;</span
       >
-        <font-awesome-icon icon="share-alt" fixed-width /> Share
-      </a>
-      <a class="nav-item nav-link" :href="collectionApiUrl" target="_blank">
-        <font-awesome-icon icon="code" fixed-width /> View JSON
-      </a>
-    </div>
-    <div class="navbar-nav ml-auto">
-      <span v-if="data_loaded && !savedStatus" class="navbar-text unsaved-warning">
+      <span class="navbar-brand-name">
+        <FormattedItemName :item_id="collection_id" item-type="collections" />
+      </span>
+    </span>
+
+    <!-- Always-visible right-side cluster: status + save + hamburger (hamburger only shows below md) -->
+    <div class="navbar-right-cluster order-md-last">
+      <span
+        v-if="data_loaded && !savedStatus"
+        class="navbar-text unsaved-warning d-none d-sm-inline"
+      >
         Unsaved changes
       </span>
-      <span v-if="data_loaded && lastModified" class="navbar-text small mx-2"
-        ><i>Last saved: {{ lastModified }}</i>
-      </span>
+      <span
+        v-if="data_loaded && !savedStatus"
+        class="unsaved-dot d-sm-none"
+        title="Unsaved changes"
+      ></span>
+      <span v-if="data_loaded && lastModified" class="navbar-text small d-none d-md-inline"
+        ><i>Last saved: {{ lastModified }}</i></span
+      >
       <font-awesome-icon
+        v-show="isNavCollapsed"
         icon="save"
         fixed-width
-        class="nav-item nav-link navbar-icon"
+        class="nav-link navbar-icon"
+        :class="{ 'navbar-icon-unsaved': data_loaded && !savedStatus }"
+        title="Save"
         @click="saveCollectionData"
       />
+      <button
+        class="navbar-toggler border-0 d-md-none"
+        type="button"
+        aria-label="Toggle navigation"
+        @click="isNavCollapsed = !isNavCollapsed"
+      >
+        <font-awesome-icon icon="bars" />
+      </button>
+    </div>
+
+    <div class="collapse navbar-collapse" :class="{ show: !isNavCollapsed }">
+      <div class="navbar-nav">
+        <a class="nav-item nav-link" href="/" title="Home">
+          <font-awesome-icon icon="home" fixed-width /> Home
+        </a>
+        <ExportDropdown :collection-id="collection_id" item-type="collections" />
+        <a
+          v-if="data_loaded"
+          class="nav-item nav-link"
+          href="#"
+          title="Share this collection"
+          @click.prevent="isSharingModalVisible = true"
+        >
+          <font-awesome-icon icon="share-alt" fixed-width /> Share
+        </a>
+        <a class="nav-item nav-link" :href="collectionApiUrl" target="_blank" title="View JSON">
+          <font-awesome-icon icon="code" fixed-width /> View JSON
+        </a>
+        <a class="nav-item nav-link d-md-none" title="Save" @click="saveCollectionData">
+          <font-awesome-icon icon="save" fixed-width /> Save
+        </a>
+        <span v-if="data_loaded && lastModified" class="navbar-text small mx-2 d-md-none"
+          ><i>Last saved: {{ lastModified }}</i></span
+        >
+      </div>
     </div>
   </nav>
 
@@ -96,8 +132,7 @@ export default {
       collection_id: this.$route.params.id,
       data_loaded: false,
       isSharingModalVisible: false,
-      isMenuDropdownVisible: false,
-      isLoadingNewBlock: false,
+      isNavCollapsed: true,
       lastModified: null,
     };
   },
@@ -182,6 +217,40 @@ export default {
 .editor-navbar {
   margin-bottom: 1rem;
   z-index: 900;
+  /* Match the natural height of a nav-link row so the collapsed (burger) bar
+     is the same height as the expanded/desktop navbar. */
+  min-height: 2.5rem;
+}
+
+/* Brand = item type + item name. Lay them out so the type yields space first:
+   as the navbar narrows the type clips away before the item name truncates. */
+.editor-navbar .navbar-brand {
+  display: flex;
+  align-items: baseline;
+  min-width: 0;
+  overflow: hidden;
+}
+.navbar-brand-type {
+  /* very high shrink factor → gives up width (and disappears) before the name */
+  flex: 0 100 auto;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+.navbar-brand-name {
+  /* protected: only truncates once the type is gone */
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* On smaller screens (mobile + the icon-only tier) drop the type entirely
+   rather than showing a clipped fragment. */
+@media (max-width: 1199.98px) {
+  .navbar-brand-type {
+    display: none;
+  }
 }
 
 label,
@@ -190,11 +259,15 @@ label,
   color: v-bind("itemTypeEntry?.labelColor");
 }
 
-.nav-link {
+/* ::v-deep so these also reach the Export link, which is the root of a multi-root
+   child component and therefore misses this component's scoped styles. */
+.editor-navbar ::v-deep(.nav-link) {
   cursor: pointer;
+  /* Keep each label on one line; the brand shrinks first instead */
+  white-space: nowrap;
 }
 
-.nav-link:hover {
+.editor-navbar ::v-deep(.nav-link:hover) {
   background-color: black;
   color: white;
 }
@@ -205,6 +278,10 @@ label,
   padding: 0.3rem;
 }
 
+::v-deep(.navbar-brand:hover .formatted-item-name) {
+  outline: 2px solid rgba(0, 0, 0, 0.3);
+}
+
 .unsaved-warning {
   font-weight: 600;
   color: #ffc845;
@@ -212,5 +289,119 @@ label,
 
 .navbar-brand {
   cursor: pointer;
+}
+
+.navbar-right-cluster {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+/* Don't let the "Last saved" stamp wrap onto a second line */
+.navbar-right-cluster .navbar-text {
+  white-space: nowrap;
+}
+
+.unsaved-dot {
+  display: inline-block;
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  background-color: #ffc845;
+  box-shadow: 0 0 0 2px rgba(255, 200, 69, 0.3);
+}
+
+.navbar-toggler {
+  color: white;
+  background: transparent;
+  padding: 0.25rem 0.5rem;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+/* Bootstrap adds a focus box-shadow ring that makes the toggler appear to jump on tap */
+.navbar-toggler:focus,
+.navbar-toggler:active {
+  outline: none;
+  box-shadow: none;
+}
+
+.navbar-right-cluster .navbar-icon {
+  /* keep save icon visually aligned with toggler & text */
+  margin: 0;
+  /* The cluster sits outside .navbar-nav, so navbar-dark's light link colour
+     doesn't reach it — set it explicitly. */
+  color: white;
+}
+
+/* Save icon doubles as a save-state indicator: amber while there are unsaved changes */
+.navbar-right-cluster .navbar-icon-unsaved {
+  color: #ffc845;
+}
+
+@media (max-width: 767.98px) {
+  .editor-navbar {
+    flex-wrap: wrap;
+  }
+  .editor-navbar .navbar-brand {
+    /* Only the compact right cluster (dot + save + hamburger) needs reserving now */
+    max-width: calc(100% - 6rem);
+    font-size: 1rem;
+    margin-right: 0;
+  }
+  /* Tighten and align the always-visible right cluster on small screens */
+  .navbar-right-cluster {
+    gap: 0.25rem;
+  }
+  .navbar-right-cluster .navbar-icon,
+  .navbar-right-cluster .navbar-toggler {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+  }
+  .editor-navbar .navbar-collapse {
+    width: 100%;
+    flex-basis: 100%;
+    border-top: 1px solid rgba(255, 255, 255, 0.15);
+    margin-top: 0.25rem;
+  }
+  .editor-navbar .navbar-collapse .navbar-nav {
+    flex-direction: column;
+    width: 100%;
+    padding: 0.25rem 0;
+  }
+  .editor-navbar .navbar-collapse ::v-deep(.nav-link) {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0.65rem 0.5rem;
+    border-radius: 0.25rem;
+  }
+  /* Keep the leading icons a consistent width so the labels line up down the menu. */
+  .editor-navbar .navbar-collapse ::v-deep(.nav-link .svg-inline--fa) {
+    flex: 0 0 auto;
+  }
+  /* Subtle dividers between top-level entries so the menu is easier to scan */
+  .editor-navbar .navbar-collapse .navbar-nav > ::v-deep(.nav-item:not(:last-child)),
+  .editor-navbar .navbar-collapse .navbar-nav > ::v-deep(.nav-link:not(:last-child)) {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+}
+
+/* Between md and xl the inline bar gets tight, so drop the text labels and show
+   icons only (hover/title tooltips still convey the label). */
+@media (min-width: 768px) and (max-width: 1199.98px) {
+  .editor-navbar .navbar-nav ::v-deep(.nav-link) {
+    font-size: 0;
+  }
+  .editor-navbar .navbar-nav ::v-deep(.svg-inline--fa) {
+    font-size: 1rem;
+  }
 }
 </style>

--- a/webapp/src/views/CollectionPage.vue
+++ b/webapp/src/views/CollectionPage.vue
@@ -350,16 +350,22 @@ label,
     flex-wrap: wrap;
   }
   .editor-navbar .navbar-brand {
-    /* Only the compact right cluster (dot + save + hamburger) needs reserving now */
-    max-width: calc(100% - 6rem);
+    /* flex-basis 0 (not auto) so the brand's long content doesn't drive line
+       wrapping — the cluster stays on this row, and the brand grows into the
+       leftover space and truncates instead of bumping the cluster to a 2nd row. */
+    flex: 1 1 0;
+    min-width: 0;
     font-size: 1rem;
     margin-right: 0;
   }
-  /* Tighten and align the always-visible right cluster on small screens */
+  /* Keep the cluster at its natural width on the right so the save icon and
+     hamburger stay on-screen; the brand truncates into the space to their left. */
   .navbar-right-cluster {
+    flex: 0 0 auto;
     gap: 0.25rem;
   }
-  .navbar-right-cluster .navbar-icon,
+  /* inline-flex is for the <button> toggler; it must NOT be applied to the save
+     <svg>, which renders/clips wrong when treated as a flex container. */
   .navbar-right-cluster .navbar-toggler {
     display: inline-flex;
     align-items: center;
@@ -368,6 +374,13 @@ label,
     width: 2.25rem;
     height: 2.25rem;
     padding: 0;
+  }
+  /* Save icon: plain box sizing (like the desktop .navbar-icon, just a touch bigger) */
+  .navbar-right-cluster .navbar-icon {
+    flex: 0 0 auto;
+    width: 2.1rem;
+    height: 2.1rem;
+    padding: 0.45rem;
   }
   .editor-navbar .navbar-collapse {
     width: 100%;

--- a/webapp/src/views/CollectionPage.vue
+++ b/webapp/src/views/CollectionPage.vue
@@ -66,7 +66,12 @@
         <a class="nav-item nav-link" :href="collectionApiUrl" target="_blank" title="View JSON">
           <font-awesome-icon icon="code" fixed-width /> View JSON
         </a>
-        <a class="nav-item nav-link d-md-none" title="Save" @click="saveCollectionData">
+        <a
+          v-if="!isNavCollapsed"
+          class="nav-item nav-link d-md-none"
+          title="Save"
+          @click="saveCollectionData"
+        >
           <font-awesome-icon icon="save" fixed-width /> Save
         </a>
         <span v-if="data_loaded && lastModified" class="navbar-text small mx-2 d-md-none"

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -5,11 +5,13 @@
     :style="{ backgroundColor: navbarColor }"
   >
     <div v-show="false" class="navbar-nav"><LoginDetails /></div>
-    <span
-      class="navbar-brand clickable flex-shrink-1 text-truncate"
-      @click="scrollToID($event, 'topScrollPoint')"
-      >{{ itemTypeEntry?.navbarName || "loading..." }}&nbsp;&nbsp;|&nbsp;&nbsp;
-      <FormattedItemName :item_id="item_id" :item-type="itemType" />
+    <span class="navbar-brand clickable" @click="scrollToID($event, 'topScrollPoint')">
+      <span class="navbar-brand-type"
+        >{{ itemTypeEntry?.navbarName || "loading..." }}&nbsp;&nbsp;|&nbsp;&nbsp;</span
+      >
+      <span class="navbar-brand-name">
+        <FormattedItemName :item_id="item_id" :item-type="itemType" />
+      </span>
     </span>
 
     <!-- Always-visible right-side cluster: status + save + hamburger (hamburger only shows below md) -->
@@ -29,9 +31,11 @@
         ><i>Last saved: {{ lastModified }}</i></span
       >
       <font-awesome-icon
+        v-show="isNavCollapsed"
         icon="save"
         fixed-width
         class="nav-link navbar-icon"
+        :class="{ 'navbar-icon-unsaved': itemDataLoaded && !savedStatus }"
         title="Save"
         @click="saveSample"
       />
@@ -47,53 +51,18 @@
 
     <div class="collapse navbar-collapse" :class="{ show: !isNavCollapsed }">
       <div class="navbar-nav">
-        <router-link class="nav-item nav-link" to="/">Home</router-link>
-        <div class="nav-item dropdown">
-          <a
-            id="navbarDropdown"
-            class="nav-link dropdown-toggle ml-2"
-            role="button"
-            data-toggle="dropdown"
-            aria-haspopup="true"
-            aria-expanded="false"
-            data-testid="add-block-button-top"
-            @click="isMenuDropdownVisible = !isMenuDropdownVisible"
-          >
-            <font-awesome-icon icon="cubes" fixed-width />
-            Add a block
-          </a>
-          <div
-            v-if="blockInfoLoaded"
-            v-show="isMenuDropdownVisible"
-            class="dropdown-menu"
-            data-testid="add-block-dropdown"
-            style="display: block"
-            aria-labelledby="navbarDropdown"
-          >
-            <h6 v-if="suggestedBlockTypes.length > 0" class="dropdown-header">
-              Suggested based on your files
-            </h6>
-            <span
-              v-for="blockInfo in suggestedBlockTypes"
-              :key="'nav-suggested-' + blockInfo.id"
-              @click="newBlock($event, blockInfo.id)"
-            >
-              <BlockTooltip :block-info="blockInfo.attributes" />
-            </span>
-            <div
-              v-if="suggestedBlockTypes.length > 0 && allBlockTypes.length > 0"
-              class="dropdown-divider"
-            ></div>
-            <h6 v-if="allBlockTypes.length > 0" class="dropdown-header">All block types</h6>
-            <span
-              v-for="blockInfo in allBlockTypes"
-              :key="'nav-all-' + blockInfo.id"
-              @click="newBlock($event, blockInfo.id)"
-            >
-              <BlockTooltip :block-info="blockInfo.attributes" />
-            </span>
-          </div>
-        </div>
+        <router-link class="nav-item nav-link" to="/" title="Home">
+          <font-awesome-icon icon="home" fixed-width /> Home
+        </router-link>
+        <AddBlockDropdown
+          variant="navlink"
+          key-prefix="nav"
+          trigger-testid="add-block-button-top"
+          menu-testid="add-block-dropdown"
+          :suggested-block-types="suggestedBlockTypes"
+          :all-block-types="allBlockTypes"
+          @select="newBlock"
+        />
         <ExportDropdown
           :item-id="item_id"
           :collection-id="itemType === 'collections' ? item_id : null"
@@ -108,7 +77,7 @@
         >
           <font-awesome-icon icon="share-alt" fixed-width /> Share
         </a>
-        <a class="nav-item nav-link" :href="itemApiUrl" target="_blank">
+        <a class="nav-item nav-link" :href="itemApiUrl" target="_blank" title="View JSON">
           <font-awesome-icon icon="code" fixed-width /> View JSON
         </a>
         <a
@@ -118,6 +87,9 @@
           @click="showVersionHistory"
         >
           <font-awesome-icon icon="history" fixed-width /> Versions
+        </a>
+        <a class="nav-item nav-link d-md-none" title="Save" @click="saveSample">
+          <font-awesome-icon icon="save" fixed-width /> Save
         </a>
         <span v-if="itemDataLoaded && lastModified" class="navbar-text small mx-2 d-md-none"
           ><i>Last saved: {{ lastModified }}</i></span
@@ -158,49 +130,16 @@
       </div>
 
       <div class="mt-4 text-center">
-        <div class="dropup d-inline-block">
-          <button
-            id="bottomAddBlockDropdown"
-            class="btn btn-primary dropdown-toggle"
-            type="button"
-            data-toggle="dropdown"
-            aria-haspopup="true"
-            aria-expanded="false"
-            data-testid="add-block-button-bottom"
-            @click="isBottomDropdownVisible = !isBottomDropdownVisible"
-          >
-            <font-awesome-icon icon="cubes" fixed-width /> Add a block
-          </button>
-          <div
-            class="dropdown-menu"
-            :class="{ show: isBottomDropdownVisible }"
-            aria-labelledby="bottomAddBlockDropdown"
-            data-testid="add-block-dropdown-bottom"
-          >
-            <h6 v-if="suggestedBlockTypes.length > 0" class="dropdown-header">
-              Suggested based on your files
-            </h6>
-            <span
-              v-for="blockInfo in suggestedBlockTypes"
-              :key="'bottom-suggested-' + blockInfo.id"
-              @click="newBlock($event, blockInfo.id)"
-            >
-              <BlockTooltip :block-info="blockInfo.attributes" />
-            </span>
-            <div
-              v-if="suggestedBlockTypes.length > 0 && allBlockTypes.length > 0"
-              class="dropdown-divider"
-            ></div>
-            <h6 v-if="allBlockTypes.length > 0" class="dropdown-header">All block types</h6>
-            <span
-              v-for="blockInfo in allBlockTypes"
-              :key="'bottom-all-' + blockInfo.id"
-              @click="newBlock($event, blockInfo.id)"
-            >
-              <BlockTooltip :block-info="blockInfo.attributes" />
-            </span>
-          </div>
-        </div>
+        <AddBlockDropdown
+          variant="button"
+          direction="up"
+          key-prefix="bottom"
+          trigger-testid="add-block-button-bottom"
+          menu-testid="add-block-dropdown-bottom"
+          :suggested-block-types="suggestedBlockTypes"
+          :all-block-types="allBlockTypes"
+          @select="newBlock"
+        />
       </div>
     </div>
 
@@ -249,7 +188,7 @@ import BokehBlock from "@/components/datablocks/BokehBlock.vue";
 import ErrorBlock from "@/components/datablocks/ErrorBlock.vue";
 import { formatDistanceToNow } from "date-fns";
 
-import BlockTooltip from "@/components/BlockTooltip";
+import AddBlockDropdown from "@/components/AddBlockDropdown";
 
 import ExportDropdown from "@/components/ExportDropdown";
 
@@ -263,7 +202,7 @@ export default {
     VersionHistoryModal,
     SharingModal,
     FormattedItemName,
-    BlockTooltip,
+    AddBlockDropdown,
     ExportDropdown,
   },
   provide() {
@@ -298,8 +237,6 @@ export default {
       itemDataLoaded: false,
       blockInfoLoaded: false,
       blocksLoaded: false,
-      isMenuDropdownVisible: false,
-      isBottomDropdownVisible: false,
       isNavCollapsed: true,
       selectedRemoteFiles: [],
       isLoadingRemoteTree: false,
@@ -438,9 +375,7 @@ export default {
     document.removeEventListener("keydown", this._keyListener);
   },
   methods: {
-    async newBlock(event, blockType, index = null) {
-      this.isMenuDropdownVisible = false;
-      this.isBottomDropdownVisible = false;
+    async newBlock(blockType, index = null) {
       this.isLoadingNewBlock = true;
       this.$refs.blockLoadingIndicator.scrollIntoView({
         behavior: "smooth",
@@ -584,6 +519,40 @@ export default {
 .editor-navbar {
   margin-bottom: 1rem;
   z-index: 900;
+  /* Match the natural height of a nav-link row so the collapsed (burger) bar
+     is the same height as the expanded/desktop navbar. */
+  min-height: 2.5rem;
+}
+
+/* Brand = item type + item name. Lay them out so the type yields space first:
+   as the navbar narrows the type clips away before the item name truncates. */
+.editor-navbar .navbar-brand {
+  display: flex;
+  align-items: baseline;
+  min-width: 0;
+  overflow: hidden;
+}
+.navbar-brand-type {
+  /* very high shrink factor → gives up width (and disappears) before the name */
+  flex: 0 100 auto;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+.navbar-brand-name {
+  /* protected: only truncates once the type is gone */
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* On smaller screens (mobile + the icon-only tier) drop the type entirely
+   rather than showing a clipped fragment. */
+@media (max-width: 1199.98px) {
+  .navbar-brand-type {
+    display: none;
+  }
 }
 
 label,
@@ -592,11 +561,15 @@ label,
   color: v-bind("itemTypeEntry?.labelColor");
 }
 
-.nav-link {
+/* ::v-deep so these also reach the Export link, which is the root of a multi-root
+   child component and therefore misses this component's scoped styles. */
+.editor-navbar ::v-deep(.nav-link) {
   cursor: pointer;
+  /* Keep each label on one line; the brand shrinks first instead */
+  white-space: nowrap;
 }
 
-.nav-link:hover {
+.editor-navbar ::v-deep(.nav-link:hover) {
   background-color: black;
   color: white;
 }
@@ -639,36 +612,16 @@ label,
   max-width: calc(100% - 30px);
 }
 
-.dropdown-menu {
-  cursor: pointer;
-}
-
-.dropdown-menu {
-  max-height: 400px;
-  overflow-y: auto;
-}
-
-.dropdown-header {
-  font-weight: 600;
-  color: #495057;
-  font-size: 0.875rem;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.dropdown-item {
-  cursor: pointer;
-}
-
-.dropdown-item:hover {
-  background-color: #f8f9fa;
-}
-
 .navbar-right-cluster {
   display: flex;
   align-items: center;
   gap: 0.5rem;
   margin-left: auto;
+}
+
+/* Don't let the "Last saved" stamp wrap onto a second line */
+.navbar-right-cluster .navbar-text {
+  white-space: nowrap;
 }
 
 .unsaved-dot {
@@ -688,9 +641,24 @@ label,
   line-height: 1;
 }
 
+/* Bootstrap adds a focus box-shadow ring that makes the toggler appear to jump on tap */
+.navbar-toggler:focus,
+.navbar-toggler:active {
+  outline: none;
+  box-shadow: none;
+}
+
 .navbar-right-cluster .navbar-icon {
   /* keep save icon visually aligned with toggler & text */
   margin: 0;
+  /* The cluster sits outside .navbar-nav, so navbar-dark's light link colour
+     doesn't reach it — set it explicitly. */
+  color: white;
+}
+
+/* Save icon doubles as a save-state indicator: amber while there are unsaved changes */
+.navbar-right-cluster .navbar-icon-unsaved {
+  color: #ffc845;
 }
 
 @media (max-width: 767.98px) {
@@ -698,29 +666,63 @@ label,
     flex-wrap: wrap;
   }
   .editor-navbar .navbar-brand {
-    max-width: calc(100% - 8rem);
+    /* Only the compact right cluster (dot + save + hamburger) needs reserving now */
+    max-width: calc(100% - 6rem);
     font-size: 1rem;
     margin-right: 0;
+  }
+  /* Tighten and align the always-visible right cluster on small screens */
+  .navbar-right-cluster {
+    gap: 0.25rem;
+  }
+  .navbar-right-cluster .navbar-icon,
+  .navbar-right-cluster .navbar-toggler {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
   }
   .editor-navbar .navbar-collapse {
     width: 100%;
     flex-basis: 100%;
+    border-top: 1px solid rgba(255, 255, 255, 0.15);
+    margin-top: 0.25rem;
   }
   .editor-navbar .navbar-collapse .navbar-nav {
     flex-direction: column;
     width: 100%;
     padding: 0.25rem 0;
   }
-  .editor-navbar .navbar-collapse .nav-link {
-    padding: 0.5rem 0.75rem;
+  .editor-navbar .navbar-collapse ::v-deep(.nav-link) {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0;
+    padding: 0.65rem 0.5rem;
+    border-radius: 0.25rem;
   }
-  /* Let dropdown menus size themselves sensibly inside the collapsed nav */
-  .editor-navbar .navbar-collapse .dropdown-menu {
-    position: static;
-    float: none;
-    width: 100%;
-    border: 0;
-    background-color: rgba(0, 0, 0, 0.15);
+  /* Keep the leading icons a consistent width so the labels line up down the menu. */
+  .editor-navbar .navbar-collapse ::v-deep(.nav-link .svg-inline--fa) {
+    flex: 0 0 auto;
+  }
+  /* Subtle dividers between top-level entries so the menu is easier to scan */
+  .editor-navbar .navbar-collapse .navbar-nav > ::v-deep(.nav-item:not(:last-child)),
+  .editor-navbar .navbar-collapse .navbar-nav > ::v-deep(.nav-link:not(:last-child)) {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+}
+
+/* Between md and xl the inline bar gets tight, so drop the text labels and show
+   icons only (hover/title tooltips still convey the label). */
+@media (min-width: 768px) and (max-width: 1199.98px) {
+  .editor-navbar .navbar-nav ::v-deep(.nav-link) {
+    font-size: 0;
+  }
+  .editor-navbar .navbar-nav ::v-deep(.svg-inline--fa) {
+    font-size: 1rem;
   }
 }
 </style>

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -1,101 +1,128 @@
 <template>
   <div id="topScrollPoint"></div>
   <nav
-    class="navbar navbar-expand sticky-top navbar-dark py-0 editor-navbar"
+    class="navbar navbar-expand-md sticky-top navbar-dark py-0 editor-navbar"
     :style="{ backgroundColor: navbarColor }"
   >
     <div v-show="false" class="navbar-nav"><LoginDetails /></div>
-    <span class="navbar-brand clickable" @click="scrollToID($event, 'topScrollPoint')"
+    <span
+      class="navbar-brand clickable flex-shrink-1 text-truncate"
+      @click="scrollToID($event, 'topScrollPoint')"
       >{{ itemTypeEntry?.navbarName || "loading..." }}&nbsp;&nbsp;|&nbsp;&nbsp;
       <FormattedItemName :item_id="item_id" :item-type="itemType" />
     </span>
-    <div class="navbar-nav">
-      <router-link class="nav-item nav-link" to="/">Home</router-link>
-      <div class="nav-item dropdown">
-        <a
-          id="navbarDropdown"
-          class="nav-link dropdown-toggle ml-2"
-          role="button"
-          data-toggle="dropdown"
-          aria-haspopup="true"
-          aria-expanded="false"
-          data-testid="add-block-button-top"
-          @click="isMenuDropdownVisible = !isMenuDropdownVisible"
-        >
-          <font-awesome-icon icon="cubes" fixed-width />
-          Add a block
-        </a>
-        <div
-          v-if="blockInfoLoaded"
-          v-show="isMenuDropdownVisible"
-          class="dropdown-menu"
-          data-testid="add-block-dropdown"
-          style="display: block"
-          aria-labelledby="navbarDropdown"
-        >
-          <h6 v-if="suggestedBlockTypes.length > 0" class="dropdown-header">
-            Suggested based on your files
-          </h6>
-          <span
-            v-for="blockInfo in suggestedBlockTypes"
-            :key="'nav-suggested-' + blockInfo.id"
-            @click="newBlock($event, blockInfo.id)"
-          >
-            <BlockTooltip :block-info="blockInfo.attributes" />
-          </span>
-          <div
-            v-if="suggestedBlockTypes.length > 0 && allBlockTypes.length > 0"
-            class="dropdown-divider"
-          ></div>
-          <h6 v-if="allBlockTypes.length > 0" class="dropdown-header">All block types</h6>
-          <span
-            v-for="blockInfo in allBlockTypes"
-            :key="'nav-all-' + blockInfo.id"
-            @click="newBlock($event, blockInfo.id)"
-          >
-            <BlockTooltip :block-info="blockInfo.attributes" />
-          </span>
-        </div>
-      </div>
-      <ExportDropdown
-        :item-id="item_id"
-        :collection-id="itemType === 'collections' ? item_id : null"
-        :item-type="itemType"
-      />
-      <a
-        v-if="itemDataLoaded && refcode"
-        class="nav-item nav-link"
-        href="#"
-        title="Share this item"
-        @click.prevent="isSharingModalVisible = true"
+
+    <!-- Always-visible right-side cluster: status + save + hamburger (hamburger only shows below md) -->
+    <div class="navbar-right-cluster order-md-last">
+      <span
+        v-if="itemDataLoaded && !savedStatus"
+        class="navbar-text unsaved-warning d-none d-sm-inline"
       >
-        <font-awesome-icon icon="share-alt" fixed-width /> Share
-      </a>
-      <a class="nav-item nav-link" :href="itemApiUrl" target="_blank">
-        <font-awesome-icon icon="code" fixed-width /> View JSON
-      </a>
-      <a
-        v-if="itemDataLoaded"
-        class="nav-item nav-link"
-        title="Version History"
-        @click="showVersionHistory"
-      >
-        <font-awesome-icon icon="history" fixed-width /> Versions
-      </a>
-    </div>
-    <div class="navbar-nav ml-auto">
-      <span v-if="itemDataLoaded && !savedStatus" class="navbar-text unsaved-warning">
         Unsaved changes
       </span>
-      <span v-if="itemDataLoaded && lastModified" class="navbar-text small mx-2"
+      <span
+        v-if="itemDataLoaded && !savedStatus"
+        class="unsaved-dot d-sm-none"
+        title="Unsaved changes"
+      ></span>
+      <span v-if="itemDataLoaded && lastModified" class="navbar-text small d-none d-md-inline"
         ><i>Last saved: {{ lastModified }}</i></span
       >
       <font-awesome-icon
         icon="save"
         fixed-width
-        class="nav-item nav-link navbar-icon"
+        class="nav-link navbar-icon"
+        title="Save"
         @click="saveSample"
       />
+      <button
+        class="navbar-toggler border-0 d-md-none"
+        type="button"
+        aria-label="Toggle navigation"
+        @click="isNavCollapsed = !isNavCollapsed"
+      >
+        <font-awesome-icon icon="bars" />
+      </button>
+    </div>
+
+    <div class="collapse navbar-collapse" :class="{ show: !isNavCollapsed }">
+      <div class="navbar-nav">
+        <router-link class="nav-item nav-link" to="/">Home</router-link>
+        <div class="nav-item dropdown">
+          <a
+            id="navbarDropdown"
+            class="nav-link dropdown-toggle ml-2"
+            role="button"
+            data-toggle="dropdown"
+            aria-haspopup="true"
+            aria-expanded="false"
+            data-testid="add-block-button-top"
+            @click="isMenuDropdownVisible = !isMenuDropdownVisible"
+          >
+            <font-awesome-icon icon="cubes" fixed-width />
+            Add a block
+          </a>
+          <div
+            v-if="blockInfoLoaded"
+            v-show="isMenuDropdownVisible"
+            class="dropdown-menu"
+            data-testid="add-block-dropdown"
+            style="display: block"
+            aria-labelledby="navbarDropdown"
+          >
+            <h6 v-if="suggestedBlockTypes.length > 0" class="dropdown-header">
+              Suggested based on your files
+            </h6>
+            <span
+              v-for="blockInfo in suggestedBlockTypes"
+              :key="'nav-suggested-' + blockInfo.id"
+              @click="newBlock($event, blockInfo.id)"
+            >
+              <BlockTooltip :block-info="blockInfo.attributes" />
+            </span>
+            <div
+              v-if="suggestedBlockTypes.length > 0 && allBlockTypes.length > 0"
+              class="dropdown-divider"
+            ></div>
+            <h6 v-if="allBlockTypes.length > 0" class="dropdown-header">All block types</h6>
+            <span
+              v-for="blockInfo in allBlockTypes"
+              :key="'nav-all-' + blockInfo.id"
+              @click="newBlock($event, blockInfo.id)"
+            >
+              <BlockTooltip :block-info="blockInfo.attributes" />
+            </span>
+          </div>
+        </div>
+        <ExportDropdown
+          :item-id="item_id"
+          :collection-id="itemType === 'collections' ? item_id : null"
+          :item-type="itemType"
+        />
+        <a
+          v-if="itemDataLoaded && refcode"
+          class="nav-item nav-link"
+          href="#"
+          title="Share this item"
+          @click.prevent="isSharingModalVisible = true"
+        >
+          <font-awesome-icon icon="share-alt" fixed-width /> Share
+        </a>
+        <a class="nav-item nav-link" :href="itemApiUrl" target="_blank">
+          <font-awesome-icon icon="code" fixed-width /> View JSON
+        </a>
+        <a
+          v-if="itemDataLoaded"
+          class="nav-item nav-link"
+          title="Version History"
+          @click="showVersionHistory"
+        >
+          <font-awesome-icon icon="history" fixed-width /> Versions
+        </a>
+        <span v-if="itemDataLoaded && lastModified" class="navbar-text small mx-2 d-md-none"
+          ><i>Last saved: {{ lastModified }}</i></span
+        >
+      </div>
     </div>
   </nav>
 
@@ -273,6 +300,7 @@ export default {
       blocksLoaded: false,
       isMenuDropdownVisible: false,
       isBottomDropdownVisible: false,
+      isNavCollapsed: true,
       selectedRemoteFiles: [],
       isLoadingRemoteTree: false,
       isLoadingRemoteFiles: false,
@@ -634,5 +662,65 @@ label,
 
 .dropdown-item:hover {
   background-color: #f8f9fa;
+}
+
+.navbar-right-cluster {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+.unsaved-dot {
+  display: inline-block;
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  background-color: #ffc845;
+  box-shadow: 0 0 0 2px rgba(255, 200, 69, 0.3);
+}
+
+.navbar-toggler {
+  color: white;
+  background: transparent;
+  padding: 0.25rem 0.5rem;
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.navbar-right-cluster .navbar-icon {
+  /* keep save icon visually aligned with toggler & text */
+  margin: 0;
+}
+
+@media (max-width: 767.98px) {
+  .editor-navbar {
+    flex-wrap: wrap;
+  }
+  .editor-navbar .navbar-brand {
+    max-width: calc(100% - 8rem);
+    font-size: 1rem;
+    margin-right: 0;
+  }
+  .editor-navbar .navbar-collapse {
+    width: 100%;
+    flex-basis: 100%;
+  }
+  .editor-navbar .navbar-collapse .navbar-nav {
+    flex-direction: column;
+    width: 100%;
+    padding: 0.25rem 0;
+  }
+  .editor-navbar .navbar-collapse .nav-link {
+    padding: 0.5rem 0.75rem;
+  }
+  /* Let dropdown menus size themselves sensibly inside the collapsed nav */
+  .editor-navbar .navbar-collapse .dropdown-menu {
+    position: static;
+    float: none;
+    width: 100%;
+    border: 0;
+    background-color: rgba(0, 0, 0, 0.15);
+  }
 }
 </style>

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -673,16 +673,22 @@ label,
     flex-wrap: wrap;
   }
   .editor-navbar .navbar-brand {
-    /* Only the compact right cluster (dot + save + hamburger) needs reserving now */
-    max-width: calc(100% - 6rem);
+    /* flex-basis 0 (not auto) so the brand's long content doesn't drive line
+       wrapping — the cluster stays on this row, and the brand grows into the
+       leftover space and truncates instead of bumping the cluster to a 2nd row. */
+    flex: 1 1 0;
+    min-width: 0;
     font-size: 1rem;
     margin-right: 0;
   }
-  /* Tighten and align the always-visible right cluster on small screens */
+  /* Keep the cluster at its natural width on the right so the save icon and
+     hamburger stay on-screen; the brand truncates into the space to their left. */
   .navbar-right-cluster {
+    flex: 0 0 auto;
     gap: 0.25rem;
   }
-  .navbar-right-cluster .navbar-icon,
+  /* inline-flex is for the <button> toggler; it must NOT be applied to the save
+     <svg>, which renders/clips wrong when treated as a flex container. */
   .navbar-right-cluster .navbar-toggler {
     display: inline-flex;
     align-items: center;
@@ -692,6 +698,14 @@ label,
     height: 2.25rem;
     padding: 0;
   }
+  /* Save icon: plain box sizing (like the desktop .navbar-icon, just a touch bigger) */
+  .navbar-right-cluster .navbar-icon {
+    flex: 0 0 auto;
+    width: 1.9rem;
+    height: 1.9rem;
+    padding: 0.45rem;
+  }
+
   .editor-navbar .navbar-collapse {
     width: 100%;
     flex-basis: 100%;

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -57,6 +57,7 @@
         <AddBlockDropdown
           variant="navlink"
           key-prefix="nav"
+          trigger-id="navbarDropdown"
           trigger-testid="add-block-button-top"
           menu-testid="add-block-dropdown"
           :suggested-block-types="suggestedBlockTypes"
@@ -88,7 +89,12 @@
         >
           <font-awesome-icon icon="history" fixed-width /> Versions
         </a>
-        <a class="nav-item nav-link d-md-none" title="Save" @click="saveSample">
+        <a
+          v-if="!isNavCollapsed"
+          class="nav-item nav-link d-md-none"
+          title="Save"
+          @click="saveSample"
+        >
           <font-awesome-icon icon="save" fixed-width /> Save
         </a>
         <span v-if="itemDataLoaded && lastModified" class="navbar-text small mx-2 d-md-none"
@@ -134,6 +140,7 @@
           variant="button"
           direction="up"
           key-prefix="bottom"
+          trigger-id="bottomAddBlockDropdown"
           trigger-testid="add-block-button-bottom"
           menu-testid="add-block-dropdown-bottom"
           :suggested-block-types="suggestedBlockTypes"


### PR DESCRIPTION
This PR makes the navbar more reactive with three modes: full text, icons only and burger button, depending on size of the display port. It also moves the add a block menu out into its own component.

Closes #1670 