### PR TITLE
Add post plot hooks to extract metadata for FAST

### DIFF
--- a/pydatalab/src/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/src/pydatalab/apps/echem/blocks.py
@@ -1,7 +1,8 @@
 import hashlib
 import warnings
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import bokeh
 import pandas as pd
@@ -78,6 +79,25 @@ class CycleBlock(DataBlock):
         "win_size_1": 1001,
         "derivative_mode": None,
     }
+
+    post_plot_hooks: ClassVar[
+        list[Callable[["CycleBlock", pd.DataFrame, pd.DataFrame | None], None]]
+    ] = []
+    """Hooks called after plot_cycle completes, receiving (block, raw_df, cycle_summary_df).
+
+    Plugins can append callables here to extract derived metrics into ``block.data["computed"]``
+    without monkey-patching. Each hook is called once per plot update with the primary
+    (non-comparison) raw and cycle-summary DataFrames.
+
+    Example::
+
+        from pydatalab.apps.echem import CycleBlock
+
+        def my_hook(block, raw_df, cycle_summary_df):
+            block.data["computed"] = {"my_metric": raw_df["voltage (V)"].max()}
+
+        CycleBlock.post_plot_hooks.append(my_hook)
+    """
 
     def _get_characteristic_mass_g(self):
         doc = flask_mongo.db.items.find_one(
@@ -434,6 +454,8 @@ class CycleBlock(DataBlock):
 
         raw_dfs = {}
         cycle_summary_dfs = {}
+        raw_df = None
+        cycle_summary_df = None
 
         if self.data.get("mode") is None:
             self.data["mode"] = "single"
@@ -539,6 +561,14 @@ class CycleBlock(DataBlock):
             self.data["bokeh_plot_data"] = bokeh.embed.json_item(
                 layout, theme=bokeh_plots.DATALAB_BOKEH_THEME
             )
+
+        if raw_df is not None:
+            for hook in self.post_plot_hooks:
+                try:
+                    hook(self, raw_df, cycle_summary_df)
+                except Exception as exc:
+                    warnings.warn(f"post_plot_hook {hook!r} failed: {exc}")
+
         return
 
     @property

--- a/pydatalab/src/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/src/pydatalab/apps/echem/blocks.py
@@ -83,18 +83,23 @@ class CycleBlock(DataBlock):
     post_plot_hooks: ClassVar[
         list[Callable[["CycleBlock", pd.DataFrame, pd.DataFrame | None], None]]
     ] = []
-    """Hooks called after plot_cycle completes, receiving (block, raw_df, cycle_summary_df).
+    """Hooks called after plot_cycle completes, receiving (block, unfiltered_df, cycle_summary_df).
 
     Plugins can append callables here to extract derived metrics into ``block.data["computed"]``
     without monkey-patching. Each hook is called once per plot update with the primary
-    (non-comparison) raw and cycle-summary DataFrames.
+    (non-comparison) DataFrames.
+
+    ``unfiltered_df`` is the full navani DataFrame re-parsed directly from the source file,
+    bypassing the BDF cache, so instrument-specific columns (e.g. ``unknown_colID_249``) that
+    are not part of the BDF schema are available. Note this incurs an extra file parse when
+    hooks are registered.
 
     Example::
 
         from pydatalab.apps.echem import CycleBlock
 
-        def my_hook(block, raw_df, cycle_summary_df):
-            block.data["computed"] = {"my_metric": raw_df["voltage (V)"].max()}
+        def my_hook(block, unfiltered_df, cycle_summary_df):
+            block.data["computed"] = {"my_metric": unfiltered_df["unknown_colID_249"].max()}
 
         CycleBlock.post_plot_hooks.append(my_hook)
     """
@@ -562,12 +567,25 @@ class CycleBlock(DataBlock):
                 layout, theme=bokeh_plots.DATALAB_BOKEH_THEME
             )
 
-        if raw_df is not None:
-            for hook in self.post_plot_hooks:
-                try:
-                    hook(self, raw_df, cycle_summary_df)
-                except Exception as exc:
-                    warnings.warn(f"post_plot_hook {hook!r} failed: {exc}")
+        if raw_df is not None and self.post_plot_hooks:
+            # Re-parse from source to get the full unfiltered DataFrame, since the BDF cache
+            # only preserves BDF-schema columns and drops instrument-specific ones.
+            file_infos = [get_file_info_by_id(fid, update_if_live=False) for fid in file_ids]
+            locations = [Path(info["location"]) for info in file_infos]
+            try:
+                unfiltered_df = self._parse_echem_files(
+                    locations[0], locations if len(locations) > 1 else None
+                )
+            except Exception as exc:
+                warnings.warn(f"post_plot_hook source re-parse failed, hooks will not run: {exc}")
+                unfiltered_df = None
+
+            if unfiltered_df is not None:
+                for hook in self.post_plot_hooks:
+                    try:
+                        hook(self, unfiltered_df, cycle_summary_df)
+                    except Exception as exc:
+                        warnings.warn(f"post_plot_hook {hook!r} failed: {exc}")
 
         return
 


### PR DESCRIPTION
An attempt at making plugins modify blocks rather than make their own block.

Here we register hooks at the plugin level for certain blocks, and these are called on the block itself after the plot is generated.

An example plugin utilising hooks:

https://github.com/datalab-industries/datalab-app-plugin-FAST

In this case the plugin will reparse the source file (needs data not stored in cache currently) and extracts a metric, this metric is then stored in the blocks data.