### PR TITLE
Expose KNOWN_USER_AGENTS

### DIFF
--- a/pydatalab/src/pydatalab/models/versions.py
+++ b/pydatalab/src/pydatalab/models/versions.py
@@ -39,6 +39,9 @@ class ItemVersion(BaseModel):
     user_id: PyObjectId | None = Field(
         None, description="User's ObjectId for efficient querying and indexing"
     )
+    creator: dict | None = Field(
+        None, description="Inlined information about the user who created this version (e.g., name)"
+    )
     datalab_version: str = Field(
         ..., description="Version of datalab-server that created this snapshot"
     )

--- a/pydatalab/src/pydatalab/models/versions.py
+++ b/pydatalab/src/pydatalab/models/versions.py
@@ -15,6 +15,7 @@ class VersionAction(str, Enum):
     MANUAL_SAVE = "manual_save"
     AUTO_SAVE = "auto_save"
     RESTORED = "restored"
+    AGENT_SAVE = "agent_save"
 
 
 class ItemVersion(BaseModel):
@@ -45,6 +46,10 @@ class ItemVersion(BaseModel):
     restored_from_version: PyObjectId | None = Field(
         None,
         description="ObjectId of the version that was restored from (only present if action='restored')",
+    )
+    user_agent: str | None = Field(
+        None,
+        description="User agent string of the client that triggered this version. Will only be stored if it matches a known value from the datalab ecosystem.",
     )
 
     @validator("restored_from_version")

--- a/pydatalab/src/pydatalab/routes/v0_1/info.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/info.py
@@ -17,6 +17,7 @@ from pydatalab.models import Collection, Person
 from pydatalab.models.items import Item
 from pydatalab.mongo import flask_mongo
 from pydatalab.permissions import active_users_or_get_only
+from pydatalab.versioning import KNOWN_USER_AGENTS
 
 from ._version import __api_version__
 
@@ -69,6 +70,7 @@ class Info(Attributes, Meta):
     identifier_prefix: str
     features: FeatureFlags = FEATURE_FLAGS
     max_upload_bytes: int
+    known_user_agents: list[str] = KNOWN_USER_AGENTS
 
     @validator("maintainer")
     def strip_maintainer_fields(cls, v):

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -1309,6 +1309,7 @@ def list_versions(refcode):
                         "action": 1,
                         "restored_from_version": 1,
                         "data.version": 1,
+                        "user_agent": 1,
                     }
                 },
                 {"$sort": {"version": -1}},
@@ -1601,7 +1602,7 @@ def save_version(refcode):
     """Manually save the current state of an item as a version snapshot with an incremental version number."""
     response, status_code = save_version_snapshot(
         refcode,
-        action=VersionAction.MANUAL_SAVE,
+        action=None,  # let the function determine the appropriate action (e.g. AGENT_SAVE vs MANUAL_SAVE) based on user-agent
         permission_filter=get_default_permissions(user_only=False),
     )
     if status_code == 200 and "version" in response:
@@ -1792,7 +1793,7 @@ def save_item():
     # If this fails, we log but don't fail the request since item was already saved.
     try:
         save_version_resp_dict, save_version_status = save_version_snapshot(
-            refcode, action=VersionAction.MANUAL_SAVE
+            refcode,
         )
         if save_version_status != 200:
             LOGGER.error(

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -1282,22 +1282,39 @@ def list_versions(refcode):
         refcode = f"{CONFIG.IDENTIFIER_PREFIX}:{refcode}"
 
     versions = list(
-        flask_mongo.db.item_versions.find(
-            {"refcode": refcode},
-            {
-                "_id": 1,
-                "timestamp": 1,
-                "user_id": 1,
-                "datalab_version": 1,
-                "version": 1,
-                "action": 1,
-                "restored_from_version": 1,
-                "data.version": 1,
-            },
-        ).sort("version", -1)
+        flask_mongo.db.item_versions.aggregate(
+            [
+                {"$match": {"refcode": refcode}},
+                {
+                    "$lookup": {
+                        "from": "users",
+                        "as": "creator",
+                        "let": {"user_id": "$user_id"},
+                        "pipeline": [
+                            {"$match": {"$expr": {"$eq": ["$_id", "$$user_id"]}}},
+                            {"$project": {"_id": 0, "display_name": 1, "gravatar_hash": 1}},
+                        ],
+                    }
+                },
+                # $lookup always yields an array; collapse the (0 or 1) match
+                # to a single-valued creator, leaving it null when absent.
+                {"$set": {"creator": {"$arrayElemAt": ["$creator", 0]}}},
+                {
+                    "$project": {
+                        "_id": 1,
+                        "timestamp": 1,
+                        "creator": 1,
+                        "datalab_version": 1,
+                        "version": 1,
+                        "action": 1,
+                        "restored_from_version": 1,
+                        "data.version": 1,
+                    }
+                },
+                {"$sort": {"version": -1}},
+            ]
+        )
     )
-    for v in versions:
-        v["_id"] = str(v["_id"])
     return jsonify({"status": "success", "versions": versions}), 200
 
 
@@ -1322,10 +1339,33 @@ def get_version(refcode, version_id):
     except (InvalidId, TypeError):
         return jsonify({"status": "error", "message": f"Invalid version_id: {version_id}"}), 400
 
-    version = flask_mongo.db.item_versions.find_one({"_id": version_object_id, "refcode": refcode})
+    version = list(
+        flask_mongo.db.item_versions.aggregate(
+            [
+                {"$match": {"_id": version_object_id, "refcode": refcode}},
+                # Lookup from user_id from users collection and fill in creator info
+                {
+                    "$lookup": {
+                        "from": "users",
+                        "as": "creator",
+                        "let": {"user_id": "$user_id"},
+                        "pipeline": [
+                            {"$match": {"$expr": {"$eq": ["$_id", "$$user_id"]}}},
+                            {"$project": {"_id": 0, "display_name": 1, "gravatar_hash": 1}},
+                        ],
+                    }
+                },
+                {"$set": {"creator": {"$arrayElemAt": ["$creator", 0]}}},
+            ]
+        )
+    )
+
+    if len(version) >= 1:
+        version = version[0]
+
     if not version:
         return jsonify({"status": "error", "message": "Version not found"}), 404
-    version["_id"] = str(version["_id"])
+
     return jsonify({"status": "success", "version": version}), 200
 
 

--- a/pydatalab/src/pydatalab/versioning.py
+++ b/pydatalab/src/pydatalab/versioning.py
@@ -93,7 +93,7 @@ def get_next_version_number(refcode: str) -> int:
 
 def save_version_snapshot(
     refcode: str,
-    action: VersionAction = VersionAction.MANUAL_SAVE,
+    action: VersionAction | None = None,
     permission_filter: dict | None = None,
 ) -> tuple[dict, int]:
     """Save the current state of an item as a version snapshot.
@@ -104,11 +104,9 @@ def save_version_snapshot(
 
     Args:
         refcode: The refcode of the item to save a version for
-        action: The reason for saving this version (VersionAction enum):
-            - VersionAction.CREATED: Initial version when item is first created
-            - VersionAction.MANUAL_SAVE: User explicitly saved the version
-            - VersionAction.AUTO_SAVE: System or block auto-save
-            - VersionAction.RESTORED: Version created after restoring to a previous version
+        action: The reason for saving this version (VersionAction enum): if None,
+                it will be set to VersionAction.AGENT_SAVE if the user agent matches a known agent,
+                or VersionAction.MANUAL_SAVE otherwise.
         permission_filter: Optional MongoDB filter to apply for permission checking.
             If None, no permission check is performed.
 
@@ -154,11 +152,15 @@ def save_version_snapshot(
 
     # Only store user agent if it matches a known agent
     _user_agent = request.headers.get("User-Agent", "unknown")
-    user_agent = "Manual save"
+    user_agent = None
     for known_agent in KNOWN_USER_AGENTS:
         if _user_agent.startswith(known_agent):
             user_agent = _user_agent
             break
+    if user_agent is not None and action is None:
+        action = VersionAction.AGENT_SAVE
+
+    action = VersionAction.MANUAL_SAVE if action is None else action
 
     version_entry = {
         "refcode": refcode,

--- a/pydatalab/src/pydatalab/versioning.py
+++ b/pydatalab/src/pydatalab/versioning.py
@@ -2,6 +2,7 @@
 
 import datetime
 
+from flask import request
 from flask_login import current_user
 from pydantic import ValidationError
 from werkzeug.exceptions import NotFound
@@ -10,6 +11,14 @@ from pydatalab.logger import LOGGER
 from pydatalab.models import ItemVersion
 from pydatalab.models.versions import VersionAction, VersionCounter
 from pydatalab.mongo import flask_mongo
+
+KNOWN_USER_AGENTS = ["datalab-python-api", "datalab-beholder", "datalab-cheminventory-sync"]
+"""User agents that are treated as special values for versioning purposes,
+e.g., to identify automated saves vs. user-initiated saves.
+
+No other agent should be stored to avoid incidental fingerprinting.
+
+"""
 
 
 def apply_protected_fields(restored_data: dict, current_item: dict) -> dict:
@@ -143,6 +152,14 @@ def save_version_snapshot(
 
     software_version = __version__
 
+    # Only store user agent if it matches a known agent
+    _user_agent = request.headers.get("User-Agent", "unknown")
+    user_agent = "Manual save"
+    for known_agent in KNOWN_USER_AGENTS:
+        if _user_agent.startswith(known_agent):
+            user_agent = _user_agent
+            break
+
     version_entry = {
         "refcode": refcode,
         "version": next_version_number,
@@ -151,6 +168,7 @@ def save_version_snapshot(
         "user_id": user_id,  # ObjectId for efficient querying
         "datalab_version": software_version,
         "data": item,  # Complete snapshot of the item at this version
+        "user_agent": user_agent,  # "What" changed the item
     }
 
     # Validate with Pydantic before inserting

--- a/pydatalab/tests/server/test_item_versions.py
+++ b/pydatalab/tests/server/test_item_versions.py
@@ -117,6 +117,9 @@ class TestListVersions:
         client.post(f"/items/{refcode}/save-version/")
 
         response = client.get(f"/items/{refcode}/versions/")
+        assert response.json["versions"][0]["creator"]["display_name"] == "Test User"
+        assert response.json["versions"][1]["creator"]["display_name"] == "Test User"
+        assert response.json["versions"][2]["creator"]["display_name"] == "Test User"
 
         assert response.status_code == 200
         assert response.json["status"] == "success"
@@ -177,6 +180,7 @@ class TestGetVersion:
         assert response.json["version"]["refcode"] == sample_with_version.refcode
         assert "data" in response.json["version"]
         assert response.json["version"]["data"]["name"] == "Version Test Sample"
+        assert response.json["version"]["creator"]["display_name"] == "Test User"
 
     def test_get_version_invalid_id(self, client, sample_with_version):
         """Test getting version with invalid ID format."""

--- a/pydatalab/tests/server/test_item_versions.py
+++ b/pydatalab/tests/server/test_item_versions.py
@@ -624,6 +624,31 @@ class TestActionFields:
         # Manual saves should not have restored_from_version
         assert version.get("restored_from_version") is None
 
+    def test_automated_save_version_endpoint_action(
+        self, client, sample_with_version, user_api_key
+    ):
+        """Test that manual save_version endpoint creates action='manual_save'."""
+        refcode = sample_with_version.refcode.split(":")[1]
+
+        # Manually save a version via save-version endpoint
+        resp = client.post(
+            f"/items/{refcode}/save-version/",
+            headers={
+                "User-Agent": "datalab-python-api/v1.0",
+                "Datalab-Api-Key": user_api_key,
+            },
+        )
+        assert resp.status_code == 200
+
+        # Check the version action in list
+        list_response = client.get(f"/items/{refcode}/versions/")
+        version = list_response.json["versions"][0]
+
+        assert version["action"] == "agent_save"
+        assert version["user_agent"] == "datalab-python-api/v1.0"
+        # Manual saves should not have restored_from_version
+        assert version.get("restored_from_version") is None
+
     def test_save_item_endpoint_creates_manual_save_action(self, client, sample_with_version):
         """Test that save_item endpoint creates action='manual_save' (user-triggered save)."""
         refcode_short = sample_with_version.refcode.split(":")[1]


### PR DESCRIPTION
Exposes KNOWN_USER_AGENTS at the info level so clients (e.g datalab-api) can validate themselves against it.

Builds on #1785, and ensures future external use cases can have their agent stored in the item_version info 