### PR TITLE
Add all oauth buttons to debug API landing page

### DIFF
--- a/pydatalab/src/pydatalab/main.py
+++ b/pydatalab/src/pydatalab/main.py
@@ -147,87 +147,60 @@ def create_app(
                 '<p style="color: FireBrick">❎ Unable to connect to underlying database</p>'
             )
 
+        # Human-readable labels for providers whose blueprint name doesn't title-case
+        # nicely; anything not listed falls back to `key.title()`.
+        provider_labels = {"orcid": "ORCID", "github": "GitHub"}
+
+        def provider_label(identity_type) -> str:
+            key = getattr(identity_type, "value", identity_type)
+            return provider_labels.get(key, key.title())
+
+        app_link_string = ""
+        if CONFIG.APP_URL:
+            app_link_string = f'<p><a href="{CONFIG.APP_URL}">Go to the web app</a></p>'
+
+        links = []
+        identities_string = ""
+
         if connected:
             if current_user.is_authenticated:
-                welcome_string = f"""
-                    <h2>Hello, {current_user.display_name}!</h2>
-                    <h3>Connected identities:</h3>
-                    <ul>
-                """
+                welcome_string = f"<h2>Hello, {current_user.display_name}!</h2>"
 
-                for identity in current_user.identities:
-                    if identity.identity_type == "github":
-                        welcome_string += f"""
-                            <li>
-                                <a href="https://github.com/{identity.name}">
-                                    <i class="fa fa-github"></i>
-                                    {identity.name}
-                                </a>
-                            </li>
-                        """
+                # List the already-connected identities by provider.
+                identities = "".join(
+                    f"<li>{provider_label(identity.identity_type)}: {identity.name}</li>"
+                    for identity in current_user.identities
+                )
+                identities_string = f"<h3>Connected identities:</h3><ul>{identities}</ul>"
 
-                    elif identity.identity_type == "orcid":
-                        welcome_string += f"""
-                            <li>
-                                <a href="https://orcid.org/{identity.name}">
-                                    <img alt="ORCID logo" style="vertical-align: middle;", src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" />
-                                    {identity.name}
-                                </a>
-                            </li>
-                        """
-
-                welcome_string += "</ul>"
-
+                # Offer a connect link for each provider not yet linked.
+                for identity_type in OAUTH_PROXIES:
+                    if identity_type not in current_user.identity_types:
+                        key = getattr(identity_type, "value", identity_type)
+                        links.append(
+                            f"<a href={url_for(f'{key}.login')}>Connect {provider_label(identity_type)}</a>"
+                        )
+                links.append(f"<a href={url_for('logout')}>Log out</a>")
             else:
                 welcome_string = (
-                    """<h2>Welcome!</h2><h4>Please connect an OAuth account to continue:</h4>"""
+                    "<h2>Welcome!</h2><h4>Please connect an OAuth account to continue:</h4>"
                 )
-
-            connect_buttons = {
-                "github": f"""
-                    <a href={url_for("github.login")}>
-                        <i class="fa fa-github"></i>
-                        Connect GitHub
-                    </a></br>
-                """,
-                "orcid": f"""
-                    <a href={url_for("orcid.login")}>
-                        <img alt="ORCID logo" style="vertical-align: middle;", src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" />
-                        Connect ORCID
-                    </a></br>
-                """,
-            }
-
-            auth_string = "<ul>"
-            logout_string = ""
-
-            if current_user.is_authenticated:
-                for k in OAUTH_PROXIES:
-                    if k in connect_buttons and k not in current_user.identity_types:
-                        auth_string += f"<li>{connect_buttons[k]}</li>"
-                logout_string += f"<a href={url_for('logout')}>Log out</a>"
-
-            else:
-                for k in OAUTH_PROXIES:
-                    if k in connect_buttons:
-                        auth_string += (
-                            f"<li>{connect_buttons[k].replace('Connect', 'Login via')}</li>"
-                        )
-
-            auth_string += "</ul>"
-
+                for identity_type in OAUTH_PROXIES:
+                    key = getattr(identity_type, "value", identity_type)
+                    links.append(
+                        f"<a href={url_for(f'{key}.login')}>Login via {provider_label(identity_type)}</a>"
+                    )
         else:
-            auth_string = ""
-            logout_string = ""
             welcome_string = ""
 
-        return f"""<head>
-            <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-            </head>
+        links_string = "<ul>" + "".join(f"<li>{link}</li>" for link in links) + "</ul>"
+
+        return f"""
             <h2><p style="color: CornflowerBlue">Welcome to pydatalab</p></h2>
 <p>{welcome_string}</p>
-<p>{auth_string}</p>
-<p>{logout_string}</p>
+{app_link_string}
+{identities_string}
+{links_string}
 <h3>API status:</h3>
 <h4>{database_string}</h4>
 """

--- a/pydatalab/tests/server/test_info_and_health.py
+++ b/pydatalab/tests/server/test_info_and_health.py
@@ -21,6 +21,15 @@ def test_info_endpoint(client, url_prefix, app):
     assert auth["email"] is bool(app.config.get("MAIL_PASSWORD", None))
 
 
+def test_landing_page(unauthenticated_client, client):
+    """Check that the rudimentary landing page renders without error for both
+    unauthenticated and authenticated users."""
+    for _client in (unauthenticated_client, client):
+        response = _client.get("/")
+        assert response.status_code == 200
+        assert b"Welcome to pydatalab" in response.data
+
+
 @pytest.mark.parametrize("url_prefix", ["", "/v0", "/v0.1", "/v0.1.0"])
 def test_healthcheck_is_alive_endpoint(client, url_prefix):
     response = client.get(f"{url_prefix}/healthcheck/is_alive")


### PR DESCRIPTION
Supersedes #1815 and closes #1814  --- I think we do need this landing page for testing OAuth methods locally. This PR just simplifies it.