### PR TITLE
Enable echem block cache invalidation based on file upload timestamps

### DIFF
--- a/pydatalab/src/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/src/pydatalab/apps/echem/blocks.py
@@ -296,7 +296,7 @@ class CycleBlock(DataBlock):
         parquet_path = cache_location.with_name(cache_location.name + "_cached.bdf.parquet")
         csv_path = cache_location.with_name(cache_location.name + ".bdf.csv")
         return self._load_and_cache_echem(
-            cache_location, parquet_path, csv_path, reload, locations=locations
+            cache_location, parquet_path, csv_path, reload=True, locations=locations
         )
 
     @staticmethod

--- a/pydatalab/src/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/src/pydatalab/apps/echem/blocks.py
@@ -237,7 +237,7 @@ class CycleBlock(DataBlock):
         return raw_df, csv_path
 
     def _load_single(self, file_id: ObjectId, reload: bool) -> tuple[pd.DataFrame, Path | None]:
-        """Parse a single echem file using navani and caches to disk.
+        """Parse a single echem file using navani and cache to disk.
 
         Returns the raw DataFrame and the BDF export path (or None if the source is already BDF
         or export failed).
@@ -272,7 +272,7 @@ class CycleBlock(DataBlock):
             # bdf_url will fall back to linking the source file directly.
             return self._load_and_cache_echem(location, parquet_path, None, reload)
 
-        csv_path = location.with_name(f"{location.stem}.bdf.csv")
+        csv_path = location.with_name(f"{bare_stem}.bdf.csv")
         return self._load_and_cache_echem(location, parquet_path, csv_path, reload)
 
     def _load_multi(
@@ -297,8 +297,7 @@ class CycleBlock(DataBlock):
         csv_path = cache_location.with_name(cache_location.name + ".bdf.csv")
 
         # Check cache age and invalidate based on the most recent source file modification time
-        reload = False
-        if parquet_path.exists():
+        if not reload and parquet_path.exists():
             cache_age = parquet_path.stat().st_mtime
             source_ages = [
                 file_info["last_modified"].timestamp()

--- a/pydatalab/src/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/src/pydatalab/apps/echem/blocks.py
@@ -80,7 +80,6 @@ class CycleBlock(DataBlock):
     }
 
     def _get_characteristic_mass_g(self):
-        # return {"characteristic_mass": 1000}
         doc = flask_mongo.db.items.find_one(
             {"item_id": self.data["item_id"]}, {"characteristic_mass": 1}
         )
@@ -238,7 +237,7 @@ class CycleBlock(DataBlock):
         return raw_df, csv_path
 
     def _load_single(self, file_id: ObjectId, reload: bool) -> tuple[pd.DataFrame, Path | None]:
-        """Parse a single echem file using navani, with pickle caching.
+        """Parse a single echem file using navani and caches to disk.
 
         Returns the raw DataFrame and the BDF export path (or None if the source is already BDF
         or export failed).
@@ -253,18 +252,26 @@ class CycleBlock(DataBlock):
         ext = self._get_file_extension(filename)
         location = Path(file_info["location"])
         bare_stem = Path(filename).stem.removesuffix(".bdf")
+        parquet_path = location.with_name(f"{bare_stem}_cached.bdf.parquet")
+
+        if (
+            parquet_path.exists()
+            and file_info["last_modified"] is not None
+            and parquet_path.stat().st_mtime < file_info["last_modified"].timestamp()
+        ):
+            LOGGER.debug("Cache is older than source file for %s, forcing reload=True", filename)
+            reload = True
+
         if ext == ".bdf.parquet":
             # Source is already parquet: generate a .bdf.csv for download alongside it.
             # The parquet cache uses a _cached suffix to avoid overwriting the source.
-            parquet_path = location.with_name(f"{bare_stem}_cached.bdf.parquet")
             csv_path = location.with_name(f"{bare_stem}.bdf.csv")
             return self._load_and_cache_echem(location, parquet_path, csv_path, reload)
         if ext.startswith(".bdf"):
             # Other BDF formats: cache to parquet but don't write a redundant .bdf.csv.
             # bdf_url will fall back to linking the source file directly.
-            parquet_path = location.with_name(f"{bare_stem}_cached.bdf.parquet")
             return self._load_and_cache_echem(location, parquet_path, None, reload)
-        parquet_path = location.with_name(f"{location.stem}_cached.bdf.parquet")
+
         csv_path = location.with_name(f"{location.stem}.bdf.csv")
         return self._load_and_cache_echem(location, parquet_path, csv_path, reload)
 
@@ -390,11 +397,7 @@ class CycleBlock(DataBlock):
             self.data["file_ids"] = file_ids
 
         else:
-            if "file_ids" not in self.data:
-                LOGGER.warning("No file_ids given, skipping plot.")
-                return
-            if self.data["file_ids"] is None or len(self.data["file_ids"]) == 0:
-                LOGGER.warning("Empty file_ids list given, skipping plot.")
+            if not self.data.get("file_ids", []):
                 return
 
             file_ids = self.data["file_ids"]
@@ -402,7 +405,7 @@ class CycleBlock(DataBlock):
         derivative_modes = (None, "dQ/dV", "dV/dQ", "final capacity")
 
         if self.data["derivative_mode"] not in derivative_modes:
-            LOGGER.warning(
+            warnings.warn(
                 "Invalid derivative_mode provided: %s. Expected one of %s. Falling back to `None`.",
                 self.data["derivative_mode"],
                 derivative_modes,
@@ -426,7 +429,7 @@ class CycleBlock(DataBlock):
             self.data["mode"] = "single"
 
         # Single/multi mode gets a single dataframe - returned as a dict for consistency
-        if self.data.get("mode") == "multi" or self.data.get("mode") == "single":
+        if self.data.get("mode") in ("multi", "single"):
             file_info = get_file_info_by_id(file_ids[0], update_if_live=True)
             filename = file_info["name"]
             raw_df, cycle_summary_df, bdf_path, first_file_id = self._load(

--- a/pydatalab/src/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/src/pydatalab/apps/echem/blocks.py
@@ -295,8 +295,21 @@ class CycleBlock(DataBlock):
         cache_location = locations[0].parent / f"merged_{cache_key}"
         parquet_path = cache_location.with_name(cache_location.name + "_cached.bdf.parquet")
         csv_path = cache_location.with_name(cache_location.name + ".bdf.csv")
+
+        # Check cache age and invalidate based on the most recent source file modification time
+        reload = False
+        if parquet_path.exists():
+            cache_age = parquet_path.stat().st_mtime
+            source_ages = [
+                file_info["last_modified"].timestamp()
+                for file_info in file_infos
+                if file_info["last_modified"]
+            ]
+            if source_ages and cache_age < max(source_ages):
+                reload = True
+
         return self._load_and_cache_echem(
-            cache_location, parquet_path, csv_path, reload=True, locations=locations
+            cache_location, parquet_path, csv_path, reload=reload, locations=locations
         )
 
     @staticmethod

--- a/pydatalab/src/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/src/pydatalab/apps/echem/blocks.py
@@ -419,9 +419,7 @@ class CycleBlock(DataBlock):
 
         if self.data["derivative_mode"] not in derivative_modes:
             warnings.warn(
-                "Invalid derivative_mode provided: %s. Expected one of %s. Falling back to `None`.",
-                self.data["derivative_mode"],
-                derivative_modes,
+                f"Invalid derivative_mode provided: {self.data['derivative_mode']}. Expected one of {derivative_modes}. Falling back to `None`."
             )
             self.data["derivative_mode"] = None
 

--- a/pydatalab/tests/server/conftest.py
+++ b/pydatalab/tests/server/conftest.py
@@ -35,7 +35,12 @@ def database(real_mongo_client):
 
 
 @pytest.fixture(scope="session")
-def app_config(tmp_path_factory, secret_key):
+def files_directory(tmp_path_factory):
+    return tmp_path_factory.mktemp("files")
+
+
+@pytest.fixture(scope="session")
+def app_config(secret_key, files_directory):
     example_remotes = [
         {
             "name": "example_data",
@@ -51,7 +56,7 @@ def app_config(tmp_path_factory, secret_key):
     yield {
         "MONGO_URI": MONGO_URI,
         "REMOTE_FILESYSTEMS": example_remotes,
-        "FILE_DIRECTORY": str(tmp_path_factory.mktemp("files")),
+        "FILE_DIRECTORY": str(files_directory),
         "TESTING": False,
         "ROOT_PATH": "/",
         "SECRET_KEY": secret_key,

--- a/pydatalab/tests/server/test_blocks.py
+++ b/pydatalab/tests/server/test_blocks.py
@@ -1,6 +1,8 @@
+import datetime
 from pathlib import Path
 
 import pytest
+from bson import ObjectId
 
 from pydatalab.apps import BLOCK_TYPES, BLOCKS
 
@@ -261,7 +263,9 @@ def test_uvvis_block_lifecycle(admin_client, default_sample_dict, example_data_d
     assert web_block.get("errors") is None
 
 
-def test_echem_block_lifecycle(admin_client, default_sample_dict, example_data_dir):
+def test_echem_block_lifecycle(
+    admin_client, default_sample_dict, example_data_dir, files_directory, database
+):
     block_type = "cycle"
 
     sample_id = f"test_sample_with_files-{block_type}-lifecycle"
@@ -356,6 +360,45 @@ def test_echem_block_lifecycle(admin_client, default_sample_dict, example_data_d
     assert "bokeh_plot_data" in web_block
     assert web_block["bokeh_plot_data"] is not None
     assert web_block.get("errors") is None
+
+    # Now back to single mode on a single file
+    block_data = item_data["blocks_obj"][block_id]
+    block_data["mode"] = "single"
+    block_data["file_ids"] = [example_file_ids[0]]
+    block_data["comparison_file_ids"] = []
+
+    response = admin_client.post("/update-block/", json={"block_data": block_data})
+    assert response.status_code == 200
+    web_block = response.json["new_block_data"]
+
+    # Check the cache exists
+    expected_cache_loc = (
+        files_directory
+        / example_file_ids[0]
+        / (str(example_files[0].stem.removesuffix(".mpr") + "_cached.bdf.parquet"))
+    )
+    assert expected_cache_loc.exists()
+    mtime = expected_cache_loc.stat().st_mtime
+    update = database.files.update_one(
+        {"_id": ObjectId(example_file_ids[0])},
+        {"$set": {"last_modified": datetime.datetime.now(tz=datetime.timezone.utc).isoformat()}},
+    )
+    assert update.modified_count == 1, "Failed to update file last_modified in database"
+
+    # Try to update the block again with the same file - should trigger a cache refresh and update the mtime
+    block_data = item_data["blocks_obj"][block_id]
+    block_data["mode"] = "single"
+    block_data["file_ids"] = [example_file_ids[0]]
+    block_data["comparison_file_ids"] = []
+
+    response = admin_client.post("/update-block/", json={"block_data": block_data})
+    assert response.status_code == 200
+    web_block = response.json["new_block_data"]
+
+    # Check the cache exists
+    assert expected_cache_loc.exists()
+    new_mtime = expected_cache_loc.stat().st_mtime
+    assert new_mtime > mtime, "Cache file was not updated on block update with same file"
 
 
 def test_xrd_block_lifecycle(admin_client, client, user_id, default_sample_dict, example_data_dir):


### PR DESCRIPTION
This PR updates the single file mode of the echem block to allow the parquet cache to be invalidated if the underlying source file has changed. Ideally, we would store the hash at time of block creation and directly compare to the new hash, but for now we can just check the `mtime` of the cache vs the database last_modified time of the file.

Also does a bit of associated tidying to the echem block.

Closes #1745 for the one async block we have, for now...