### PR TITLE
Handle block cleanup when gridfs file has been dereferenced

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/blocks.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/blocks.py
@@ -186,9 +186,7 @@ def _cleanup_stale_tasks():
                     bucket.delete(grid_file._id)
                     deleted_files += 1
                 except Exception as e:
-                    LOGGER.error(
-                        "Error deleting GridFS file for task %s: %s", task_id, str(e)
-                    )
+                    LOGGER.error("Error deleting GridFS file for task %s: %s", task_id, str(e))
 
         # Delete the task documents
         result = flask_mongo.db.tasks.delete_many(

--- a/pydatalab/src/pydatalab/routes/v0_1/blocks.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/blocks.py
@@ -182,8 +182,13 @@ def _cleanup_stale_tasks():
         deleted_files = 0
         for task_id in task_ids:
             for grid_file in bucket.find({"filename": task_id}):
-                bucket.delete(grid_file._id)
-                deleted_files += 1
+                try:
+                    bucket.delete(grid_file._id)
+                    deleted_files += 1
+                except Exception as e:
+                    LOGGER.error(
+                        "Error deleting GridFS file for task %s: %s", task_id, str(e)
+                    )
 
         # Delete the task documents
         result = flask_mongo.db.tasks.delete_many(


### PR DESCRIPTION
Have been seeing some log entries where the gridfs bucket is not found (i.e., it has already been removed). This PR simply continues and cleans up the task.

We may need an extra clean up task (manual) to clear grid fs infrequently too.