### PR TITLE
Assorted fixes for collections page (spurious unsaved warning, graph layout & loading)

### DIFF
--- a/webapp/cypress/e2e/collectionPage.cy.js
+++ b/webapp/cypress/e2e/collectionPage.cy.js
@@ -60,4 +60,42 @@ describe("Collection page", () => {
     cy.get(".navbar-toggler").click();
     cy.get("nav.editor-navbar").findByText("Home").should("be.visible");
   });
+
+  it("does not show a spurious 'Unsaved changes' warning on first load", () => {
+    cy.visit(`/collections/${collectionId}`);
+
+    // wait for the page to finish loading (collection information rendered)
+    cy.get("#collection-information").should("exist");
+
+    // The collection has not been edited, so no unsaved warning should appear.
+    // Give any first-load v-model normalisation a chance to (incorrectly) fire.
+    cy.wait(500);
+    cy.get(".unsaved-warning").should("not.exist");
+    cy.get(".navbar-icon-unsaved").should("not.exist");
+  });
+
+  it("loads the relationship graph", () => {
+    cy.intercept("GET", "**/item-graph*").as("getItemGraph");
+
+    cy.visit(`/collections/${collectionId}`);
+    cy.get("#collection-information").should("exist");
+
+    // The graph fetch must actually fire (it short-circuits if the current user
+    // is not loaded into the store), and the cytoscape canvas should render.
+    cy.wait("@getItemGraph").its("response.statusCode").should("eq", 200);
+    cy.get("#cy canvas").should("exist");
+  });
+
+  it("shows the unsaved warning after editing the title", () => {
+    cy.visit(`/collections/${collectionId}`);
+    cy.get("#collection-information").should("exist");
+
+    // Editing a field marks the collection as unsaved...
+    cy.get("#name").clear();
+    cy.get("#name").type("Edited but unsaved title");
+    cy.get(".unsaved-warning").should("exist");
+
+    // ...and the edited value is retained in the input.
+    cy.get("#name").should("have.value", "Edited but unsaved title");
+  });
 });

--- a/webapp/src/components/CollectionInformation.vue
+++ b/webapp/src/components/CollectionInformation.vue
@@ -68,7 +68,7 @@
 
 <script>
 import { createComputedSetterForCollectionField } from "@/field_utils.js";
-import { getCollectionSampleList } from "@/server_fetch_utils";
+import { getCollectionData } from "@/server_fetch_utils";
 import TiptapInline from "@/components/TiptapInline";
 import Creators from "@/components/Creators";
 import CollectionRelationshipVisualization from "@/components/CollectionRelationshipVisualization";
@@ -140,8 +140,8 @@ export default {
     CollectionDescription: createComputedSetterForCollectionField("description"),
     Title: createComputedSetterForCollectionField("title"),
     Name: createComputedSetterForCollectionField("name"),
-    CollectionCreators: createComputedSetterForCollectionField("creators"),
-    CollectionGroups: createComputedSetterForCollectionField("groups"),
+    CollectionCreators: createComputedSetterForCollectionField("creators", []),
+    CollectionGroups: createComputedSetterForCollectionField("groups", []),
     children() {
       return this.$store.state.all_collection_children[this.collection_id] || [];
     },
@@ -150,21 +150,12 @@ export default {
       return collection?.refcode || null;
     },
   },
-  created() {
-    this.getCollectionChildren();
-  },
   methods: {
-    getCollectionChildren() {
-      getCollectionSampleList(this.collection_id)
-        .then(() => {
-          this.tableIsReady = true;
-        })
-        .catch(() => {
-          this.fetchError = true;
-        });
-    },
     handleItemsRemovedFromCollection() {
-      this.getCollectionChildren();
+      // The page-level fetch already populated the child items; after a removal
+      // we re-fetch the collection (data + child items in one request) to refresh
+      // the table.
+      getCollectionData(this.collection_id);
     },
   },
 };

--- a/webapp/src/components/CollectionInformation.vue
+++ b/webapp/src/components/CollectionInformation.vue
@@ -61,14 +61,12 @@
       ]"
       :show-buttons="true"
       :collection-id="collection_id"
-      @remove-selected-items-from-collection="handleItemsRemovedFromCollection"
     />
   </div>
 </template>
 
 <script>
 import { createComputedSetterForCollectionField } from "@/field_utils.js";
-import { getCollectionData } from "@/server_fetch_utils";
 import TiptapInline from "@/components/TiptapInline";
 import Creators from "@/components/Creators";
 import CollectionRelationshipVisualization from "@/components/CollectionRelationshipVisualization";
@@ -140,22 +138,14 @@ export default {
     CollectionDescription: createComputedSetterForCollectionField("description"),
     Title: createComputedSetterForCollectionField("title"),
     Name: createComputedSetterForCollectionField("name"),
-    CollectionCreators: createComputedSetterForCollectionField("creators", []),
-    CollectionGroups: createComputedSetterForCollectionField("groups", []),
+    CollectionCreators: createComputedSetterForCollectionField("creators"),
+    CollectionGroups: createComputedSetterForCollectionField("groups"),
     children() {
       return this.$store.state.all_collection_children[this.collection_id] || [];
     },
     collectionRefcode() {
       const collection = this.$store.state.all_collection_data[this.collection_id];
       return collection?.refcode || null;
-    },
-  },
-  methods: {
-    handleItemsRemovedFromCollection() {
-      // The page-level fetch already populated the child items; after a removal
-      // we re-fetch the collection (data + child items in one request) to refresh
-      // the table.
-      getCollectionData(this.collection_id);
     },
   },
 };

--- a/webapp/src/components/CollectionRelationshipVisualization.vue
+++ b/webapp/src/components/CollectionRelationshipVisualization.vue
@@ -21,8 +21,8 @@
     <ItemGraph
       :graph-data="graphData"
       style="height: 200px; width: 100%; border: 1px solid transparent; border-radius: 5px"
-      :default-graph-style="'elk-stress'"
       :show-options="false"
+      :default-show-blocks="false"
     />
   </div>
 </template>

--- a/webapp/src/components/ItemGraph.vue
+++ b/webapp/src/components/ItemGraph.vue
@@ -296,11 +296,11 @@ export default {
         container: this.$refs.cyContainer,
         elements: { nodes: this.graphData.nodes || [], edges: validEdges },
         userPanningEnabled: true,
-        minZoom: 0.5,
+        minZoom: 0.05,
         maxZoom: 1,
         animatedZooming: false,
         userZoomingEnabled: true,
-        wheelSensitivity: 0.2,
+        wheelSensitivity: 0.5,
         boxSelectionEnabled: false,
         style: [
           {
@@ -371,6 +371,9 @@ export default {
 
       this.cy.on("layoutstop", () => {
         this.layoutIsRunning = false;
+        // Once the layout has settled, fit the whole graph within the container
+        // box (with a little padding) so nothing overflows the visible area.
+        this.cy.fit(undefined, 20);
       });
 
       // tapdragover and tapdragout are mouseover and mouseout events
@@ -386,14 +389,6 @@ export default {
         node.style("opacity", 1);
         node.style("border-width", node.data("special") == 1 ? 2 : 0);
         node.style("border-color", "grey");
-      });
-      // Re-run layout when a node is dragged, locking the dragged node in place
-      // so the rest of the graph adjusts around it
-      this.cy.on("dragfree", "node", (evt) => {
-        var node = evt.target;
-        node.lock();
-        this.updateAndRunLayout();
-        node.unlock();
       });
 
       this.cy.on("click", "node", function (evt) {

--- a/webapp/src/components/ToggleableCreatorsFormGroup.vue
+++ b/webapp/src/components/ToggleableCreatorsFormGroup.vue
@@ -57,7 +57,8 @@ export default {
     label: { type: String, default: "Creators" },
     modelValue: {
       type: Array,
-      required: true,
+      required: false,
+      default: () => [],
     },
   },
   emits: ["update:modelValue"],

--- a/webapp/src/components/ToggleableGroupsFormGroup.vue
+++ b/webapp/src/components/ToggleableGroupsFormGroup.vue
@@ -51,7 +51,8 @@ export default {
     collectionId: { type: String, required: false, default: null },
     modelValue: {
       type: Array,
-      required: true,
+      required: false,
+      default: () => [],
     },
   },
   emits: ["update:modelValue"],

--- a/webapp/src/field_utils.js
+++ b/webapp/src/field_utils.js
@@ -96,16 +96,24 @@ export function createComputedSetterForItemField(item_field) {
   };
 }
 
-export function createComputedSetterForCollectionField(collection_field) {
+export function createComputedSetterForCollectionField(collection_field, defaultValue = undefined) {
   return {
     get() {
       if (this.collection_id in store.state.all_collection_data) {
         let value = store.state.all_collection_data[this.collection_id][collection_field];
+        if (value === undefined || value === null) {
+          // Field absent (e.g. collection not yet loaded, or an optional field
+          // that was never set): fall back to the supplied default so that, for
+          // example, array-typed v-model bindings receive [] rather than
+          // undefined and don't trip required-prop validation.
+          return defaultValue;
+        }
         if (DATETIME_FIELDS.has(collection_field)) {
           value = dateTimeParser(value);
         }
         return value;
       }
+      return defaultValue;
     },
     set(value) {
       if (DATETIME_FIELDS.has(collection_field)) {

--- a/webapp/src/field_utils.js
+++ b/webapp/src/field_utils.js
@@ -96,24 +96,16 @@ export function createComputedSetterForItemField(item_field) {
   };
 }
 
-export function createComputedSetterForCollectionField(collection_field, defaultValue = undefined) {
+export function createComputedSetterForCollectionField(collection_field) {
   return {
     get() {
       if (this.collection_id in store.state.all_collection_data) {
         let value = store.state.all_collection_data[this.collection_id][collection_field];
-        if (value === undefined || value === null) {
-          // Field absent (e.g. collection not yet loaded, or an optional field
-          // that was never set): fall back to the supplied default so that, for
-          // example, array-typed v-model bindings receive [] rather than
-          // undefined and don't trip required-prop validation.
-          return defaultValue;
-        }
         if (DATETIME_FIELDS.has(collection_field)) {
           value = dateTimeParser(value);
         }
         return value;
       }
-      return defaultValue;
     },
     set(value) {
       if (DATETIME_FIELDS.has(collection_field)) {

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -214,8 +214,6 @@ export default createStore({
       // payload should have the following fields:
       // collection_id, data, child_items
       state.all_collection_data[payload.collection_id] = payload.data;
-      // The `/collections/<id>` response already includes the child items, so
-      // store them here too rather than making a second identical request.
       if (payload.child_items !== undefined) {
         state.all_collection_children[payload.collection_id] = payload.child_items;
       }

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -214,6 +214,11 @@ export default createStore({
       // payload should have the following fields:
       // collection_id, data, child_items
       state.all_collection_data[payload.collection_id] = payload.data;
+      // The `/collections/<id>` response already includes the child items, so
+      // store them here too rather than making a second identical request.
+      if (payload.child_items !== undefined) {
+        state.all_collection_children[payload.collection_id] = payload.child_items;
+      }
       state.saved_status_collections[payload.collection_id] = true;
     },
     setCollectionSampleList(state, payload) {

--- a/webapp/src/views/CollectionPage.vue
+++ b/webapp/src/views/CollectionPage.vue
@@ -199,6 +199,16 @@ export default {
     async getCollection() {
       await getCollectionData(this.collection_id);
       this.data_loaded = true;
+      // Mark the collection as saved once child components (e.g. the Tiptap
+      // description editor) have mounted and emitted their initial v-model
+      // normalisation, which would otherwise flip the status to "unsaved" on
+      // first load. Mirrors the same guard in EditPage.getSampleData.
+      this.$nextTick(() => {
+        this.$store.commit("setSavedCollection", {
+          collection_id: this.collection_id,
+          isSaved: true,
+        });
+      });
       this.setLastModified();
     },
     leavePageWarningListener(event) {

--- a/webapp/src/views/CollectionPage.vue
+++ b/webapp/src/views/CollectionPage.vue
@@ -4,6 +4,7 @@
     class="navbar navbar-expand-md sticky-top navbar-dark py-0 editor-navbar"
     :style="{ backgroundColor: navbarColor }"
   >
+    <div v-show="false" class="navbar-nav"><LoginDetails /></div>
     <span class="navbar-brand clickable" @click="scrollToID($event, 'topScrollPoint')">
       <span class="navbar-brand-type"
         >{{ itemTypeEntry?.navbarName || "loading..." }}&nbsp;&nbsp;|&nbsp;&nbsp;</span
@@ -83,7 +84,7 @@
 
   <!-- Item-type header information goes here -->
   <div class="editor-body">
-    <CollectionInformation :collection_id="collection_id" />
+    <CollectionInformation v-if="data_loaded" :collection_id="collection_id" />
     <SharingModal v-model="isSharingModalVisible" :collection-id="collection_id" />
   </div>
 </template>
@@ -92,6 +93,7 @@
 import { DialogService } from "@/services/DialogService";
 
 import CollectionInformation from "@/components/CollectionInformation";
+import LoginDetails from "@/components/LoginDetails";
 import SharingModal from "@/components/SharingModal.vue";
 import { getCollectionData, saveCollection } from "@/server_fetch_utils";
 import FormattedItemName from "@/components/FormattedItemName.vue";
@@ -104,6 +106,7 @@ import ExportDropdown from "@/components/ExportDropdown";
 export default {
   components: {
     CollectionInformation,
+    LoginDetails,
     SharingModal,
     FormattedItemName,
     ExportDropdown,


### PR DESCRIPTION
We added this at some point to the general item page, but it seems that collections are often marked as unsaved on first load. Also fixes graph loading in collections by adding a shadow login, in case the user visits a collection page directly.

Closes #1748 
Closes #1749

Other changes:

- default graph zoom to fit whole graph in box
- increase zoom sensitivity