### PR TITLE
Improvements to ELN export: capture other file reprs and report progress to UI

### DIFF
--- a/pydatalab/src/pydatalab/config.py
+++ b/pydatalab/src/pydatalab/config.py
@@ -198,6 +198,11 @@ class ServerConfig(BaseSettings):
         description="Whether the Flask app is being deployed behind a reverse proxy. If `True`, the reverse proxy middleware described in the [Flask docs](https://flask.palletsprojects.com/en/2.2.x/deploying/proxy_fix/) will be attached to the app.",
     )
 
+    USE_X_ACCEL_REDIRECT: bool = Field(
+        False,
+        description="Whether to offload large file/export downloads to the reverse proxy via the `X-Accel-Redirect` header rather than streaming them through a Flask worker. Requires an **nginx** proxy with a matching `internal` location; leave `False` for other proxies (Caddy, traefik) or when running without a proxy.",
+    )
+
     GITHUB_ORG_ALLOW_LIST: list[str] | None = Field(
         [],
         description="A list of GitHub organization IDs (available from `https://api.github.com/orgs/<org_name>`, and are immutable) or organisation names (which can change, so be warned), that the membership of which will be required to register a new datalab account. Setting the value to `None` will allow any GitHub user to register an account.",

--- a/pydatalab/src/pydatalab/export.py
+++ b/pydatalab/src/pydatalab/export.py
@@ -83,24 +83,31 @@ def write_eln_file(
         items: List of items to include in the ELN file, with all metadata and file info included.
         info: Metadata for the collection (or item) being exported.
         output_path: Path where the .eln file should be saved.
-        on_stage: Optional :data:`StageCallback` invoked with a progress message
+        on_stage: Optional `StageCallback` invoked with a progress message
             as each entry is archived.
-        primary_key: The primary key field to use for item folders (default: "item_id", but "refcode" is more user-friendly and stable)
+        primary_key: The item field used to key item folders in the archive
+            (`"item_id"` by default, the human-friendly identifier, or
+            `"refcode"` for stable, immutable identifiers).
 
     """
 
     total = len(items)
     root_folder = Path(root_folder_name)
 
-    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_STORED) as zipf:
         ro_crate_metadata = generate_ro_crate_metadata(info, items, primary_key=primary_key)
         zipf.writestr(
             str(root_folder / "ro-crate-metadata.json"),
             json.dumps(ro_crate_metadata, ensure_ascii=False, indent=2),
         )
 
+        # Emit ~10 progress stages across the whole export regardless of size, so
+        # the stored `stages` list stays small (and well clear of MongoDB's 16MB
+        # document limit) for large collections.
+        stage_interval = max(1, total // 10)
+
         for ind, item in enumerate(items):
-            if on_stage is not None:
+            if on_stage is not None and (ind % stage_interval == 0 or ind == total - 1):
                 on_stage(f"Archiving entry {ind + 1}/{total}: {item[primary_key]}")
 
             item_folder = root_folder / item[primary_key]
@@ -316,10 +323,10 @@ def create_eln_file(
         output_path: Path where the .eln file should be saved
         item_id: ID of the item to export
         related_item_ids: List of related item IDs to include in the export.
-        on_stage: Optional :data:`StageCallback` invoked with progress messages
+        on_stage: Optional `StageCallback` invoked with progress messages
             as the export proceeds.
         primary_key: The item field used to key item folders in the archive
-            (``"item_id"`` by default, or ``"refcode"`` for stable identifiers).
+            (`"item_id"` by default, or `"refcode"` for stable identifiers).
 
     """
     if not collection_id and not item_id:

--- a/pydatalab/src/pydatalab/export.py
+++ b/pydatalab/src/pydatalab/export.py
@@ -23,6 +23,44 @@ from pydatalab.routes.v0_1.items import (
 
 __all__ = ("generate_ro_crate_metadata", "create_eln_file")
 
+ALTERNATIVE_REPRESENTATION_PATTERNS: tuple[str, ...] = ("*.bdf.parquet",)
+"""Glob patterns for alternative/derived representations of an uploaded file.
+
+Each uploaded file lives in its own directory keyed by its database ID, and some
+blocks write derived representations of the data alongside the original (for
+example, the echem block writes a ``*.bdf.parquet`` cache next to the source
+file). Any sibling matching one of these patterns is included in the export and
+described as a file in its own right. Extend this tuple to capture further
+representation formats.
+"""
+
+
+def find_alternative_representations(source_path: Path) -> list[Path]:
+    """Find alternative representation files stored alongside ``source_path``.
+
+    Looks in the same directory as the file for siblings matching any of the
+    configured :data:`ALTERNATIVE_REPRESENTATION_PATTERNS`, excluding the source
+    file itself.
+
+    Parameters:
+        source_path: The on-disk location of the original uploaded file.
+
+    Returns:
+        A sorted, de-duplicated list of matching sibling paths.
+
+    """
+    file_dir = source_path.parent
+    matches: list[Path] = []
+    seen: set[Path] = set()
+    for pattern in ALTERNATIVE_REPRESENTATION_PATTERNS:
+        for match in file_dir.glob(pattern):
+            if match == source_path or match in seen or not match.is_file():
+                continue
+            seen.add(match)
+            matches.append(match)
+
+    return sorted(matches)
+
 
 def write_eln_file(root_folder_name, items, info, output_path) -> None:
     """Write an ELN file to disk containing the given items and collection metadata.
@@ -60,6 +98,10 @@ def write_eln_file(root_folder_name, items, info, output_path) -> None:
                 if source_path.exists():
                     dest_file = item_folder / file["name"]
                     shutil.copy2(source_path, dest_file)
+
+                    # Include any alternative representations stored alongside the file.
+                    for alt in find_alternative_representations(source_path):
+                        shutil.copy2(alt, item_folder / alt.name)
                 else:
                     LOGGER.warning("ELN export: File not found on disk: %s", file["location"])
 
@@ -178,6 +220,25 @@ def generate_ro_crate_metadata(collection_data: dict, child_items: list[dict]) -
                 file_metadata["dateCreated"] = file["last_modified"].isoformat()
 
             files_metadata.append(file_metadata)
+
+            # Describe any alternative representations stored alongside the file.
+            if file.get("location"):
+                for alt in find_alternative_representations(Path(file["location"])):
+                    alt_id = f"./{item['refcode']}/{alt.name}"
+                    files.append({"@id": alt_id})
+
+                    alt_metadata = {
+                        "@id": alt_id,
+                        "@type": "File",
+                        "contentSize": alt.stat().st_size,
+                        "name": alt.name,
+                        "description": f"Alternative representation of {file['name']}",
+                    }
+
+                    alt_mtime = datetime.fromtimestamp(alt.stat().st_mtime, tz=timezone.utc)
+                    alt_metadata["dateCreated"] = alt_mtime.isoformat()
+
+                    files_metadata.append(alt_metadata)
 
         # Add file for datalab metadata
         item_metadata_file = {

--- a/pydatalab/src/pydatalab/export.py
+++ b/pydatalab/src/pydatalab/export.py
@@ -198,7 +198,7 @@ def generate_ro_crate_metadata(collection_data: dict, child_items: list[dict]) -
     people = {}
 
     for item in child_items:
-        identifier = f"{CONFIG.IDENTIFIER_PREFIX}:{item['refcode']}"
+        identifier = item["refcode"]
 
         item_metadata = {
             "@id": f"./{item['refcode']}/",

--- a/pydatalab/src/pydatalab/export.py
+++ b/pydatalab/src/pydatalab/export.py
@@ -71,7 +71,9 @@ def find_alternative_representations(source_path: Path) -> list[Path]:
     return sorted(matches)
 
 
-def write_eln_file(root_folder_name, items, info, output_path, on_stage=None) -> None:
+def write_eln_file(
+    root_folder_name, items, info, output_path, on_stage=None, primary_key="item_id"
+) -> None:
     """Write an ELN file to disk containing the given items and collection metadata.
     Will first write to an intermediate temporary directory.
 
@@ -82,6 +84,7 @@ def write_eln_file(root_folder_name, items, info, output_path, on_stage=None) ->
         output_path: Path where the .eln file should be saved.
         on_stage: Optional :data:`StageCallback` invoked with a progress message
             as each entry is archived.
+        primary_key: The primary key field to use for item folders (default: "item_id", but "refcode" is more user-friendly and stable)
 
     """
 
@@ -93,15 +96,15 @@ def write_eln_file(root_folder_name, items, info, output_path, on_stage=None) ->
         root_folder = temp_path / root_folder_name
         root_folder.mkdir()
 
-        ro_crate_metadata = generate_ro_crate_metadata(info, items)
+        ro_crate_metadata = generate_ro_crate_metadata(info, items, primary_key=primary_key)
         with open(root_folder / "ro-crate-metadata.json", "w", encoding="utf-8") as f:
             json.dump(ro_crate_metadata, f, ensure_ascii=False)
 
         for ind, item in enumerate(items):
             if on_stage is not None:
-                on_stage(f"Archiving entry {ind + 1}/{total}: {item['refcode']}")
+                on_stage(f"Archiving entry {ind + 1}/{total}: {item[primary_key]}")
 
-            item_folder = root_folder / item["refcode"]
+            item_folder = root_folder / item[primary_key]
             item_folder.mkdir()
 
             item_metadata = ITEM_MODELS[item.get("type")](**item).json(indent=2)
@@ -135,7 +138,9 @@ def write_eln_file(root_folder_name, items, info, output_path, on_stage=None) ->
                     zipf.write(file_path, arcname)
 
 
-def generate_ro_crate_metadata(collection_data: dict, child_items: list[dict]) -> dict:
+def generate_ro_crate_metadata(
+    collection_data: dict, child_items: list[dict], primary_key: str = "item_id"
+) -> dict:
     """Generate RO-Crate metadata for the .eln file.
 
     Parameters:
@@ -150,7 +155,7 @@ def generate_ro_crate_metadata(collection_data: dict, child_items: list[dict]) -
     for item in child_items:
         experiments.append(
             {
-                "@id": f"./{item['refcode']}/",
+                "@id": f"./{item[primary_key]}/",
             }
         )
 
@@ -201,7 +206,7 @@ def generate_ro_crate_metadata(collection_data: dict, child_items: list[dict]) -
         identifier = item["refcode"]
 
         item_metadata = {
-            "@id": f"./{item['refcode']}/",
+            "@id": f"./{item[primary_key]}/",
             "@type": "Dataset",
             "name": item.get("name", item["item_id"]),
             "identifier": identifier,
@@ -229,7 +234,7 @@ def generate_ro_crate_metadata(collection_data: dict, child_items: list[dict]) -
         files = []
         files_metadata: list[dict] = []
         for file in item.get("files", []):
-            file_id = f"./{item['refcode']}/{file['name']}"
+            file_id = f"./{item[primary_key]}/{file['name']}"
             files.append({"@id": file_id})
 
             file_metadata = {
@@ -247,7 +252,7 @@ def generate_ro_crate_metadata(collection_data: dict, child_items: list[dict]) -
             # Describe any alternative representations stored alongside the file.
             if file.get("location"):
                 for alt in find_alternative_representations(Path(file["location"])):
-                    alt_id = f"./{item['refcode']}/{alt.name}"
+                    alt_id = f"./{item[primary_key]}/{alt.name}"
                     files.append({"@id": alt_id})
 
                     alt_metadata = {
@@ -265,11 +270,11 @@ def generate_ro_crate_metadata(collection_data: dict, child_items: list[dict]) -
 
         # Add file for datalab metadata
         item_metadata_file = {
-            "@id": f"./{item['refcode']}/metadata.json",
+            "@id": f"./{item[primary_key]}/metadata.json",
             "@type": "File",
             "name": "metadata.json",
             "encodingFormat": "application/json",
-            "description": f"Metadata for item {item['refcode']}",
+            "description": f"Metadata for item {item['refcode']} / {item['item_id']}",
         }
 
         files.append({"@id": item_metadata_file["@id"]})
@@ -312,6 +317,7 @@ def create_eln_file(
     item_id: str | None = None,
     related_item_ids: list[str] | None = None,
     on_stage: "StageCallback | None" = None,
+    primary_key: str = "item_id",
 ) -> None:
     """Create a .eln file for a collection, item, or set of items.
 
@@ -322,6 +328,8 @@ def create_eln_file(
         related_item_ids: List of related item IDs to include in the export.
         on_stage: Optional :data:`StageCallback` invoked with progress messages
             as the export proceeds.
+        primary_key: The item field used to key item folders in the archive
+            (``"item_id"`` by default, or ``"refcode"`` for stable identifiers).
 
     """
     if not collection_id and not item_id:
@@ -422,4 +430,11 @@ def create_eln_file(
     if on_stage is not None:
         on_stage(f"Resolved {len(all_items)} entries for export")
 
-    write_eln_file(root_folder_name, all_items, collection_data, output_path, on_stage=on_stage)
+    write_eln_file(
+        root_folder_name,
+        all_items,
+        collection_data,
+        output_path,
+        on_stage=on_stage,
+        primary_key=primary_key,
+    )

--- a/pydatalab/src/pydatalab/export.py
+++ b/pydatalab/src/pydatalab/export.py
@@ -286,27 +286,28 @@ def generate_ro_crate_metadata(
         graph.append(item_metadata)
         if files_metadata:
             graph.extend(files_metadata)
-        if people:
-            graph.extend(people.values())
 
-        create_action = {
-            "@id": "#ro-crate-created",
-            "@type": "CreateAction",
-            "object": {"@id": "./"},
-            "endTime": datetime.now(tz=timezone.utc).isoformat(),
-            "instrument": {"@id": "https://datalab-org.io"},
-            "actionStatus": {"@id": "http://schema.org/CompletedActionStatus"},
-        }
+    create_action = {
+        "@id": "#ro-crate-created",
+        "@type": "CreateAction",
+        "object": {"@id": "./"},
+        "endTime": datetime.now(tz=timezone.utc).isoformat(),
+        "instrument": {"@id": "https://datalab-org.io"},
+        "actionStatus": {"@id": "http://schema.org/CompletedActionStatus"},
+    }
 
-        software = {
-            "@id": "https://datalab-org.io",
-            "@type": "SoftwareApplication",
-            "name": "datalab",
-            "version": __version__,
-        }
+    software = {
+        "@id": "https://datalab-org.io",
+        "@type": "SoftwareApplication",
+        "name": "datalab",
+        "version": __version__,
+    }
 
-        graph.append(create_action)
-        graph.append(software)
+    graph.append(create_action)
+    graph.append(software)
+
+    if people:
+        graph.extend(people.values())
 
     return metadata
 

--- a/pydatalab/src/pydatalab/export.py
+++ b/pydatalab/src/pydatalab/export.py
@@ -1,6 +1,5 @@
 """This module implements methods for exporting datalab data
 to other formats, such as .eln files.
-
 """
 
 import json
@@ -97,7 +96,7 @@ def write_eln_file(
         ro_crate_metadata = generate_ro_crate_metadata(info, items, primary_key=primary_key)
         zipf.writestr(
             str(root_folder / "ro-crate-metadata.json"),
-            json.dumps(ro_crate_metadata, ensure_ascii=False),
+            json.dumps(ro_crate_metadata, ensure_ascii=False, indent=2),
         )
 
         for ind, item in enumerate(items):

--- a/pydatalab/src/pydatalab/export.py
+++ b/pydatalab/src/pydatalab/export.py
@@ -4,8 +4,6 @@ to other formats, such as .eln files.
 """
 
 import json
-import shutil
-import tempfile
 import zipfile
 from collections.abc import Callable
 from datetime import datetime, timezone
@@ -75,7 +73,11 @@ def write_eln_file(
     root_folder_name, items, info, output_path, on_stage=None, primary_key="item_id"
 ) -> None:
     """Write an ELN file to disk containing the given items and collection metadata.
-    Will first write to an intermediate temporary directory.
+
+    Each entry is streamed directly into the output zip archive as it is
+    processed, rather than first being staged in an intermediate directory.
+    This avoids copying every uploaded file twice and keeping a second full copy
+    of the export on disk.
 
     Parameters:
         root_folder_name: The name of the root folder in the ELN file.
@@ -89,38 +91,32 @@ def write_eln_file(
     """
 
     total = len(items)
+    root_folder = Path(root_folder_name)
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = Path(temp_dir)
-
-        root_folder = temp_path / root_folder_name
-        root_folder.mkdir()
-
+    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zipf:
         ro_crate_metadata = generate_ro_crate_metadata(info, items, primary_key=primary_key)
-        with open(root_folder / "ro-crate-metadata.json", "w", encoding="utf-8") as f:
-            json.dump(ro_crate_metadata, f, ensure_ascii=False)
+        zipf.writestr(
+            str(root_folder / "ro-crate-metadata.json"),
+            json.dumps(ro_crate_metadata, ensure_ascii=False),
+        )
 
         for ind, item in enumerate(items):
             if on_stage is not None:
                 on_stage(f"Archiving entry {ind + 1}/{total}: {item[primary_key]}")
 
             item_folder = root_folder / item[primary_key]
-            item_folder.mkdir()
 
             item_metadata = ITEM_MODELS[item.get("type")](**item).json(indent=2)
-
-            with open(item_folder / "metadata.json", "w", encoding="utf-8") as f:
-                f.write(item_metadata)
+            zipf.writestr(str(item_folder / "metadata.json"), item_metadata)
 
             for file in item.get("files", []):
                 source_path = Path(file["location"])
                 if source_path.exists():
-                    dest_file = item_folder / file["name"]
-                    shutil.copy2(source_path, dest_file)
+                    zipf.write(source_path, str(item_folder / file["name"]))
 
                     # Include any alternative representations stored alongside the file.
                     for alt in find_alternative_representations(source_path):
-                        shutil.copy2(alt, item_folder / alt.name)
+                        zipf.write(alt, str(item_folder / alt.name))
                 else:
                     LOGGER.warning("ELN export: File not found on disk: %s", file["location"])
                     if on_stage is not None:
@@ -129,13 +125,7 @@ def write_eln_file(
                         )
 
         if on_stage is not None:
-            on_stage(f"Compressing archive of {total} entries")
-
-        with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zipf:
-            for file_path in root_folder.rglob("*"):
-                if file_path.is_file():
-                    arcname = file_path.relative_to(temp_path)
-                    zipf.write(file_path, arcname)
+            on_stage(f"Finished archiving {total} entries")
 
 
 def generate_ro_crate_metadata(

--- a/pydatalab/src/pydatalab/export.py
+++ b/pydatalab/src/pydatalab/export.py
@@ -7,6 +7,7 @@ import json
 import shutil
 import tempfile
 import zipfile
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -22,6 +23,14 @@ from pydatalab.routes.v0_1.items import (
 )
 
 __all__ = ("generate_ro_crate_metadata", "create_eln_file")
+
+StageCallback = Callable[..., None]
+"""A callback invoked with progress messages as the export proceeds.
+
+Called as ``on_stage(message, level="info")`` where ``level`` is one of
+``"info"``, ``"warning"`` or ``"error"``. Used to report per-entry progress back
+to the caller (e.g. to persist stages on the export task).
+"""
 
 ALTERNATIVE_REPRESENTATION_PATTERNS: tuple[str, ...] = ("*.bdf.parquet",)
 """Glob patterns for alternative/derived representations of an uploaded file.
@@ -62,7 +71,7 @@ def find_alternative_representations(source_path: Path) -> list[Path]:
     return sorted(matches)
 
 
-def write_eln_file(root_folder_name, items, info, output_path) -> None:
+def write_eln_file(root_folder_name, items, info, output_path, on_stage=None) -> None:
     """Write an ELN file to disk containing the given items and collection metadata.
     Will first write to an intermediate temporary directory.
 
@@ -71,8 +80,12 @@ def write_eln_file(root_folder_name, items, info, output_path) -> None:
         items: List of items to include in the ELN file, with all metadata and file info included.
         info: Metadata for the collection (or item) being exported.
         output_path: Path where the .eln file should be saved.
+        on_stage: Optional :data:`StageCallback` invoked with a progress message
+            as each entry is archived.
 
     """
+
+    total = len(items)
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
@@ -84,7 +97,10 @@ def write_eln_file(root_folder_name, items, info, output_path) -> None:
         with open(root_folder / "ro-crate-metadata.json", "w", encoding="utf-8") as f:
             json.dump(ro_crate_metadata, f, ensure_ascii=False)
 
-        for item in items:
+        for ind, item in enumerate(items):
+            if on_stage is not None:
+                on_stage(f"Archiving entry {ind + 1}/{total}: {item['refcode']}")
+
             item_folder = root_folder / item["refcode"]
             item_folder.mkdir()
 
@@ -104,6 +120,13 @@ def write_eln_file(root_folder_name, items, info, output_path) -> None:
                         shutil.copy2(alt, item_folder / alt.name)
                 else:
                     LOGGER.warning("ELN export: File not found on disk: %s", file["location"])
+                    if on_stage is not None:
+                        on_stage(
+                            f"File not found on disk, skipping: {file['name']}", level="warning"
+                        )
+
+        if on_stage is not None:
+            on_stage(f"Compressing archive of {total} entries")
 
         with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zipf:
             for file_path in root_folder.rglob("*"):
@@ -288,6 +311,7 @@ def create_eln_file(
     collection_id: str | None = None,
     item_id: str | None = None,
     related_item_ids: list[str] | None = None,
+    on_stage: "StageCallback | None" = None,
 ) -> None:
     """Create a .eln file for a collection, item, or set of items.
 
@@ -296,6 +320,8 @@ def create_eln_file(
         output_path: Path where the .eln file should be saved
         item_id: ID of the item to export
         related_item_ids: List of related item IDs to include in the export.
+        on_stage: Optional :data:`StageCallback` invoked with progress messages
+            as the export proceeds.
 
     """
     if not collection_id and not item_id:
@@ -393,4 +419,7 @@ def create_eln_file(
 
     all_items = _all_items
 
-    write_eln_file(root_folder_name, all_items, collection_data, output_path)
+    if on_stage is not None:
+        on_stage(f"Resolved {len(all_items)} entries for export")
+
+    write_eln_file(root_folder_name, all_items, collection_data, output_path, on_stage=on_stage)

--- a/pydatalab/src/pydatalab/main.py
+++ b/pydatalab/src/pydatalab/main.py
@@ -86,6 +86,15 @@ def create_app(
         # https://flask.palletsprojects.com/en/2.2.x/deploying/proxy_fix/
         app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)  # type: ignore
 
+    if CONFIG.USE_X_ACCEL_REDIRECT and not CONFIG.BEHIND_REVERSE_PROXY:
+        # X-Accel-Redirect hands downloads off to nginx; without a proxy in front
+        # to intercept the header, clients would receive empty-bodied responses.
+        LOGGER.warning(
+            "USE_X_ACCEL_REDIRECT is enabled but BEHIND_REVERSE_PROXY is False: "
+            "file/export downloads will return empty responses unless an nginx "
+            "proxy is configured to honour the X-Accel-Redirect header."
+        )
+
     CORS(
         app,
         resources={r"/*": {"origins": "*"}},

--- a/pydatalab/src/pydatalab/models/tasks.py
+++ b/pydatalab/src/pydatalab/models/tasks.py
@@ -37,6 +37,9 @@ class ExportTaskSpec(TaskSpec):
     item_id: str | None = Field(None, description="Item ID being exported")
     export_type: str = Field(..., description="Type of export: collection/item/graph")
     file_path: str | None = Field(None, description="Path to generated .eln file")
+    stages: list[TaskStage] = Field(
+        default_factory=list, description="Timestamped processing stages"
+    )
 
 
 class BlockProcessingTaskSpec(TaskSpec):

--- a/pydatalab/src/pydatalab/routes/v0_1/export.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/export.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
-from flask import Blueprint, jsonify, request, send_file
+from flask import Blueprint, jsonify, make_response, request, send_file
 from flask_login import current_user
 
 from pydatalab.config import CONFIG
@@ -178,6 +178,51 @@ def get_export_status(task_id: str):
     return jsonify(response), 200
 
 
+# Internal nginx location that aliases the on-disk export directory (see
+# `_do_export`, which writes to `<tempdir>/eln-exports/`). The matching nginx
+# config marks this location `internal;` so clients cannot request it directly:
+#
+#     location /_protected_exports/ {
+#         internal;
+#         alias /tmp/eln-exports/;   # must match the export dir used in _do_export
+#     }
+#
+# Only the basename of the export file is appended, so the alias above is the
+# single source of truth for where the bytes live on disk.
+X_ACCEL_EXPORT_LOCATION = "/_protected_exports"
+
+EXPORT_MIMETYPE = "application/vnd.eln+zip"
+
+
+def _serve_export_file(file_path: str, filename: str):
+    """Return a response that delivers a generated export file to the client.
+
+    When `CONFIG.USE_X_ACCEL_REDIRECT` is enabled (nginx deployments), the
+    gunicorn worker does *not* stream the bytes itself: it returns an empty
+    response carrying an `X-Accel-Redirect` header, and nginx serves the file
+    off disk with kernel sendfile. This frees the worker the instant auth
+    passes, so multi-GB downloads no longer tie up (or time out) a worker.
+
+    Otherwise (dev/test, a non-nginx proxy, or running without a proxy) we fall
+    back to streaming the file directly through Flask with `send_file`.
+    """
+    if CONFIG.USE_X_ACCEL_REDIRECT:
+        # Map the absolute on-disk path to the internal nginx location by
+        # basename; nginx's `alias` resolves it back to the real directory.
+        internal_uri = f"{X_ACCEL_EXPORT_LOCATION}/{Path(file_path).name}"
+
+        response = make_response("")
+        response.headers["X-Accel-Redirect"] = internal_uri
+        response.headers["Content-Type"] = EXPORT_MIMETYPE
+        response.headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+        # Deliberately omit Content-Length: nginx sets it from the file it serves.
+        return response
+
+    return send_file(
+        file_path, as_attachment=True, download_name=filename, mimetype=EXPORT_MIMETYPE
+    )
+
+
 @EXPORT.route("/exports/<string:task_id>/download", methods=["GET"])
 def download_export(task_id: str):
     if not CONFIG.TESTING:
@@ -203,9 +248,7 @@ def download_export(task_id: str):
 
     filename = f"{spec.get('collection_id') or spec.get('item_id')}.eln"
 
-    return send_file(
-        file_path, as_attachment=True, download_name=filename, mimetype="application/vnd.eln+zip"
-    )
+    return _serve_export_file(file_path, filename)
 
 
 @EXPORT.route("/items/<string:item_id>/export", methods=["POST"])

--- a/pydatalab/src/pydatalab/routes/v0_1/export.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/export.py
@@ -9,7 +9,7 @@ from flask_login import current_user
 
 from pydatalab.config import CONFIG
 from pydatalab.export import create_eln_file
-from pydatalab.models.tasks import ExportTaskSpec, Task, TaskStatus, TaskType
+from pydatalab.models.tasks import ExportTaskSpec, Task, TaskStage, TaskStatus, TaskType
 from pydatalab.mongo import flask_mongo
 from pydatalab.permissions import PUBLIC_USER_ID, active_users_or_get_only
 from pydatalab.scheduler import task_scheduler
@@ -37,6 +37,12 @@ def _do_export(
     export_type: str = "collection",
     related_item_ids: list[str] | None = None,
 ):
+    def add_stage(message: str, level: str = "info"):
+        stage = TaskStage(timestamp=datetime.now(tz=timezone.utc), message=message, level=level)
+        flask_mongo.db.tasks.update_one(
+            {"task_id": task_id}, {"$push": {"spec.stages": stage.dict()}}
+        )
+
     try:
         flask_mongo.db.tasks.update_one(
             {"task_id": task_id}, {"$set": {"status": TaskStatus.PROCESSING}}
@@ -48,9 +54,14 @@ def _do_export(
         output_path = export_dir / f"{task_id}.eln"
 
         if export_type == "collection":
-            create_eln_file(str(output_path), collection_id=collection_id)
+            create_eln_file(str(output_path), collection_id=collection_id, on_stage=add_stage)
         elif export_type in ["item", "graph"]:
-            create_eln_file(str(output_path), item_id=item_id, related_item_ids=related_item_ids)
+            create_eln_file(
+                str(output_path),
+                item_id=item_id,
+                related_item_ids=related_item_ids,
+                on_stage=add_stage,
+            )
 
         flask_mongo.db.tasks.update_one(
             {"task_id": task_id},
@@ -148,6 +159,9 @@ def get_export_status(task_id: str):
         "status": task["status"],
         "created_at": task["created_at"].isoformat() if task.get("created_at") else None,
     }
+
+    if task.get("spec", {}).get("stages"):
+        response["stages"] = task["spec"]["stages"]
 
     if task["status"] == TaskStatus.READY:
         response["download_url"] = f"/exports/{task_id}/download"

--- a/pydatalab/src/pydatalab/routes/v0_1/export.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/export.py
@@ -34,6 +34,24 @@ def _export_dir() -> Path:
     return Path(tempfile.gettempdir()) / "eln-exports"
 
 
+def _is_export_path_safe(file_path: str, task_id: str) -> bool:
+    """Whether a task's stored ``file_path`` is a legitimate generated export.
+
+    Defends :func:`download_export` and :func:`_cleanup_old_exports` against
+    serving or deleting arbitrary local files should a task document become
+    corrupted or tampered with. Generated exports are always written as
+    ``<export_dir>/<task_id>.eln`` (see :func:`_do_export`), so the resolved
+    path must match that location *exactly* — both the directory and the random
+    per-task ``<task_id>.eln`` basename — so a path such as
+    ``/some/other/dir/<task_id>.eln`` or ``/etc/passwd`` is rejected.
+    """
+    try:
+        expected = (_export_dir() / f"{task_id}.eln").resolve()
+        return Path(file_path).resolve() == expected
+    except (OSError, ValueError, RuntimeError):
+        return False
+
+
 @EXPORT.record_once
 def _register_app(state):
     global _app
@@ -72,7 +90,13 @@ def _cleanup_old_exports():
         for task in old_tasks:
             task_ids.append(task["task_id"])
             file_path = task.get("spec", {}).get("file_path")
-            if file_path:
+            if file_path and not _is_export_path_safe(file_path, task["task_id"]):
+                LOGGER.warning(
+                    "Refusing to remove unexpected export path %s for task %s",
+                    file_path,
+                    task["task_id"],
+                )
+            elif file_path:
                 try:
                     os.remove(file_path)
                     deleted_files += 1
@@ -311,7 +335,11 @@ def download_export(task_id: str):
 
     spec = task.get("spec", {})
     file_path = spec.get("file_path")
-    if not file_path or not os.path.exists(file_path):
+    if (
+        not file_path
+        or not _is_export_path_safe(file_path, task_id)
+        or not os.path.exists(file_path)
+    ):
         return jsonify({"status": "error", "message": "Export file not found"}), 404
 
     filename = f"{spec.get('collection_id') or spec.get('item_id')}.eln"

--- a/pydatalab/src/pydatalab/routes/v0_1/export.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/export.py
@@ -1,7 +1,8 @@
+import contextlib
 import os
 import tempfile
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from flask import Blueprint, jsonify, make_response, request, send_file
@@ -9,6 +10,7 @@ from flask_login import current_user
 
 from pydatalab.config import CONFIG
 from pydatalab.export import create_eln_file
+from pydatalab.logger import LOGGER
 from pydatalab.models.tasks import ExportTaskSpec, Task, TaskStage, TaskStatus, TaskType
 from pydatalab.mongo import flask_mongo
 from pydatalab.permissions import PUBLIC_USER_ID, active_users_or_get_only
@@ -18,11 +20,79 @@ EXPORT = Blueprint("export", __name__)
 
 _app = None
 
+EXPORT_MAX_AGE_HOURS = 24
+"""Generated `.eln` files (and their export tasks) are purged this many hours
+after creation by the periodic :func:`_cleanup_old_exports` job."""
+
+
+def _export_dir() -> Path:
+    """The directory in which generated `.eln` files are stored.
+
+    Single source of truth shared by export generation, the cleanup job, and
+    (by convention) the nginx alias in :data:`X_ACCEL_EXPORT_LOCATION`.
+    """
+    return Path(tempfile.gettempdir()) / "eln-exports"
+
 
 @EXPORT.record_once
 def _register_app(state):
     global _app
     _app = state.app
+
+    task_scheduler.add_periodic_job(
+        func=_cleanup_old_exports,
+        job_id="export_file_cleanup",
+        hours=EXPORT_MAX_AGE_HOURS,
+    )
+    LOGGER.info("Registered export cleanup job (every %d hours)", EXPORT_MAX_AGE_HOURS)
+
+
+def _cleanup_old_exports():
+    """Periodic cleanup of generated `.eln` exports older than the max age.
+
+    Runs on an interval via APScheduler. Deletes any export task whose file is
+    older than :data:`EXPORT_MAX_AGE_HOURS`, removing both the on-disk `.eln`
+    file and the task document. Idempotent and safe to run per-worker.
+    """
+    app_ctx = _app.app_context() if _app else contextlib.nullcontext()
+
+    with app_ctx:
+        age_cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=EXPORT_MAX_AGE_HOURS)
+
+        old_tasks = flask_mongo.db.tasks.find(
+            {
+                "type": TaskType.EXPORT,
+                "created_at": {"$lt": age_cutoff},
+            },
+            {"task_id": 1, "spec.file_path": 1},
+        )
+
+        deleted_files = 0
+        task_ids = []
+        for task in old_tasks:
+            task_ids.append(task["task_id"])
+            file_path = task.get("spec", {}).get("file_path")
+            if file_path:
+                try:
+                    os.remove(file_path)
+                    deleted_files += 1
+                except FileNotFoundError:
+                    pass
+                except OSError as exc:
+                    LOGGER.warning("Could not remove export file %s: %s", file_path, exc)
+
+        if not task_ids:
+            return
+
+        result = flask_mongo.db.tasks.delete_many(
+            {"task_id": {"$in": task_ids}, "type": TaskType.EXPORT}
+        )
+
+        LOGGER.info(
+            "Cleaned up %d old export tasks and %d export files",
+            result.deleted_count,
+            deleted_files,
+        )
 
 
 @EXPORT.before_request
@@ -48,7 +118,7 @@ def _do_export(
             {"task_id": task_id}, {"$set": {"status": TaskStatus.PROCESSING}}
         )
 
-        export_dir = Path(tempfile.gettempdir()) / "eln-exports"
+        export_dir = _export_dir()
         export_dir.mkdir(exist_ok=True, parents=True)
 
         output_path = export_dir / f"{task_id}.eln"
@@ -94,8 +164,6 @@ def _generate_export_in_background(
     export_type: str = "collection",
     related_item_ids: list[str] | None = None,
 ):
-    import contextlib
-
     app_ctx = _app.app_context() if _app is not None else contextlib.nullcontext()
     with app_ctx:
         _do_export(task_id, collection_id, item_id, export_type, related_item_ids)

--- a/pydatalab/tests/server/test_export.py
+++ b/pydatalab/tests/server/test_export.py
@@ -158,7 +158,12 @@ def test_get_export_status_not_found(client):
     assert "not found" in data["message"].lower()
 
 
-def test_download_export_success(client, user_id, database, tmp_path):
+def test_download_export_success(client, user_id, database, tmp_path, monkeypatch):
+    import pydatalab.routes.v0_1.export as export_routes
+
+    # Point the export dir at tmp_path so the file passes _is_export_path_safe.
+    monkeypatch.setattr(export_routes, "_export_dir", lambda: tmp_path)
+
     task_id = "test-download-task"
     collection_id = "test_collection"
     file_path = tmp_path / f"{task_id}.eln"
@@ -333,12 +338,16 @@ def test_do_export_error_handling(database, user_id):
     database.tasks.delete_one({"task_id": task_id})
 
 
-def test_cleanup_old_exports(database, user_id, tmp_path):
+def test_cleanup_old_exports(database, user_id, tmp_path, monkeypatch):
     """The periodic cleanup should delete export tasks (and their .eln files)
     older than EXPORT_MAX_AGE_HOURS, while leaving recent ones untouched."""
     from datetime import timedelta
 
+    import pydatalab.routes.v0_1.export as export_routes
     from pydatalab.routes.v0_1.export import EXPORT_MAX_AGE_HOURS, _cleanup_old_exports
+
+    # Point the export dir at tmp_path so files pass _is_export_path_safe.
+    monkeypatch.setattr(export_routes, "_export_dir", lambda: tmp_path)
 
     now = datetime.now(tz=timezone.utc)
 

--- a/pydatalab/tests/server/test_export.py
+++ b/pydatalab/tests/server/test_export.py
@@ -333,6 +333,95 @@ def test_do_export_error_handling(database, user_id):
     database.tasks.delete_one({"task_id": task_id})
 
 
+def test_cleanup_old_exports(database, user_id, tmp_path):
+    """The periodic cleanup should delete export tasks (and their .eln files)
+    older than EXPORT_MAX_AGE_HOURS, while leaving recent ones untouched."""
+    from datetime import timedelta
+
+    from pydatalab.routes.v0_1.export import EXPORT_MAX_AGE_HOURS, _cleanup_old_exports
+
+    now = datetime.now(tz=timezone.utc)
+
+    # An old export: created beyond the max age, with a file still on disk.
+    old_task_id = "old-export-to-clean"
+    old_file = tmp_path / f"{old_task_id}.eln"
+    old_file.write_bytes(b"old export content")
+    old_task = Task(
+        type=TaskType.EXPORT,
+        task_id=old_task_id,
+        creator_id=user_id,
+        status=TaskStatus.READY,
+        created_at=now - timedelta(hours=EXPORT_MAX_AGE_HOURS + 1),
+        spec=ExportTaskSpec(
+            collection_id="test_collection",
+            export_type="collection",
+            file_path=str(old_file),
+        ),
+    )
+    database.tasks.insert_one(old_task.dict())
+
+    # A recent export: created within the window, must be retained.
+    recent_task_id = "recent-export-to-keep"
+    recent_file = tmp_path / f"{recent_task_id}.eln"
+    recent_file.write_bytes(b"recent export content")
+    recent_task = Task(
+        type=TaskType.EXPORT,
+        task_id=recent_task_id,
+        creator_id=user_id,
+        status=TaskStatus.READY,
+        created_at=now - timedelta(hours=1),
+        spec=ExportTaskSpec(
+            collection_id="test_collection",
+            export_type="collection",
+            file_path=str(recent_file),
+        ),
+    )
+    database.tasks.insert_one(recent_task.dict())
+
+    try:
+        _cleanup_old_exports()
+
+        # Old task and its file are gone.
+        assert database.tasks.find_one({"task_id": old_task_id}) is None
+        assert not old_file.exists()
+
+        # Recent task and its file remain.
+        assert database.tasks.find_one({"task_id": recent_task_id}) is not None
+        assert recent_file.exists()
+
+    finally:
+        database.tasks.delete_one({"task_id": old_task_id})
+        database.tasks.delete_one({"task_id": recent_task_id})
+
+
+def test_cleanup_old_exports_missing_file(database, user_id):
+    """Cleanup should still purge an old task whose .eln file is already gone."""
+    from datetime import timedelta
+
+    from pydatalab.routes.v0_1.export import EXPORT_MAX_AGE_HOURS, _cleanup_old_exports
+
+    task_id = "old-export-missing-file"
+    task = Task(
+        type=TaskType.EXPORT,
+        task_id=task_id,
+        creator_id=user_id,
+        status=TaskStatus.READY,
+        created_at=datetime.now(tz=timezone.utc) - timedelta(hours=EXPORT_MAX_AGE_HOURS + 1),
+        spec=ExportTaskSpec(
+            collection_id="test_collection",
+            export_type="collection",
+            file_path="/nonexistent/already-deleted.eln",
+        ),
+    )
+    database.tasks.insert_one(task.dict())
+
+    try:
+        _cleanup_old_exports()
+        assert database.tasks.find_one({"task_id": task_id}) is None
+    finally:
+        database.tasks.delete_one({"task_id": task_id})
+
+
 def test_do_export_status_transitions(database, sample_collection, user_id):
     from pydatalab.routes.v0_1.export import _do_export
 

--- a/pydatalab/tests/server/test_export_utils.py
+++ b/pydatalab/tests/server/test_export_utils.py
@@ -50,7 +50,90 @@ def test_generate_ro_crate_metadata():
     sample1 = next(item for item in metadata["@graph"] if item["@id"] == "./sample1/")
     assert sample1["@type"] == "Dataset"
     assert sample1["name"] == "Sample 1"
-    assert sample1["identifier"] == "test:sample1"
+    assert sample1["identifier"] == "sample1"
+
+
+def _people_sharing_items(num_items, creator_id):
+    """Build ``num_items`` child items that all share a single creator."""
+    return [
+        {
+            "item_id": f"sample{i}",
+            "name": f"Sample {i}",
+            "refcode": f"test:CODE{i}",
+            "creators": [{"display_name": "Shared Creator", "immutable_id": creator_id}],
+        }
+        for i in range(num_items)
+    ]
+
+
+def test_ro_crate_people_not_duplicated():
+    """A creator shared across many items should appear exactly once in the graph."""
+    creator_id = ObjectId()
+    child_items = _people_sharing_items(3, creator_id)
+
+    metadata = generate_ro_crate_metadata({"collection_id": "c", "title": "C"}, child_items)
+
+    people = [node for node in metadata["@graph"] if node.get("@type") == "Person"]
+    assert len(people) == 1
+    assert people[0]["@id"] == f"./people/{creator_id}"
+
+    # The single person node should still be referenced as an author by every item.
+    for item in child_items:
+        dataset = next(n for n in metadata["@graph"] if n["@id"] == f"./{item['item_id']}/")
+        assert dataset["authors"] == [{"@id": f"./people/{creator_id}"}]
+
+
+def test_ro_crate_software_and_action_not_duplicated_per_item():
+    """The ``SoftwareApplication`` and ``CreateAction`` nodes describe the export
+    as a whole, so they must appear once regardless of the number of items."""
+    child_items = _people_sharing_items(4, ObjectId())
+
+    metadata = generate_ro_crate_metadata({"collection_id": "c", "title": "C"}, child_items)
+
+    software = [n for n in metadata["@graph"] if n.get("@type") == "SoftwareApplication"]
+    actions = [n for n in metadata["@graph"] if n.get("@type") == "CreateAction"]
+    assert len(software) == 1
+    assert len(actions) == 1
+
+    # No graph node should be emitted twice (would be invalid RO-Crate).
+    ids = [n["@id"] for n in metadata["@graph"]]
+    assert len(ids) == len(set(ids))
+
+
+@pytest.mark.parametrize("primary_key", ["item_id", "refcode"])
+def test_ro_crate_primary_key_switch(primary_key):
+    """The folder/``@id`` key can be switched between ``item_id`` and ``refcode``."""
+    child_items = [
+        {
+            "item_id": "sample_a",
+            "name": "Sample A",
+            "refcode": "test:REFA",
+            "creators": [],
+        }
+    ]
+
+    metadata = generate_ro_crate_metadata(
+        {"collection_id": "c", "title": "C"}, child_items, primary_key=primary_key
+    )
+
+    expected_key = child_items[0][primary_key]
+    other_key = child_items[0]["refcode" if primary_key == "item_id" else "item_id"]
+
+    dataset_ids = [n["@id"] for n in metadata["@graph"] if n.get("@type") == "Dataset"]
+    assert f"./{expected_key}/" in dataset_ids
+    if expected_key != other_key:
+        assert f"./{other_key}/" not in dataset_ids
+
+    # The per-item metadata.json file should hang off the same key.
+    assert any(
+        n["@id"] == f"./{expected_key}/metadata.json"
+        for n in metadata["@graph"]
+        if n.get("@type") == "File"
+    )
+
+    # The stable identifier is always the refcode, independent of the folder key.
+    dataset = next(n for n in metadata["@graph"] if n["@id"] == f"./{expected_key}/")
+    assert dataset["identifier"] == "test:REFA"
 
 
 def test_create_eln_file_items(database, tmp_path, user_id):
@@ -86,7 +169,12 @@ def test_create_eln_file_items(database, tmp_path, user_id):
     output_path = tmp_path / "test_samples.eln"
 
     try:
-        create_eln_file(output_path, item_id=sample_item_id, related_item_ids=[sample_item_id_2])
+        create_eln_file(
+            output_path,
+            item_id=sample_item_id,
+            related_item_ids=[sample_item_id_2],
+            primary_key="refcode",
+        )
         assert output_path.exists()
 
         with zipfile.ZipFile(output_path, "r") as zf:
@@ -114,6 +202,66 @@ def test_create_eln_file_items(database, tmp_path, user_id):
 
             except KeyError:
                 pytest.fail(f"Metadata file for {sample_item_id} not found in ELN file: {files}")
+
+    finally:
+        database.items.delete_one({"_id": sample_id})
+        database.items.delete_one({"_id": sample_id_2})
+
+
+def test_create_eln_file_items_default_item_id_key(database, tmp_path, user_id):
+    """By default (no ``primary_key``) exports key item folders by ``item_id``,
+    which is the more human-friendly layout preferred for manual exports."""
+    sample_id = ObjectId()
+    sample_id_2 = ObjectId()
+    sample_item_id = "human_sample"
+    sample_item_id_2 = "human_sample_2"
+
+    sample_data = {
+        "_id": sample_id,
+        "item_id": sample_item_id,
+        "name": "Test Sample",
+        "type": "samples",
+        "refcode": "test:HUMAN1",
+        "relationships": [{"type": "samples", "immutable_id": sample_id_2}],
+        "creator_ids": [user_id],
+        "creators": [{"display_name": "Test User", "immutable_id": user_id}],
+    }
+
+    sample_data_2 = {
+        "_id": sample_id_2,
+        "item_id": sample_item_id_2,
+        "name": "Test Sample 2",
+        "type": "samples",
+        "refcode": "test:HUMAN2",
+        "creator_ids": [user_id],
+        "creators": [{"display_name": "Test User", "immutable_id": user_id}],
+    }
+
+    database.items.insert_one(sample_data)
+    database.items.insert_one(sample_data_2)
+
+    output_path = tmp_path / "human_samples.eln"
+
+    try:
+        # No primary_key argument -> defaults to "item_id"
+        create_eln_file(output_path, item_id=sample_item_id, related_item_ids=[sample_item_id_2])
+        assert output_path.exists()
+
+        # The root folder is still the main item's refcode, but item folders inside
+        # are keyed by item_id, not refcode.
+        root = sample_data["refcode"]
+        with zipfile.ZipFile(output_path, "r") as zf:
+            files = zf.namelist()
+
+            assert f"{root}/{sample_item_id}/metadata.json" in files
+            assert f"{root}/{sample_item_id_2}/metadata.json" in files
+
+            # The refcode-keyed paths must NOT be present under the default.
+            assert f"{root}/{sample_data['refcode']}/metadata.json" not in files
+            assert f"{root}/{sample_data_2['refcode']}/metadata.json" not in files
+
+            with zf.open(f"{root}/{sample_item_id}/metadata.json") as f:
+                assert json.load(f)["item_id"] == sample_item_id
 
     finally:
         database.items.delete_one({"_id": sample_id})
@@ -158,7 +306,7 @@ def test_create_eln_file_collection(database, tmp_path, user_id):
     output_path = tmp_path / "test.eln"
 
     try:
-        create_eln_file(output_path, collection_id)
+        create_eln_file(output_path, collection_id, primary_key="refcode")
         assert output_path.exists()
 
         with zipfile.ZipFile(output_path, "r") as zf:

--- a/webapp/src/components/ExportButton.vue
+++ b/webapp/src/components/ExportButton.vue
@@ -7,22 +7,26 @@
       @click="handleExport"
     >
       <span v-if="!isExporting"> <i class="fa fa-download"></i> Export as .eln </span>
-      <span v-else> <i class="fa fa-spinner fa-spin"></i> {{ exportStatusText }} </span>
+      <span v-else> <i class="fa fa-spinner fa-spin"></i> Exporting&hellip; </span>
     </button>
+    <ExportProgressModal
+      ref="progressModal"
+      :export-type="exportType"
+      @close="isExporting = false"
+    />
   </div>
 </template>
 
 <script>
-import {
-  startCollectionExport,
-  startItemExport,
-  getExportStatus,
-  getExportDownloadUrl,
-} from "@/server_fetch_utils";
+import { startCollectionExport, startItemExport } from "@/server_fetch_utils";
 import { DialogService } from "@/services/DialogService";
+import ExportProgressModal from "@/components/ExportProgressModal";
 
 export default {
   name: "ExportButton",
+  components: {
+    ExportProgressModal,
+  },
   props: {
     collectionId: {
       type: String,
@@ -36,8 +40,6 @@ export default {
   data() {
     return {
       isExporting: false,
-      exportStatusText: "Preparing export...",
-      pollInterval: null,
     };
   },
   computed: {
@@ -45,18 +47,13 @@ export default {
       return this.collectionId ? "collection" : "item";
     },
   },
-  beforeUnmount() {
-    if (this.pollInterval) {
-      clearInterval(this.pollInterval);
-    }
-  },
   methods: {
     async handleExport() {
+      if (this.isExporting) {
+        return;
+      }
       try {
         this.isExporting = true;
-        this.exportStatusText = "Starting export...";
-
-        console.log("Export - collectionId:", this.collectionId, "itemId:", this.itemId);
 
         let response;
         if (this.collectionId) {
@@ -67,15 +64,7 @@ export default {
           throw new Error("Either collectionId or itemId must be provided");
         }
 
-        const taskId = response.task_id;
-
-        DialogService.alert({
-          title: "Export in Progress",
-          message: `Your ${this.exportType} is being exported. This may take a few moments. You'll be notified when it's ready to download.`,
-          type: "info",
-        });
-
-        this.pollExportStatus(taskId);
+        this.$refs.progressModal.start(response.task_id);
       } catch (error) {
         console.error("Export failed:", error);
         this.isExporting = false;
@@ -84,51 +73,6 @@ export default {
           message: error.message || "Failed to start the export. Please try again.",
         });
       }
-    },
-
-    async pollExportStatus(taskId) {
-      this.exportStatusText = "Processing...";
-
-      this.pollInterval = setInterval(async () => {
-        try {
-          const status = await getExportStatus(taskId);
-
-          if (status.status === "ready") {
-            clearInterval(this.pollInterval);
-            this.downloadExport(taskId);
-            this.isExporting = false;
-            DialogService.closeCurrentDialog(true);
-            DialogService.alert({
-              title: "Export Complete",
-              message: `Your ${this.exportType} has been exported successfully.`,
-              type: "success",
-            });
-          } else if (status.status === "error") {
-            clearInterval(this.pollInterval);
-            this.isExporting = false;
-            DialogService.error({
-              title: "Export Failed",
-              message: status.error_message || "An error occurred during export.",
-            });
-          } else if (status.status === "processing") {
-            this.exportStatusText = "Generating .eln file...";
-          }
-        } catch (error) {
-          clearInterval(this.pollInterval);
-          this.isExporting = false;
-          console.error("Error polling export status:", error);
-        }
-      }, 2000);
-    },
-
-    downloadExport(taskId) {
-      const downloadUrl = getExportDownloadUrl(taskId);
-      const link = document.createElement("a");
-      link.href = downloadUrl;
-      link.style.display = "none";
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
     },
   },
 };

--- a/webapp/src/components/ExportProgressModal.vue
+++ b/webapp/src/components/ExportProgressModal.vue
@@ -40,10 +40,13 @@
       </template>
 
       <template #footer>
+        <!-- No `download` attribute: the server sets `Content-Disposition: attachment`
+             with the intended `<collection_id|item_id>.eln` filename, and a `download`
+             attribute here would override it (e.g. to `collection.eln`) for same-origin
+             deployments. -->
         <a
           v-if="status === 'ready'"
           :href="downloadUrl"
-          :download="downloadName"
           class="btn btn-primary"
           data-testid="export-download-link"
         >
@@ -100,9 +103,6 @@ export default {
     },
     downloadUrl() {
       return this.taskId ? getExportDownloadUrl(this.taskId) : "#";
-    },
-    downloadName() {
-      return `${this.exportType}.eln`;
     },
   },
   watch: {

--- a/webapp/src/components/ExportProgressModal.vue
+++ b/webapp/src/components/ExportProgressModal.vue
@@ -1,0 +1,215 @@
+<template>
+  <!-- Teleport to <body> so the fixed-position modal is not clipped or hidden by a
+       transformed/overflow ancestor of wherever the trigger button is mounted (e.g.
+       the collection page header). -->
+  <Teleport to="body">
+    <Modal v-model="isOpen" :is-large="true">
+      <template #header>
+        <i class="fa fa-download mr-1"></i>
+        {{ headerText }}
+      </template>
+
+      <template #body>
+        <div ref="logContainer" class="export-log" data-testid="export-log">
+          <div
+            v-for="(stage, index) in stages"
+            :key="index"
+            class="export-log-line"
+            :class="`level-${stage.level || 'info'}`"
+          >
+            <span class="export-log-time">{{ formatTime(stage.timestamp) }}</span>
+            <span class="export-log-message">{{ stage.message }}</span>
+          </div>
+          <div v-if="stages.length === 0 && status === 'processing'" class="text-muted">
+            <i class="fa fa-spinner fa-spin"></i> Starting export&hellip;
+          </div>
+        </div>
+
+        <div v-if="status === 'error'" class="alert alert-danger mt-3 mb-0">
+          <i class="fa fa-exclamation-triangle mr-1"></i>
+          {{ errorMessage || "An error occurred during export." }}
+        </div>
+        <div v-else-if="status === 'ready'" class="alert alert-success mt-3 mb-0">
+          <i class="fa fa-check-circle mr-1"></i>
+          Export complete &mdash; your file is ready to download.
+        </div>
+        <div v-else class="mt-3 text-muted d-flex align-items-center">
+          <i class="fa fa-spinner fa-spin mr-2"></i>
+          Generating&nbsp;<code>.eln</code>&nbsp;file&hellip;
+        </div>
+      </template>
+
+      <template #footer>
+        <a
+          v-if="status === 'ready'"
+          :href="downloadUrl"
+          :download="downloadName"
+          class="btn btn-primary"
+          data-testid="export-download-link"
+        >
+          <i class="fa fa-download mr-1"></i> Download .eln
+        </a>
+        <button type="button" class="btn btn-secondary" @click="close">
+          {{ isFinished ? "Close" : "Cancel" }}
+        </button>
+      </template>
+    </Modal>
+  </Teleport>
+</template>
+
+<script>
+import Modal from "@/components/Modal";
+import { getExportStatus, getExportDownloadUrl } from "@/server_fetch_utils";
+
+const POLL_INTERVAL_MS = 2000;
+
+export default {
+  name: "ExportProgressModal",
+  components: {
+    Modal,
+  },
+  props: {
+    exportType: {
+      type: String,
+      default: "export",
+    },
+  },
+  emits: ["close"],
+  data() {
+    return {
+      isOpen: false,
+      taskId: null,
+      status: "processing",
+      stages: [],
+      errorMessage: null,
+      pollInterval: null,
+    };
+  },
+  computed: {
+    isFinished() {
+      return this.status === "ready" || this.status === "error";
+    },
+    headerText() {
+      if (this.status === "ready") {
+        return "Export complete";
+      }
+      if (this.status === "error") {
+        return "Export failed";
+      }
+      return `Exporting ${this.exportType}…`;
+    },
+    downloadUrl() {
+      return this.taskId ? getExportDownloadUrl(this.taskId) : "#";
+    },
+    downloadName() {
+      return `${this.exportType}.eln`;
+    },
+  },
+  watch: {
+    isOpen(open) {
+      if (!open) {
+        this.stopPolling();
+        this.$emit("close");
+      }
+    },
+    stages() {
+      this.$nextTick(this.scrollLogToBottom);
+    },
+  },
+  beforeUnmount() {
+    this.stopPolling();
+  },
+  methods: {
+    // Open the modal for a freshly-started export task and begin streaming its stages.
+    start(taskId) {
+      this.taskId = taskId;
+      this.status = "processing";
+      this.stages = [];
+      this.errorMessage = null;
+      this.isOpen = true;
+      this.poll();
+      this.pollInterval = setInterval(this.poll, POLL_INTERVAL_MS);
+    },
+    async poll() {
+      if (!this.taskId) {
+        return;
+      }
+      try {
+        const status = await getExportStatus(this.taskId);
+        this.stages = status.stages || [];
+        this.status = status.status;
+
+        if (status.status === "ready") {
+          this.stopPolling();
+        } else if (status.status === "error") {
+          this.errorMessage = status.error_message;
+          this.stopPolling();
+        }
+      } catch (error) {
+        console.error("Error polling export status:", error);
+        this.status = "error";
+        this.errorMessage = "Lost connection while checking export status.";
+        this.stopPolling();
+      }
+    },
+    stopPolling() {
+      if (this.pollInterval) {
+        clearInterval(this.pollInterval);
+        this.pollInterval = null;
+      }
+    },
+    close() {
+      this.isOpen = false;
+    },
+    scrollLogToBottom() {
+      const el = this.$refs.logContainer;
+      if (el) {
+        el.scrollTop = el.scrollHeight;
+      }
+    },
+    formatTime(timestamp) {
+      if (!timestamp) {
+        return "";
+      }
+      const date = new Date(timestamp);
+      if (Number.isNaN(date.getTime())) {
+        return "";
+      }
+      return date.toLocaleTimeString();
+    },
+  },
+};
+</script>
+
+<style scoped>
+.export-log {
+  max-height: 40vh;
+  overflow-y: auto;
+  background-color: #1e1e1e;
+  color: #d4d4d4;
+  border-radius: 5px;
+  padding: 0.75rem 1rem;
+  font-family: var(--bs-font-monospace, monospace);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.export-log-line {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.export-log-time {
+  color: #6a9955;
+  margin-right: 0.75rem;
+  user-select: none;
+}
+
+.export-log-line.level-warning .export-log-message {
+  color: #dcdcaa;
+}
+
+.export-log-line.level-error .export-log-message {
+  color: #f48771;
+}
+</style>

--- a/webapp/src/components/SampleGraphExportModal.vue
+++ b/webapp/src/components/SampleGraphExportModal.vue
@@ -152,20 +152,17 @@
         <button type="button" class="btn btn-secondary" @click="isModalOpen = false">Cancel</button>
       </template>
     </Modal>
+
+    <ExportProgressModal ref="progressModal" export-type="item" />
   </div>
 </template>
 
 <script>
 import Modal from "@/components/Modal";
 import ItemGraph from "@/components/ItemGraph";
+import ExportProgressModal from "@/components/ExportProgressModal";
 
-import {
-  startItemExport,
-  getExportStatus,
-  getExportDownloadUrl,
-  createNewCollection,
-  getItemGraph,
-} from "@/server_fetch_utils";
+import { startItemExport, createNewCollection, getItemGraph } from "@/server_fetch_utils";
 import { DialogService } from "@/services/DialogService";
 
 export default {
@@ -173,6 +170,7 @@ export default {
   components: {
     Modal,
     ItemGraph,
+    ExportProgressModal,
   },
   props: {
     itemId: {
@@ -191,7 +189,6 @@ export default {
       createCollection: false,
       collectionId: "",
       collectionTitle: "",
-      pollInterval: null,
       graphDepth: 1,
       graphData: { nodes: [], edges: [] },
       isGraphLoading: false,
@@ -212,11 +209,6 @@ export default {
       this.loadGraphWithDepth();
       this.loadRelatedSamples();
     },
-  },
-  beforeUnmount() {
-    if (this.pollInterval) {
-      clearInterval(this.pollInterval);
-    }
   },
   methods: {
     async loadRelatedSamples() {
@@ -271,19 +263,15 @@ export default {
     },
 
     async handleExport() {
+      if (this.isExporting) {
+        return;
+      }
       try {
         this.isExporting = true;
 
         if (this.exportOnlyThisItem) {
           const response = await startItemExport(this.itemId);
-          const taskId = response.task_id;
-          DialogService.alert({
-            title: "Export in Progress",
-            message:
-              "Your item is being exported. This may take a few moments. You'll be notified when it's ready to download.",
-            type: "info",
-          });
-          this.pollExportStatus(taskId);
+          this.showProgress(response.task_id);
           return;
         }
 
@@ -326,16 +314,7 @@ export default {
           related_item_ids: this.selectedSampleIds,
           max_depth: this.graphDepth,
         });
-        const taskId = response.task_id;
-
-        DialogService.alert({
-          title: "Export in Progress",
-          message:
-            "Your items are being exported. This may take a few moments. You'll be notified when it's ready to download.",
-          type: "info",
-        });
-
-        this.pollExportStatus(taskId);
+        this.showProgress(response.task_id);
       } catch (error) {
         console.error("Export failed:", error);
         this.isExporting = false;
@@ -346,48 +325,11 @@ export default {
       }
     },
 
-    async pollExportStatus(taskId) {
-      this.pollInterval = setInterval(async () => {
-        try {
-          const status = await getExportStatus(taskId);
-
-          if (status.status === "ready") {
-            clearInterval(this.pollInterval);
-            this.downloadExport(taskId);
-            this.isExporting = false;
-            this.isModalOpen = false;
-            DialogService.closeCurrentDialog(true);
-
-            DialogService.alert({
-              title: "Export Complete",
-              message:
-                "Your items have been exported successfully and the download should begin shortly.",
-              type: "success",
-            });
-          } else if (status.status === "error") {
-            clearInterval(this.pollInterval);
-            this.isExporting = false;
-            DialogService.error({
-              title: "Export Failed",
-              message: status.error_message || "An error occurred during export.",
-            });
-          }
-        } catch (error) {
-          clearInterval(this.pollInterval);
-          this.isExporting = false;
-          console.error("Error polling export status:", error);
-        }
-      }, 2000);
-    },
-
-    downloadExport(taskId) {
-      const downloadUrl = getExportDownloadUrl(taskId);
-      const link = document.createElement("a");
-      link.href = downloadUrl;
-      link.style.display = "none";
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+    // Close this configuration modal and stream the export's progress in the progress modal.
+    showProgress(taskId) {
+      this.isExporting = false;
+      this.isModalOpen = false;
+      this.$refs.progressModal.start(taskId);
     },
 
     show() {


### PR DESCRIPTION
This pull request makes several improvements to the ELN export process and format.

- The export now captures certain alternative representations of files created by blocks (e.g., .parquet.bdf) (closes #1690)
- The export now reports progress via the status route with a new UI modal
- `X-Accel-Redirect` can be configured to serve large exports directly from nginx (closes #1802)
- Refcodes are now constructed properly (closes #1805) and creators and other metadata are not duplicated per item (closes #1808)
- The export can be optionally keyed on refcode or the more human-friendly item ID
- Process: files are now streamed directly into a zip file rather than needing double the space, and compression is now avoided
- There is a new clean up task to remove ELN exports on disk after 24 hours