### PR TITLE
Add a modal for sharing items with creators and groups

### DIFF
--- a/webapp/cypress/e2e/shareItem.cy.js
+++ b/webapp/cypress/e2e/shareItem.cy.js
@@ -1,0 +1,98 @@
+// E2E coverage for the sharing flow: opening the SharingModal from the
+// inline Creators/Groups widgets and from the navbar, switching tabs, and
+// verifying the QR code / shareable link appear.
+
+const item_ids = ["share_test_sample"];
+
+before(() => {
+  cy.loginViaTestMagicLink("test-user@example.com", "user");
+  cy.visit("/");
+  cy.removeAllTestSamples(item_ids, true);
+  cy.createSample("share_test_sample", "Sample for sharing tests");
+});
+
+after(() => {
+  cy.visit("/");
+  cy.removeAllTestSamples(item_ids, true);
+  cy.logout();
+});
+
+const modal = () => cy.get(".modal.show");
+
+describe("Sharing modal", () => {
+  beforeEach(() => {
+    cy.loginViaTestMagicLink("test-user@example.com", "user");
+    cy.visit("/");
+  });
+
+  it("seeded sample is available", () => {
+    cy.findByText("share_test_sample");
+  });
+
+  it("opens the sharing modal from the navbar and shows both tabs", () => {
+    cy.findByText("share_test_sample").click();
+
+    cy.get("nav").contains("a", "Share").click();
+
+    modal().within(() => {
+      // Default tab: Direct access.
+      cy.get(".nav-tabs").contains("Direct access").should("have.class", "active");
+      cy.get(".nav-tabs").contains("Sharing links & labels");
+      cy.contains("People with access");
+      cy.contains("Editor");
+      cy.get(".fa-lock").should("exist");
+
+      // Switch to the links tab — QR + shareable link render.
+      cy.get(".nav-tabs").contains("Sharing links & labels").click();
+      cy.get('[data-testid="shareable-link"]').should("be.visible");
+      cy.get('[data-testid="shareable-link"] a').should("have.attr", "href");
+    });
+
+    modal().contains("button", "Done").click();
+    cy.get(".modal.show").should("not.exist");
+  });
+
+  it("opens the sharing modal by clicking the inline Creators widget", () => {
+    cy.findByText("share_test_sample").click();
+
+    cy.get('[data-testid="toggleable-creators"]').click();
+
+    modal().within(() => {
+      cy.contains("People with access").should("be.visible");
+    });
+
+    modal().contains("button", "Done").click();
+  });
+
+  it("opens the sharing modal by clicking the inline Groups widget", () => {
+    cy.findByText("share_test_sample").click();
+
+    cy.get('[data-testid="toggleable-groups"]').click();
+
+    modal().within(() => {
+      cy.contains("Groups with access").should("be.visible");
+    });
+
+    modal().contains("button", "Done").click();
+  });
+
+  it("opens the UserSelect editor when entering Manage mode for People", () => {
+    cy.findByText("share_test_sample").click();
+    cy.get("nav").contains("a", "Share").click();
+
+    // Two "Manage" buttons exist (People + Groups); take the first.
+    modal().contains("button", "Manage").first().click();
+    modal().find(".vs__dropdown-toggle").should("exist");
+
+    // Click outside the dropdown (modal header is safe) to dismiss Manage
+    // mode via OnClickOutside. Shadow equals current value so no confirm
+    // dialog should fire.
+    modal().find(".modal-header").click();
+    modal().find(".vs__dropdown-toggle").should("not.exist");
+    cy.contains("Update Permissions").should("not.exist");
+
+    // Explicitly use the footer's primary Done button.
+    modal().find(".modal-footer .btn-primary").click();
+    cy.get(".modal.show").should("not.exist");
+  });
+});

--- a/webapp/src/components/EquipmentInformation.vue
+++ b/webapp/src/components/EquipmentInformation.vue
@@ -2,37 +2,54 @@
   <div class="container">
     <!-- Item information -->
     <div id="equipment-information" class="form-row">
-      <div class="form-group col-md-2 col-sm-4">
-        <label class="mr-2">Refcode</label>
-        <div><FormattedRefcode :refcode="Refcode" /></div>
-      </div>
-      <div class="form-group col-md-2 col-sm-4">
-        <label for="equip-item_id" class="mr-2">Item id</label>
-        <input id="equip-item_id" class="form-control-plaintext" readonly="true" :value="item_id" />
-      </div>
-      <div class="form-group col-md-6 col-sm-8">
+      <div class="form-group col-md-8 col-sm-8">
         <label for="equip-name" class="mr-2">Name</label>
         <input id="equip-name" v-model="Name" class="form-control" />
       </div>
-      <div class="form-group col-md-2 col-sm-4">
+      <div class="form-group col-md-4 col-sm-4">
         <label for="equip-date" class="mr-2">Date</label>
         <input id="equip-date" v-model="EquipmentDate" type="datetime-local" class="form-control" />
       </div>
     </div>
+
     <div class="form-row">
-      <div class="form-group col-md-2">
+      <div class="form-group col-md-3 col-sm-4">
+        <label class="mr-2">Refcode</label>
+        <div><FormattedRefcode :refcode="Refcode" /></div>
+      </div>
+      <div class="form-group col-md-3 col-sm-3 col-6 pb-3">
+        <ToggleableItemStatusFormGroup
+          v-model="Status"
+          :possible-item-statuses="possibleItemStatuses"
+        />
+      </div>
+      <div class="form-group col-md-3 col-sm-3">
         <label id="collections" class="mr-2">Collections</label>
         <div>
           <CollectionList aria-labelledby="collections" :collections="Collections" />
         </div>
       </div>
-      <div class="form-group col-md-5">
-        <label for="equip-manufacturer" class="mr-2">Manufacturer</label>
-        <span>
-          <input id="equip-manufacturer" v-model="Manufacturer" class="form-control" />
-        </span>
+      <div class="form-group col-md-3 col-sm-2">
+        <label for="equip-item_id" class="mr-2">Item id</label>
+        <input id="equip-item_id" class="form-control-plaintext" readonly="true" :value="item_id" />
       </div>
-      <div class="form-group col-md-5">
+    </div>
+
+    <div class="form-row">
+      <div class="form-group col-6 pb-3">
+        <ToggleableCreatorsFormGroup v-model="Maintainers" :refcode="Refcode" label="Maintainers" />
+      </div>
+      <div class="form-group col-6 pb-3">
+        <ToggleableGroupsFormGroup v-model="ItemGroups" :refcode="Refcode" />
+      </div>
+    </div>
+
+    <div class="form-row">
+      <div class="form-group col-md-6">
+        <label for="equip-manufacturer" class="mr-2">Manufacturer</label>
+        <input id="equip-manufacturer" v-model="Manufacturer" class="form-control" />
+      </div>
+      <div class="form-group col-md-6">
         <label for="equip-location" class="mr-2">Location</label>
         <AutoComplete
           v-model="Location"
@@ -49,23 +66,9 @@
         <label for="equip-serial" class="mr-2">Serial no(s).</label>
         <input id="equip-serial" v-model="SerialNos" class="form-control" />
       </div>
-      <div class="col-md-4 pb-3">
-        <label id="equip-maintainers" class="mr-2">Maintainers</label>
-        <div class="mx-auto">
-          <Creators aria-labelledby="equip-maintainers" :creators="Maintainers" :size="36" />
-        </div>
-      </div>
-    </div>
-    <div class="form-row">
-      <div class="form-group col-md-8">
+      <div class="form-group col-md-4">
         <label for="equip-contact" class="mr-2">Contact information</label>
         <input id="equip-contact" v-model="Contact" class="form-control" />
-      </div>
-      <div class="form-group col-md-3 col-sm-3 col-6 pb-3">
-        <ToggleableItemStatusFormGroup
-          v-model="Status"
-          :possible-item-statuses="possibleItemStatuses"
-        />
       </div>
     </div>
     <label id="equip-description-label" class="mr-2">Description</label>
@@ -87,8 +90,9 @@ import TiptapInline from "@/components/TiptapInline";
 import TableOfContents from "@/components/TableOfContents";
 import CollectionList from "@/components/CollectionList";
 import FormattedRefcode from "@/components/FormattedRefcode";
-import Creators from "@/components/Creators";
+import ToggleableCreatorsFormGroup from "@/components/ToggleableCreatorsFormGroup";
 import ToggleableItemStatusFormGroup from "@/components/ToggleableItemStatusFormGroup";
+import ToggleableGroupsFormGroup from "@/components/ToggleableGroupsFormGroup";
 
 export default {
   components: {
@@ -97,8 +101,9 @@ export default {
     CollectionList,
     TableOfContents,
     FormattedRefcode,
-    Creators,
+    ToggleableCreatorsFormGroup,
     ToggleableItemStatusFormGroup,
+    ToggleableGroupsFormGroup,
   },
   props: {
     item_id: { type: String, required: true },
@@ -125,6 +130,7 @@ export default {
     EquipmentDate: createComputedSetterForItemField("date"),
     SerialNos: createComputedSetterForItemField("serial_numbers"),
     Maintainers: createComputedSetterForItemField("creators"),
+    ItemGroups: createComputedSetterForItemField("groups"),
     Contact: createComputedSetterForItemField("contact"),
     Status: createComputedSetterForItemField("status"),
     schema() {

--- a/webapp/src/components/QRCode.vue
+++ b/webapp/src/components/QRCode.vue
@@ -32,7 +32,7 @@
       <span v-else class="badge bg-warning text-dark">Public QR Code</span>
     </div>
 
-    <div class="shareable-link mt-2 d-flex align-items-center">
+    <div class="shareable-link mt-2 d-flex align-items-center" data-testid="shareable-link">
       <a
         :href="currentQRCodeUrl"
         target="_blank"

--- a/webapp/src/components/SharingModal.vue
+++ b/webapp/src/components/SharingModal.vue
@@ -11,7 +11,7 @@
       />
     </template>
     <template #body>
-      <ul class="nav nav-tabs mb-4">
+      <ul v-if="refcode" class="nav nav-tabs mb-4">
         <li class="nav-item">
           <a
             class="nav-link"
@@ -111,7 +111,7 @@
       </div>
 
       <!-- Sharing links & labels tab -->
-      <div v-else-if="activeTab === 'links'">
+      <div v-else-if="activeTab === 'links' && refcode">
         <p class="text-muted small">
           Share this item with a printable QR code or copyable link. Public links bypass
           authentication and can be revoked at any time.
@@ -210,6 +210,16 @@ export default {
     editingGroups(now, was) {
       if (was && !now) this.persistGroups();
     },
+    modelValue(now) {
+      if (!now) {
+        // Flip editing flags off so the existing watchers run their
+        // persist-or-revert logic, then reset the active tab so the modal
+        // reopens in a predictable state.
+        this.editingPeople = false;
+        this.editingGroups = false;
+        this.activeTab = "direct";
+      }
+    },
   },
   methods: {
     async persistCreators() {
@@ -226,7 +236,9 @@ export default {
       }
       const confirmed = await DialogService.confirm({
         title: "Update Permissions",
-        message: "Update the people with access to this item?",
+        message: `Update the people with access to this ${
+          this.isCollection ? "collection" : "item"
+        }?`,
         type: "warning",
       });
       if (!confirmed) {
@@ -248,10 +260,6 @@ export default {
           });
         }
       } catch (err) {
-        DialogService.error({
-          title: "Permission Update Failed",
-          message: "Error updating permissions: " + err,
-        });
         this.creatorsShadow = [...this.creators];
       }
     },
@@ -261,7 +269,9 @@ export default {
       }
       const confirmed = await DialogService.confirm({
         title: "Update Permissions",
-        message: "Update the groups with access to this item?",
+        message: `Update the groups with access to this ${
+          this.isCollection ? "collection" : "item"
+        }?`,
         type: "warning",
       });
       if (!confirmed) {
@@ -283,10 +293,6 @@ export default {
           });
         }
       } catch (err) {
-        DialogService.error({
-          title: "Permission Update Failed",
-          message: "Error updating group permissions: " + err,
-        });
         this.groupsShadow = [...this.groups];
       }
     },

--- a/webapp/src/components/SharingModal.vue
+++ b/webapp/src/components/SharingModal.vue
@@ -1,0 +1,322 @@
+<template>
+  <Modal :model-value="modelValue" @update:model-value="$emit('update:modelValue', $event)">
+    <template #header>
+      <font-awesome-icon icon="share-alt" class="me-2" />
+      Share
+      <FormattedItemName
+        v-if="headerName"
+        class="ms-2"
+        :item_id="headerName"
+        :item-type="itemType"
+      />
+    </template>
+    <template #body>
+      <ul class="nav nav-tabs mb-4">
+        <li class="nav-item">
+          <a
+            class="nav-link"
+            :class="{ active: activeTab === 'direct' }"
+            href="#"
+            @click.prevent="activeTab = 'direct'"
+          >
+            <font-awesome-icon icon="user-friends" class="me-2" />
+            Direct access
+          </a>
+        </li>
+        <li class="nav-item">
+          <a
+            class="nav-link"
+            :class="{ active: activeTab === 'links' }"
+            href="#"
+            @click.prevent="activeTab = 'links'"
+          >
+            <font-awesome-icon icon="link" class="me-2" />
+            Sharing links &amp; labels
+          </a>
+        </li>
+      </ul>
+
+      <!-- Direct access tab -->
+      <div v-if="activeTab === 'direct'">
+        <!-- People with access -->
+        <div class="mb-4">
+          <div class="d-flex align-items-center justify-content-between mb-3">
+            <h6 class="fw-bold mb-0">People with access</h6>
+            <button
+              type="button"
+              class="btn btn-sm btn-outline-secondary"
+              @click="editingPeople = !editingPeople"
+            >
+              <font-awesome-icon :icon="editingPeople ? 'check' : 'pen'" class="me-1" />
+              {{ editingPeople ? "Done" : "Manage" }}
+            </button>
+          </div>
+          <OnClickOutside v-if="editingPeople" @trigger="editingPeople = false">
+            <UserSelect
+              v-model="creatorsShadow"
+              aria-label="Manage people with access"
+              multiple
+              @click.stop
+            />
+          </OnClickOutside>
+          <ul v-else-if="creators && creators.length" class="list-unstyled mb-0">
+            <li
+              v-for="person in creators"
+              :key="person.immutable_id"
+              class="share-row d-flex align-items-center py-2"
+            >
+              <Creators :creators="[person]" :size="36" class="flex-grow-1" />
+              <div class="role-control text-muted" title="Creators currently have edit access">
+                <span class="me-3">Editor</span>
+                <font-awesome-icon icon="lock" />
+              </div>
+            </li>
+          </ul>
+          <p v-else class="text-muted small mb-0">No users have direct access yet.</p>
+        </div>
+
+        <!-- Groups with access -->
+        <div class="mb-4">
+          <div class="d-flex align-items-center justify-content-between mb-3">
+            <h6 class="fw-bold mb-0">Groups with access</h6>
+            <button
+              type="button"
+              class="btn btn-sm btn-outline-secondary"
+              @click="editingGroups = !editingGroups"
+            >
+              <font-awesome-icon :icon="editingGroups ? 'check' : 'pen'" class="me-1" />
+              {{ editingGroups ? "Done" : "Manage" }}
+            </button>
+          </div>
+          <OnClickOutside v-if="editingGroups" @trigger="editingGroups = false">
+            <GroupSelect v-model="groupsShadow" multiple @click.stop />
+          </OnClickOutside>
+          <ul v-else-if="groups && groups.length" class="list-unstyled mb-0">
+            <li
+              v-for="group in groups"
+              :key="group.immutable_id"
+              class="share-row d-flex align-items-center py-2"
+            >
+              <div class="flex-grow-1">
+                <FormattedGroupName :group="group" :size="36" />
+              </div>
+              <div class="role-control text-muted" title="Groups currently have read-only access">
+                <span class="me-3">Viewer</span>
+                <font-awesome-icon icon="lock" />
+              </div>
+            </li>
+          </ul>
+          <p v-else class="text-muted small mb-0">No groups have access yet.</p>
+        </div>
+      </div>
+
+      <!-- Sharing links & labels tab -->
+      <div v-else-if="activeTab === 'links'">
+        <p class="text-muted small">
+          Share this item with a printable QR code or copyable link. Public links bypass
+          authentication and can be revoked at any time.
+        </p>
+        <QRCode :refcode="refcode" />
+      </div>
+    </template>
+    <template #footer>
+      <button type="button" class="btn btn-primary" @click="$emit('update:modelValue', false)">
+        Done
+      </button>
+    </template>
+  </Modal>
+</template>
+
+<script>
+import { toRaw } from "vue";
+import { OnClickOutside } from "@vueuse/components";
+import Modal from "@/components/Modal.vue";
+import QRCode from "@/components/QRCode.vue";
+import UserSelect from "@/components/UserSelect.vue";
+import GroupSelect from "@/components/GroupSelect.vue";
+import FormattedItemName from "@/components/FormattedItemName.vue";
+import Creators from "@/components/Creators.vue";
+import FormattedGroupName from "@/components/FormattedGroupName.vue";
+import { DialogService } from "@/services/DialogService";
+import { updateItemPermissions, updateCollectionPermissions } from "@/server_fetch_utils.js";
+
+export default {
+  name: "SharingModal",
+  components: {
+    Modal,
+    QRCode,
+    UserSelect,
+    GroupSelect,
+    FormattedItemName,
+    Creators,
+    FormattedGroupName,
+    OnClickOutside,
+  },
+  props: {
+    modelValue: Boolean,
+    refcode: { type: String, default: null },
+    itemId: { type: String, default: null },
+    collectionId: { type: String, default: null },
+  },
+  emits: ["update:modelValue"],
+  data() {
+    return {
+      activeTab: "direct",
+      editingPeople: false,
+      editingGroups: false,
+      creatorsShadow: [],
+      groupsShadow: [],
+    };
+  },
+  computed: {
+    isCollection() {
+      return !!this.collectionId;
+    },
+    sourceData() {
+      if (this.isCollection) {
+        return this.$store.state.all_collection_data[this.collectionId] || {};
+      }
+      return this.$store.state.all_item_data[this.itemId] || {};
+    },
+    itemType() {
+      return this.isCollection ? "collections" : this.sourceData.type;
+    },
+    headerName() {
+      return this.isCollection ? this.collectionId : this.itemId;
+    },
+    creators() {
+      return this.sourceData.creators || [];
+    },
+    groups() {
+      return this.sourceData.groups || [];
+    },
+  },
+  watch: {
+    creators: {
+      immediate: true,
+      handler(newVal) {
+        this.creatorsShadow = Array.isArray(newVal) ? [...newVal] : [];
+      },
+    },
+    groups: {
+      immediate: true,
+      handler(newVal) {
+        this.groupsShadow = Array.isArray(newVal) ? [...newVal] : [];
+      },
+    },
+    editingPeople(now, was) {
+      if (was && !now) this.persistCreators();
+    },
+    editingGroups(now, was) {
+      if (was && !now) this.persistGroups();
+    },
+  },
+  methods: {
+    async persistCreators() {
+      if (JSON.stringify(toRaw(this.creators)) === JSON.stringify(toRaw(this.creatorsShadow))) {
+        return;
+      }
+      if (!this.creatorsShadow.length) {
+        DialogService.error({
+          title: "Permission Update Failed",
+          message: "You must have at least one creator.",
+        });
+        this.creatorsShadow = [...this.creators];
+        return;
+      }
+      const confirmed = await DialogService.confirm({
+        title: "Update Permissions",
+        message: "Update the people with access to this item?",
+        type: "warning",
+      });
+      if (!confirmed) {
+        this.creatorsShadow = [...this.creators];
+        return;
+      }
+      try {
+        if (this.isCollection) {
+          await updateCollectionPermissions(this.collectionId, this.creatorsShadow);
+          this.$store.commit("updateCollectionData", {
+            collection_id: this.collectionId,
+            block_data: { creators: [...this.creatorsShadow] },
+          });
+        } else {
+          await updateItemPermissions(this.refcode, this.creatorsShadow);
+          this.$store.commit("updateItemData", {
+            item_id: this.itemId,
+            item_data: { creators: [...this.creatorsShadow] },
+          });
+        }
+      } catch (err) {
+        DialogService.error({
+          title: "Permission Update Failed",
+          message: "Error updating permissions: " + err,
+        });
+        this.creatorsShadow = [...this.creators];
+      }
+    },
+    async persistGroups() {
+      if (JSON.stringify(toRaw(this.groups)) === JSON.stringify(toRaw(this.groupsShadow))) {
+        return;
+      }
+      const confirmed = await DialogService.confirm({
+        title: "Update Permissions",
+        message: "Update the groups with access to this item?",
+        type: "warning",
+      });
+      if (!confirmed) {
+        this.groupsShadow = [...this.groups];
+        return;
+      }
+      try {
+        if (this.isCollection) {
+          await updateCollectionPermissions(this.collectionId, null, this.groupsShadow);
+          this.$store.commit("updateCollectionData", {
+            collection_id: this.collectionId,
+            block_data: { groups: [...this.groupsShadow] },
+          });
+        } else {
+          await updateItemPermissions(this.refcode, null, this.groupsShadow);
+          this.$store.commit("updateItemData", {
+            item_id: this.itemId,
+            item_data: { groups: [...this.groupsShadow] },
+          });
+        }
+      } catch (err) {
+        DialogService.error({
+          title: "Permission Update Failed",
+          message: "Error updating group permissions: " + err,
+        });
+        this.groupsShadow = [...this.groups];
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.nav-tabs .nav-link {
+  color: #0056b3;
+  font-weight: 600;
+}
+.nav-tabs .nav-link.active {
+  color: #003d82;
+}
+
+.share-row {
+  border-bottom: 1px solid #f1f3f5;
+}
+.share-row:last-child {
+  border-bottom: none;
+}
+
+.role-control {
+  cursor: not-allowed;
+  user-select: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+}
+.role-control:hover {
+  background-color: #f1f3f5;
+}
+</style>

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -23,20 +23,30 @@
             <label for="startmat-refcode">Refcode</label>
             <div id="startmat-refcode"><FormattedRefcode :refcode="Refcode" /></div>
           </div>
-          <div v-if="Barcode" class="form-group col-md-3 col-sm-4 col-6">
-            <label for="startmat-barcode">Barcode</label>
-            <div id="startmat-barcode"><FormattedBarCode :barcode="Barcode" /></div>
-          </div>
-          <div class="form-group col-md-4 col-sm-4 col-6">
-            <ToggleableCollectionFormGroup v-model="Collections" />
-          </div>
-          <div class="form-group col-md-5 col-sm-4 col-12">
+          <div class="form-group col-md-3 col-sm-4 col-12">
             <ToggleableItemStatusFormGroup
               v-model="Status"
               :possible-item-statuses="possibleItemStatuses"
             />
           </div>
+          <div class="form-group col-md-3 col-sm-4 col-6">
+            <ToggleableCollectionFormGroup v-model="Collections" />
+          </div>
+          <div v-if="Barcode" class="form-group col-md-3 col-sm-4 col-6">
+            <label for="startmat-barcode">Barcode</label>
+            <div id="startmat-barcode"><FormattedBarCode :barcode="Barcode" /></div>
+          </div>
         </div>
+
+        <div class="form-row">
+          <div class="form-group col-6 pb-3">
+            <ToggleableCreatorsFormGroup v-model="ItemCreators" :refcode="Refcode" />
+          </div>
+          <div class="form-group col-6 pb-3">
+            <ToggleableGroupsFormGroup v-model="ItemGroups" :refcode="Refcode" />
+          </div>
+        </div>
+
         <div class="form-row">
           <div class="form-group col-lg-12 col-sm-12">
             <label for="startmat-location">Location</label>
@@ -117,6 +127,8 @@ import FormattedBarCode from "@/components/FormattedBarcode";
 import StyledInput from "@/components/StyledInput";
 import SynthesisInformation from "@/components/SynthesisInformation";
 import ItemRelationshipVisualization from "@/components/ItemRelationshipVisualization";
+import ToggleableCreatorsFormGroup from "@/components/ToggleableCreatorsFormGroup";
+import ToggleableGroupsFormGroup from "@/components/ToggleableGroupsFormGroup";
 
 import AutoComplete from "primevue/autocomplete";
 import { getStartingMaterialList, getEquipmentList } from "@/server_fetch_utils.js";
@@ -135,6 +147,8 @@ export default {
     FormattedBarCode,
     SynthesisInformation,
     SubstanceInformation,
+    ToggleableCreatorsFormGroup,
+    ToggleableGroupsFormGroup,
   },
   props: {
     item_id: { type: String, required: true },
@@ -166,6 +180,8 @@ export default {
     Collections: createComputedSetterForItemField("collections"),
     Refcode: createComputedSetterForItemField("refcode"),
     Status: createComputedSetterForItemField("status"),
+    ItemCreators: createComputedSetterForItemField("creators"),
+    ItemGroups: createComputedSetterForItemField("groups"),
     schema() {
       return this.$store.state.schemas[this.item?.type];
     },

--- a/webapp/src/components/ToggleableCreatorsFormGroup.vue
+++ b/webapp/src/components/ToggleableCreatorsFormGroup.vue
@@ -2,10 +2,11 @@
   <div
     ref="outerdiv"
     class="h-100 form-group clickable"
-    @click="isEditingCreators = !isEditingCreators"
+    data-testid="toggleable-creators"
+    @click="handleClick"
   >
-    <label id="creators" class="clickable">
-      Creators
+    <label class="clickable">
+      {{ label }}
       <font-awesome-icon
         id="edit-icon"
         class="pl-1"
@@ -18,7 +19,7 @@
       <Creators
         v-if="!isEditingCreators"
         :show-names="!value || value.length <= 1"
-        aria-labelledby="creators"
+        :aria-label="label"
         :creators="shadowValue"
       />
       <OnClickOutside
@@ -26,7 +27,7 @@
         :options="{ ignore: [outerDivRef] }"
         @trigger="isEditingCreators = false"
       >
-        <UserSelect v-model="shadowValue" aria-labelledby="creators" multiple @click.stop />
+        <UserSelect v-model="shadowValue" :aria-label="label" multiple @click.stop />
       </OnClickOutside>
     </div>
   </div>
@@ -47,9 +48,13 @@ export default {
     Creators,
     OnClickOutside,
   },
+  inject: {
+    openSharingModal: { default: null },
+  },
   props: {
     refcode: { type: String, required: false, default: null },
     collectionId: { type: String, required: false, default: null },
+    label: { type: String, default: "Creators" },
     modelValue: {
       type: Array,
       required: true,
@@ -127,6 +132,15 @@ export default {
   },
   async mounted() {
     this.outerDivRef = this.$refs.outerdiv; // we need to get the editIcon's ref to be accessible in the template so we can exclude it from the ClickOutside
+  },
+  methods: {
+    handleClick() {
+      if (this.openSharingModal) {
+        this.openSharingModal();
+        return;
+      }
+      this.isEditingCreators = !this.isEditingCreators;
+    },
   },
 };
 </script>

--- a/webapp/src/components/ToggleableGroupsFormGroup.vue
+++ b/webapp/src/components/ToggleableGroupsFormGroup.vue
@@ -2,10 +2,11 @@
   <div
     ref="outerdiv"
     class="h-100 form-group clickable"
-    @click="isEditingGroups = !isEditingGroups"
+    data-testid="toggleable-groups"
+    @click="handleClick"
   >
-    <label id="groups" class="clickable">
-      Shared with Groups (read-only)
+    <label class="clickable">
+      Shared with Groups
       <font-awesome-icon id="edit-icon" class="pl-1" icon="pen" size="xs" :fade="isEditingGroups" />
     </label>
     <div>
@@ -41,6 +42,9 @@ export default {
     GroupSelect,
     FormattedGroupName,
     OnClickOutside,
+  },
+  inject: {
+    openSharingModal: { default: null },
   },
   props: {
     refcode: { type: String, required: false, default: null },
@@ -119,6 +123,15 @@ export default {
   },
   async mounted() {
     this.outerDivRef = this.$refs.outerdiv;
+  },
+  methods: {
+    handleClick() {
+      if (this.openSharingModal) {
+        this.openSharingModal();
+        return;
+      }
+      this.isEditingGroups = !this.isEditingGroups;
+    },
   },
 };
 </script>

--- a/webapp/src/main.js
+++ b/webapp/src/main.js
@@ -70,6 +70,10 @@ import {
   faQuoteRight,
   faLaptopCode,
   faSquareRootAlt,
+  faShareAlt,
+  faUserFriends,
+  faCaretDown,
+  faLock,
 } from "@fortawesome/free-solid-svg-icons";
 import { faPlusSquare } from "@fortawesome/free-regular-svg-icons";
 import { faGithub, faOrcid, faGoogle, faMicrosoft } from "@fortawesome/free-brands-svg-icons";
@@ -140,6 +144,10 @@ library.add(
   faQuoteRight,
   faLaptopCode,
   faSquareRootAlt,
+  faShareAlt,
+  faUserFriends,
+  faCaretDown,
+  faLock,
 );
 
 // import "@uppy/vue"

--- a/webapp/src/views/CollectionPage.vue
+++ b/webapp/src/views/CollectionPage.vue
@@ -11,6 +11,15 @@
     <div class="navbar-nav">
       <a class="nav-item nav-link" href="/">Home</a>
       <ExportDropdown :collection-id="collection_id" item-type="collections" />
+      <a
+        v-if="data_loaded"
+        class="nav-item nav-link"
+        href="#"
+        title="Share this collection"
+        @click.prevent="isSharingModalVisible = true"
+      >
+        <font-awesome-icon icon="share-alt" fixed-width /> Share
+      </a>
       <a class="nav-item nav-link" :href="collectionApiUrl" target="_blank">
         <font-awesome-icon icon="code" fixed-width /> View JSON
       </a>
@@ -34,6 +43,7 @@
   <!-- Item-type header information goes here -->
   <div class="editor-body">
     <CollectionInformation :collection_id="collection_id" />
+    <SharingModal v-model="isSharingModalVisible" :collection-id="collection_id" />
   </div>
 </template>
 
@@ -41,6 +51,7 @@
 import { DialogService } from "@/services/DialogService";
 
 import CollectionInformation from "@/components/CollectionInformation";
+import SharingModal from "@/components/SharingModal.vue";
 import { getCollectionData, saveCollection } from "@/server_fetch_utils";
 import FormattedItemName from "@/components/FormattedItemName.vue";
 import { itemTypes } from "@/resources.js";
@@ -52,8 +63,16 @@ import ExportDropdown from "@/components/ExportDropdown";
 export default {
   components: {
     CollectionInformation,
+    SharingModal,
     FormattedItemName,
     ExportDropdown,
+  },
+  provide() {
+    return {
+      openSharingModal: () => {
+        this.isSharingModalVisible = true;
+      },
+    };
   },
   async beforeRouteLeave(to, from, next) {
     // give warning before leaving the page by the vue router (which would not trigger "beforeunload")
@@ -76,6 +95,7 @@ export default {
     return {
       collection_id: this.$route.params.id,
       data_loaded: false,
+      isSharingModalVisible: false,
       isMenuDropdownVisible: false,
       isLoadingNewBlock: false,
       lastModified: null,

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -62,6 +62,14 @@
         :collection-id="itemType === 'collections' ? item_id : null"
         :item-type="itemType"
       />
+      <a
+        v-if="itemDataLoaded && refcode"
+        class="nav-item nav-link"
+        title="Share this item"
+        @click="isSharingModalVisible = true"
+      >
+        <font-awesome-icon icon="share-alt" fixed-width /> Share
+      </a>
       <a class="nav-item nav-link" :href="itemApiUrl" target="_blank">
         <font-awesome-icon icon="code" fixed-width /> View JSON
       </a>
@@ -176,6 +184,12 @@
       :current-version="item_data.version"
       @version-restored="handleVersionRestored"
     />
+    <SharingModal
+      v-if="refcode && item_id"
+      v-model="isSharingModalVisible"
+      :refcode="refcode"
+      :item-id="item_id"
+    />
   </div>
 </template>
 
@@ -188,6 +202,7 @@ import SelectableFileTree from "@/components/SelectableFileTree";
 import FileList from "@/components/FileList";
 import FileSelectModal from "@/components/FileSelectModal";
 import VersionHistoryModal from "@/components/VersionHistoryModal.vue";
+import SharingModal from "@/components/SharingModal.vue";
 import {
   getItemData,
   getItemByRefcode,
@@ -218,6 +233,7 @@ export default {
     LoginDetails,
     FileSelectModal,
     VersionHistoryModal,
+    SharingModal,
     FormattedItemName,
     BlockTooltip,
     ExportDropdown,
@@ -255,6 +271,7 @@ export default {
       isLoadingNewBlock: false,
       lastModified: null,
       isVersionHistoryVisible: false,
+      isSharingModalVisible: false,
     };
   },
   computed: {

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -65,8 +65,9 @@
       <a
         v-if="itemDataLoaded && refcode"
         class="nav-item nav-link"
+        href="#"
         title="Share this item"
-        @click="isSharingModalVisible = true"
+        @click.prevent="isSharingModalVisible = true"
       >
         <font-awesome-icon icon="share-alt" fixed-width /> Share
       </a>
@@ -237,6 +238,13 @@ export default {
     FormattedItemName,
     BlockTooltip,
     ExportDropdown,
+  },
+  provide() {
+    return {
+      openSharingModal: () => {
+        this.isSharingModalVisible = true;
+      },
+    };
   },
   async beforeRouteLeave(to, from, next) {
     // give warning before leaving the page by the vue router (which would not trigger "beforeunload")


### PR DESCRIPTION
This PR adds a modal for a sharing menu:

<img width="1429" height="751" alt="image" src="https://github.com/user-attachments/assets/3dddd28b-0024-4fb8-a62c-3963709d09d5" />

<img width="1426" height="877" alt="image" src="https://github.com/user-attachments/assets/e8150f62-7f19-48c8-bb60-0dbbecbd69b1" />

Also reorders some input boxes on item pages to unify them with samples/cells.
