### PR TITLE
Fix minor API landing page issue

### DIFF
--- a/pydatalab/src/pydatalab/main.py
+++ b/pydatalab/src/pydatalab/main.py
@@ -203,13 +203,16 @@ def create_app(
 
             if current_user.is_authenticated:
                 for k in OAUTH_PROXIES:
-                    if k not in current_user.identity_types:
+                    if k in connect_buttons and k not in current_user.identity_types:
                         auth_string += f"<li>{connect_buttons[k]}</li>"
                 logout_string += f"<a href={url_for('logout')}>Log out</a>"
 
             else:
                 for k in OAUTH_PROXIES:
-                    auth_string += f"<li>{connect_buttons[k].replace('Connect', 'Login via')}</li>"
+                    if k in connect_buttons:
+                        auth_string += (
+                            f"<li>{connect_buttons[k].replace('Connect', 'Login via')}</li>"
+                        )
 
             auth_string += "</ul>"
 


### PR DESCRIPTION
#1705 broke the landing API landing page in a minor way that messes up status checks -- it tries to render buttons for connecting accounts that don't exist. I'm tempted to replace this landing page with some instructions and remove the login parts altogether, but for now this fixes the current broken behaviour.