### PR TITLE
Preliminary support for custom item models

### DIFF
--- a/pydatalab/docs/plugins.md
+++ b/pydatalab/docs/plugins.md
@@ -1,9 +1,12 @@
 # Plugins
 
-*datalab*'s plugin system is under active development, as is this documentation page.
-The most mature plugin type are custom application data blocks, a template repository for which can be found at [datalab-org/datalab-app-plugin-template](https://github.com/datalab-org/datalab-app-plugin-template) (see more below).
+*datalab* supports plugins that extend the server with new functionality, in
+particular:
 
-*datalab* supports plugins that extend the server with new functionality.
+- New data block types, which render interactive views of attached files in item
+  detail pages.
+- Custom item types, which are served through the same generic endpoints as the built-in `samples`, `cells`, `starting_materials` and `equipment` types.
+
 Some self-declared plugins can be found via the [`datalab-plugin` topic on GitHub](https://github.com/topics/datalab-plugin), in lieu of a formal registry at this time.
 Plugins can also be kept private and installed from e.g., a private git repository, or a local path on the host, using the same installation described below.
 
@@ -12,11 +15,10 @@ Plugins can also be kept private and installed from e.g., a private git reposito
 
 ## What a plugin is
 
-At present, a *datalab* plugin is a Python package that registers one or more [data block](blocks/index.md) classes via a Python entry point.
+At present, a *datalab* plugin is a Python package that registers one or more [data block](blocks/index.md) classes or item types via a Python entry point.
 Data blocks ingest a file (or set of files) attached to an item and render an interactive view of the parsed data, e.g. an NMR spectrum, an electrochemistry cycler trace, or an XRD pattern.
+Plugins (and deployments) can also register **custom item types**, new top-level item models served through the generic item endpoints (see [below](#custom-item-types)). Further plugin types, e.g., ingestion hooks and webapp components, are planned in the future (see [roadmap.md](roadmap.md)); please reach out if you have a specific use case.
 *datalab* discovers them at server startup by enumerating the relevant entry point group, with no changes required to the core code.
-
-Additional plugin types: custom item types, ingestion hooks, and webapp components are planned in the future (see [roadmap.md](roadmap.md)); please reach out if you have a specific use case.
 
 ## Writing a plugin
 
@@ -65,6 +67,67 @@ To revert to the locked core dependencies without any plugins, run:
 ```shell
 uv sync --all-extras --dev
 ```
+
+## Custom item types
+
+Beyond data blocks, a deployment can register **custom item types** new top-level item models that are served through the same generic endpoints as the built-in `samples`, `cells`, `starting_materials` and `equipment` types, and advertised at `/info/types`.
+
+A custom item type is a subclass either of an existing item model (to extend it) or of the base `Item` model (for a wholly new type).
+At a minimum, it **must** declare its own unique `type` literal (this should be treated as namespaced the per-deployment to avoid collisions):
+
+```python
+from typing import Literal
+
+from pydantic import Field
+
+from pydatalab.models.samples import Sample
+
+
+class MySample(Sample):
+    type: Literal["my_samples"] = "my_samples"
+
+    drying_time: float | None = Field(
+        None,
+        # opt this field into item list/summary views:
+        json_schema_extra={"datalab_include_field_in_summary": True},
+    )
+```
+
+There are two ways to register a custom item type, both of which run at server startup and require no changes to the core code:
+
+1. **From a plugin package**, via the `pydatalab.item_types` entry point group
+   (mirrors the data block mechanism):
+
+    ```toml
+    # pyproject.toml of the plugin package
+    [project.entry-points."pydatalab.item_types"]
+    my_samples = "my_plugin.models:MySample"
+    ```
+
+2. **From the server config**, by listing dotted import paths
+   (`package.module:ClassName`) in `CUSTOM_ITEM_MODELS` — convenient for models
+   that are already importable by the server:
+
+    ```json
+    {
+      "CUSTOM_ITEM_MODELS": [
+        "my_package.models:MySample",
+        "my_package.models:MyItem"
+      ]
+    }
+    ```
+
+Custom types must use a `type` value that does not collide with a built-in type.
+Fields tagged with `json_schema_extra={"datalab_include_field_in_summary": True}` are additionally included in item list/summary responses.
+A worked example of both a `Sample` subclass and a standalone `Item` subclass lives at `pydatalab/src/pydatalab/models/_example_custom.py`.
+
+Eventually, such item types will allow for rich descriptions of unitful quantites, semantic annotations and URIs for fields, and cross-linking between items via custom relationships.
+
+!!! warning "Backend-only for now"
+    Custom item type support is currently backend-only: the web UI does not yet
+    render bespoke fields or provide tailored create/edit forms for custom types.
+
+## Plugin installation
 
 The same `invoke dev.install` task is used by the production Docker image (`.docker/server/Dockerfile`): a `plugins.toml` at the repository root is picked up automatically at build time, so plugins can be baked into a custom image without modifying the Dockerfile itself.
 It will also be invoked from the [*datalab* Ansible role](https://github.com/datalab-org/datalab-ansible-terraform) to provision plugins on a deployed server when a `plugins.toml` is provided; see the role documentation for details.

--- a/pydatalab/docs/plugins.md
+++ b/pydatalab/docs/plugins.md
@@ -73,7 +73,8 @@ uv sync --all-extras --dev
 Beyond data blocks, a deployment can register **custom item types**: new top-level item models that are served through the same generic endpoints as the built-in `samples`, `cells`, `starting_materials` and `equipment` types, and advertised at `/info/types`.
 
 A custom item type is a subclass either of an existing item model (to extend it) or of the base `Item` model (for a wholly new type).
-At a minimum, it **must** declare its own `type` literal, which must not collide with a built-in type and must begin with an underscore, reserving the un-prefixed namespace for built-in types:
+At a minimum, it **must** declare its own `type` literal, which must not collide with a built-in type.
+Custom types are namespaced with a leading underscore, reserving the un-prefixed namespace for built-in types; a type that does not already have one has it added at registration (so `my_samples` is served as `_my_samples`):
 
 ```python
 from typing import Literal
@@ -84,7 +85,7 @@ from pydatalab.models.samples import Sample
 
 
 class MySample(Sample):
-    type: Literal["_my_samples"] = "_my_samples"
+    type: Literal["my_samples"] = "my_samples"
 
     drying_time: float | None = Field(
         None,

--- a/pydatalab/docs/plugins.md
+++ b/pydatalab/docs/plugins.md
@@ -70,10 +70,10 @@ uv sync --all-extras --dev
 
 ## Custom item types
 
-Beyond data blocks, a deployment can register **custom item types** new top-level item models that are served through the same generic endpoints as the built-in `samples`, `cells`, `starting_materials` and `equipment` types, and advertised at `/info/types`.
+Beyond data blocks, a deployment can register **custom item types**: new top-level item models that are served through the same generic endpoints as the built-in `samples`, `cells`, `starting_materials` and `equipment` types, and advertised at `/info/types`.
 
 A custom item type is a subclass either of an existing item model (to extend it) or of the base `Item` model (for a wholly new type).
-At a minimum, it **must** declare its own unique `type` literal (this should be treated as namespaced the per-deployment to avoid collisions):
+At a minimum, it **must** declare its own `type` literal, which must not collide with a built-in type and must begin with an underscore, reserving the un-prefixed namespace for built-in types:
 
 ```python
 from typing import Literal
@@ -84,7 +84,7 @@ from pydatalab.models.samples import Sample
 
 
 class MySample(Sample):
-    type: Literal["my_samples"] = "my_samples"
+    type: Literal["_my_samples"] = "_my_samples"
 
     drying_time: float | None = Field(
         None,
@@ -117,15 +117,33 @@ There are two ways to register a custom item type, both of which run at server s
     }
     ```
 
-Custom types must use a `type` value that does not collide with a built-in type.
 Fields tagged with `json_schema_extra={"datalab_include_field_in_summary": True}` are additionally included in item list/summary responses.
 A worked example of both a `Sample` subclass and a standalone `Item` subclass lives at `pydatalab/src/pydatalab/models/_example_custom.py`.
 
-Eventually, such item types will allow for rich descriptions of unitful quantites, semantic annotations and URIs for fields, and cross-linking between items via custom relationships.
+### What belongs in a custom item type
+
+Custom item types are for metadata that describes the item itself, and in particular for values recorded for *every* item of that type:
+
+- **Intrinsic properties of the thing**: dimensions, a supplier batch number, an electrode loading.
+- **Input parameters of how it was made**: the settings of a synthesis or fabrication step (temperature, duration, atmosphere).
+- **High-level results that are always measured**: a single summary number per item — a capacity, a purity, a yield.
+
+Data with one value per file, per scan or per cycle belongs in a [data block](blocks/index.md) instead: a block can be attached many times, whereas a field exists exactly once per item.
+Similarly, anything with its own identity or provenance (a precursor batch, a piece of equipment) is better modelled as its own item and linked via a relationship.
+As a rule of thumb, if you would want to *filter* the item list by it, it is a field on the item type; if you would want to *plot* it, it is probably block data.
+
+!!! note "Extending nested fields is future work"
+    Custom types can add new fields, including nested models of their own, but
+    extending the structured fields that built-in models already define (e.g.
+    adding a field to the entries of `synthesis_constituents`) is not yet
+    supported.
 
 !!! warning "Backend-only for now"
-    Custom item type support is currently backend-only: the web UI does not yet
-    render bespoke fields or provide tailored create/edit forms for custom types.
+    The web UI does not yet render bespoke fields or provide tailored
+    create/edit forms for custom types, so custom fields are readable and
+    writable through the API but do not appear in item detail pages.
+
+Eventually, such item types will allow for rich descriptions of unitful quantites, semantic annotations and URIs for fields, and cross-linking between items via custom relationships.
 
 ## Plugin installation
 

--- a/pydatalab/docs/roadmap.md
+++ b/pydatalab/docs/roadmap.md
@@ -9,7 +9,7 @@ There are also [several issues with the 'suggestions' label](https://github.com/
 
 The plugin entry points exposed today only cover [data blocks](plugins.md). Planned extensions include:
 
-- **Custom item types** — register new top-level item models (beyond the built-in samples, cells, and starting materials) from a plugin package.
+- **Custom item types** [in-progress #1767](https://github.com/datalab-org/datalab/issues/1767) — register new top-level item models (beyond the built-in samples, cells, and starting materials) from a plugin package.
 - **Ingestion hooks** — allow plugins to register handlers that run on file upload, item creation, or other lifecycle events.
 - **Webapp components** — distribute Vue components alongside the Python plugin package so that custom blocks and item types can ship their own UI.
 

--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -937,19 +937,6 @@
       "title": "InlineSubstance",
       "type": "object"
     },
-    "KnownType": {
-      "description": "An enumeration of the types of entry known by this implementation, should be made dynamic in the future.",
-      "enum": [
-        "samples",
-        "starting_materials",
-        "blocks",
-        "files",
-        "people",
-        "collections"
-      ],
-      "title": "KnownType",
-      "type": "string"
-    },
     "Person": {
       "description": "A model that describes an individual and their digital identities.",
       "properties": {
@@ -1135,8 +1122,9 @@
           "description": "The type of relationship between the two items. If the type is 'other', then a human-readable description should be provided."
         },
         "type": {
-          "$ref": "#/$defs/KnownType",
-          "description": "The type of the related resource."
+          "description": "The type of the related resource.\n\nValidated dynamically against the registered item types plus the other\nknown entry types (see `KnownType`), so that custom item types can also\nparticipate in relationships.",
+          "title": "Type",
+          "type": "string"
         },
         "immutable_id": {
           "anyOf": [

--- a/pydatalab/schemas/equipment.json
+++ b/pydatalab/schemas/equipment.json
@@ -773,19 +773,6 @@
       "title": "IdentityType",
       "type": "string"
     },
-    "KnownType": {
-      "description": "An enumeration of the types of entry known by this implementation, should be made dynamic in the future.",
-      "enum": [
-        "samples",
-        "starting_materials",
-        "blocks",
-        "files",
-        "people",
-        "collections"
-      ],
-      "title": "KnownType",
-      "type": "string"
-    },
     "Person": {
       "description": "A model that describes an individual and their digital identities.",
       "properties": {
@@ -971,8 +958,9 @@
           "description": "The type of relationship between the two items. If the type is 'other', then a human-readable description should be provided."
         },
         "type": {
-          "$ref": "#/$defs/KnownType",
-          "description": "The type of the related resource."
+          "description": "The type of the related resource.\n\nValidated dynamically against the registered item types plus the other\nknown entry types (see `KnownType`), so that custom item types can also\nparticipate in relationships.",
+          "title": "Type",
+          "type": "string"
         },
         "immutable_id": {
           "anyOf": [

--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -922,19 +922,6 @@
       "title": "ItemStatus",
       "type": "string"
     },
-    "KnownType": {
-      "description": "An enumeration of the types of entry known by this implementation, should be made dynamic in the future.",
-      "enum": [
-        "samples",
-        "starting_materials",
-        "blocks",
-        "files",
-        "people",
-        "collections"
-      ],
-      "title": "KnownType",
-      "type": "string"
-    },
     "Person": {
       "description": "A model that describes an individual and their digital identities.",
       "properties": {
@@ -1120,8 +1107,9 @@
           "description": "The type of relationship between the two items. If the type is 'other', then a human-readable description should be provided."
         },
         "type": {
-          "$ref": "#/$defs/KnownType",
-          "description": "The type of the related resource."
+          "description": "The type of the related resource.\n\nValidated dynamically against the registered item types plus the other\nknown entry types (see `KnownType`), so that custom item types can also\nparticipate in relationships.",
+          "title": "Type",
+          "type": "string"
         },
         "immutable_id": {
           "anyOf": [

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -909,19 +909,6 @@
       "title": "InlineSubstance",
       "type": "object"
     },
-    "KnownType": {
-      "description": "An enumeration of the types of entry known by this implementation, should be made dynamic in the future.",
-      "enum": [
-        "samples",
-        "starting_materials",
-        "blocks",
-        "files",
-        "people",
-        "collections"
-      ],
-      "title": "KnownType",
-      "type": "string"
-    },
     "Person": {
       "description": "A model that describes an individual and their digital identities.",
       "properties": {
@@ -1121,8 +1108,9 @@
           "description": "The type of relationship between the two items. If the type is 'other', then a human-readable description should be provided."
         },
         "type": {
-          "$ref": "#/$defs/KnownType",
-          "description": "The type of the related resource."
+          "description": "The type of the related resource.\n\nValidated dynamically against the registered item types plus the other\nknown entry types (see `KnownType`), so that custom item types can also\nparticipate in relationships.",
+          "title": "Type",
+          "type": "string"
         },
         "immutable_id": {
           "anyOf": [

--- a/pydatalab/src/pydatalab/apps/__init__.py
+++ b/pydatalab/src/pydatalab/apps/__init__.py
@@ -140,3 +140,33 @@ def load_block_plugins():
 
 
 load_block_plugins()
+
+
+def load_item_plugins():
+    """Search through any registered entry points at 'pydatalab.item_types' and
+    register them as custom `Item` subclasses, making them available through the
+    generic item endpoints and at `/info/types`.
+
+    Each entry point must resolve to a concrete `Item` subclass declaring its
+    own unique `type` literal; `register_item_model` enforces this and mutates
+    the global `ITEM_MODELS`/`ITEM_SCHEMAS` registries in place.
+    """
+    from importlib.metadata import entry_points
+
+    from pydatalab.models import register_item_model
+
+    item_plugins = []
+    for entry_point in entry_points(group="pydatalab.item_types"):
+        # As with block plugins, tolerate the pydantic v2 deprecation warnings
+        # emitted at import time by plugins that have not yet migrated.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PydanticDeprecatedSince20)
+            model = entry_point.load()
+
+        register_item_model(model)
+        item_plugins.append(model)
+
+    return item_plugins
+
+
+load_item_plugins()

--- a/pydatalab/src/pydatalab/config.py
+++ b/pydatalab/src/pydatalab/config.py
@@ -258,6 +258,11 @@ its importance when deploying a datalab instance.""",
         description="A list of block type slugs (e.g. ['cycle', 'xrd']) that should be processed asynchronously via the task queue. Defaults to no blocks.",
     )
 
+    CUSTOM_ITEM_MODELS: list[str] = Field(
+        [],
+        description="A list of dotted import paths ('package.module:ClassName') to custom `Item` subclasses to register as additional item types served through the generic item endpoints, e.g. ['mypackage.models:MySample']. Each model must declare its own unique `type` literal.",
+    )
+
     BACKUP_STRATEGIES: dict[str, BackupStrategy] | None = Field(
         {
             "daily-snapshots": BackupStrategy(

--- a/pydatalab/src/pydatalab/main.py
+++ b/pydatalab/src/pydatalab/main.py
@@ -208,6 +208,7 @@ def create_app(
     # Register any custom item models declared in the config so that they are
     # served via the generic item endpoints and appear in `/info/types`.
     from pydatalab.models import load_custom_item_models
+
     load_custom_item_models(CONFIG.CUSTOM_ITEM_MODELS)
 
     register_endpoints(app)

--- a/pydatalab/src/pydatalab/main.py
+++ b/pydatalab/src/pydatalab/main.py
@@ -205,6 +205,11 @@ def create_app(
         )
         return response
 
+    # Register any custom item models declared in the config so that they are
+    # served via the generic item endpoints and appear in `/info/types`.
+    from pydatalab.models import load_custom_item_models
+    load_custom_item_models(CONFIG.CUSTOM_ITEM_MODELS)
+
     register_endpoints(app)
     LOGGER.info("App created.")
 

--- a/pydatalab/src/pydatalab/models/__init__.py
+++ b/pydatalab/src/pydatalab/models/__init__.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 
 from pydatalab.models.cells import Cell
 from pydatalab.models.collections import Collection
@@ -11,15 +12,40 @@ from pydatalab.models.starting_materials import StartingMaterial
 from pydatalab.models.versions import ItemVersion
 
 
+def _item_type_for(model: type[Item]) -> str:
+    """Return the `type` literal default declared by an item model."""
+    return model.model_json_schema()["properties"]["type"]["default"]
+
+
+def _all_item_subclasses(base: type[Item] = Item) -> list[type[Item]]:
+    """Recursively collect all concrete (non-abstract) subclasses of `Item`.
+
+    Unlike `Item.__subclasses__()`, this walks the full subclass tree so that
+    custom item types defined as subclasses of a *concrete* built-in (e.g.
+    `class MySample(Sample)`) are also discovered. Base classes appear before
+    their own subclasses, so callers can resolve `type` collisions in favour of
+    the more general (built-in) class via first-seen-wins.
+    """
+    subclasses: list[type[Item]] = []
+    for subclass in base.__subclasses__():
+        if not inspect.isabstract(subclass):
+            subclasses.append(subclass)
+        subclasses.extend(_all_item_subclasses(subclass))
+    return subclasses
+
+
 @functools.lru_cache(maxsize=1)
 def get_item_models() -> dict[str, type[Item]]:
+    """Returns a dictionary of item models keyed by their type.
+
+    If two models declare the same `type`, the first one seen wins (built-ins
+    are defined first, so they are never clobbered by a custom subclass that
+    forgot to override its `type` literal).
     """
-    Returns a dictionary of item models keyed by their type.
-    """
-    return {
-        model.model_json_schema()["properties"]["type"]["default"]: model
-        for model in Item.__subclasses__()
-    }
+    models: dict[str, type[Item]] = {}
+    for model in _all_item_subclasses():
+        models.setdefault(_item_type_for(model), model)
+    return models
 
 
 @functools.lru_cache(maxsize=1)
@@ -27,8 +53,106 @@ def generate_schemas() -> dict[str, dict]:
     return {t: model.model_json_schema(by_alias=False) for t, model in get_item_models().items()}
 
 
-ITEM_MODELS: dict[str, type[Item]] = get_item_models()
-ITEM_SCHEMAS = generate_schemas()
+# The registries are populated in place by `refresh_item_models` below and are
+# imported *by value* across the codebase (e.g. `from pydatalab.models import
+# ITEM_MODELS`). They must therefore always be mutated in place, never
+# reassigned, so that those importers observe later (dynamic) registrations.
+ITEM_MODELS: dict[str, type[Item]] = {}
+ITEM_SCHEMAS: dict[str, dict] = {}
+
+
+def refresh_item_models() -> None:
+    """Rebuild `ITEM_MODELS`/`ITEM_SCHEMAS` in place from the current set of
+    `Item` subclasses, picking up any models imported since the last build."""
+    get_item_models.cache_clear()
+    generate_schemas.cache_clear()
+    ITEM_MODELS.clear()
+    ITEM_MODELS.update(get_item_models())
+    ITEM_SCHEMAS.clear()
+    ITEM_SCHEMAS.update(generate_schemas())
+
+
+refresh_item_models()
+
+# Snapshot of the built-in item types, used to reject custom registrations that
+# collide with a reserved type.
+BUILTIN_ITEM_TYPES: frozenset[str] = frozenset(ITEM_MODELS)
+
+
+def register_item_model(model: type[Item]) -> None:
+    """Register a custom `Item` subclass into the global registries in place.
+
+    Validates that `model` is a concrete `Item` subclass declaring its own
+    unique `type` literal that does not collide with a built-in type. Safe to
+    call repeatedly with the same model.
+    """
+    if not (isinstance(model, type) and issubclass(model, Item)):
+        raise TypeError(f"{model!r} must be a subclass of Item to be registered as an item type.")
+
+    if inspect.isabstract(model):
+        raise TypeError(f"Cannot register abstract item model {model!r}.")
+
+    item_type = _item_type_for(model)
+
+    if item_type in BUILTIN_ITEM_TYPES:
+        raise ValueError(
+            f"Custom item model {model.__name__!r} uses the reserved built-in type {item_type!r}; "
+            "custom types must declare their own unique `type` literal."
+        )
+
+    existing = ITEM_MODELS.get(item_type)
+    if existing is not None and existing is not model:
+        raise ValueError(
+            f"Item type {item_type!r} is already registered to {existing.__name__!r}; "
+            f"cannot register {model.__name__!r}."
+        )
+
+    ITEM_MODELS[item_type] = model
+    ITEM_SCHEMAS[item_type] = model.model_json_schema(by_alias=False)
+
+
+def flagged_summary_fields(types) -> list[str]:
+    """Return the field names flagged with ``datalab_include_field_in_summary``
+    in the schemas of the given item types.
+
+    Used by the item list/summary endpoints to project additional fields beyond
+    the hand-tuned base projection, so that (custom or built-in) fields opt into
+    list views declaratively, e.g.::
+
+        drying_time: float | None = Field(
+            None, json_schema_extra={"datalab_include_field_in_summary": True}
+        )
+    """
+    fields: set[str] = set()
+    for item_type in types:
+        schema = ITEM_SCHEMAS.get(item_type)
+        if not schema:
+            continue
+        for name, prop in schema.get("properties", {}).items():
+            if isinstance(prop, dict) and prop.get("datalab_include_field_in_summary"):
+                fields.add(name)
+    return sorted(fields)
+
+
+def load_custom_item_models(paths: list[str]) -> None:
+    """Import and register custom item models from a list of dotted paths.
+
+    Each path is of the form ``"package.module:ClassName"`` and must resolve to
+    a concrete `Item` subclass declaring its own unique `type` literal. Used to
+    dynamically register deployment-specific item types from the config without
+    packaging them as plugins.
+    """
+    import importlib
+
+    for path in paths:
+        module_path, _, attr = path.partition(":")
+        if not module_path or not attr:
+            raise ValueError(
+                f"Invalid custom item model path {path!r}; expected 'package.module:ClassName'."
+            )
+        module = importlib.import_module(module_path)
+        register_item_model(getattr(module, attr))
+
 
 __all__ = (
     "File",
@@ -41,4 +165,9 @@ __all__ = (
     "ItemVersion",
     "ITEM_MODELS",
     "ITEM_SCHEMAS",
+    "BUILTIN_ITEM_TYPES",
+    "register_item_model",
+    "refresh_item_models",
+    "load_custom_item_models",
+    "flagged_summary_fields",
 )

--- a/pydatalab/src/pydatalab/models/__init__.py
+++ b/pydatalab/src/pydatalab/models/__init__.py
@@ -61,30 +61,91 @@ ITEM_MODELS: dict[str, type[Item]] = {}
 ITEM_SCHEMAS: dict[str, dict] = {}
 
 
+# Snapshot of the built-in item types, used to reject custom registrations that
+# collide with a reserved type. Populated by the bootstrapping call to
+# `refresh_item_models` below, which is the only call made before it is set.
+BUILTIN_ITEM_TYPES: frozenset[str] = frozenset()
+
+
 def refresh_item_models() -> None:
-    """Rebuild `ITEM_MODELS`/`ITEM_SCHEMAS` in place from the current set of
-    `Item` subclasses, picking up any models imported since the last build."""
+    """Rebuild the built-in entries of `ITEM_MODELS`/`ITEM_SCHEMAS` in place from
+    the current set of `Item` subclasses.
+
+    Custom item types are deliberately *not* rediscovered by the subclass walk:
+    they are owned by `register_item_model`, which validates them and rewrites
+    un-namespaced types in place. Picking them up here would register whatever
+    `type` they happen to declare, bypassing that namespacing, so any already
+    registered custom types are left untouched instead.
+    """
     get_item_models.cache_clear()
     generate_schemas.cache_clear()
-    ITEM_MODELS.clear()
-    ITEM_MODELS.update(get_item_models())
-    ITEM_SCHEMAS.clear()
-    ITEM_SCHEMAS.update(generate_schemas())
+
+    models = get_item_models()
+    schemas = generate_schemas()
+
+    if BUILTIN_ITEM_TYPES:
+        models = {t: model for t, model in models.items() if t in BUILTIN_ITEM_TYPES}
+        schemas = {t: schema for t, schema in schemas.items() if t in BUILTIN_ITEM_TYPES}
+    else:
+        # Bootstrapping call at import time: only the built-ins exist.
+        ITEM_MODELS.clear()
+        ITEM_SCHEMAS.clear()
+
+    ITEM_MODELS.update(models)
+    ITEM_SCHEMAS.update(schemas)
 
 
 refresh_item_models()
 
-# Snapshot of the built-in item types, used to reject custom registrations that
-# collide with a reserved type.
-BUILTIN_ITEM_TYPES: frozenset[str] = frozenset(ITEM_MODELS)
+BUILTIN_ITEM_TYPES = frozenset(ITEM_MODELS)
+
+
+def _namespace_item_model(model: type[Item], item_type: str) -> str:
+    """Rewrite the `type` literal of an item model *in place* to `item_type`.
+
+    Custom item types are namespaced with a leading to
+    reserve the un-prefixed namespace for built-in types. Rather than
+    registering a synthesised subclass carrying the namespaced literal, the
+    declaring class itself is modified, so that a model constructed directly by
+    plugin code (`MySample(item_id=...)`) and one constructed by the server
+    through the registry agree on their `type`, and so that `isinstance` checks
+    against the declaring class continue to hold.
+
+    Returns the namespaced type.
+    """
+    from typing import Literal
+
+    from pydantic.fields import FieldInfo
+
+    # Imported lazily: `pydatalab.logger` pulls in `CONFIG`, which imports this
+    # module, so a top-level import would be circular.
+    from pydatalab.logger import LOGGER
+
+    field = model.model_fields["type"]
+    fields = getattr(model, "__pydantic_fields__", model.model_fields)
+    fields["type"] = FieldInfo(
+        annotation=Literal[item_type],  # type: ignore[valid-type]
+        default=item_type,
+        description=field.description,
+    )
+    # Force a rebuild so the validators and (JSON) schemas are regenerated from
+    # the rewritten field rather than the cached core schema.
+    model.model_rebuild(force=True)
+
+    LOGGER.debug("Namespaced custom item type of %s as %s", model.__name__, item_type)
+
+    return item_type
 
 
 def register_item_model(model: type[Item]) -> None:
     """Register a custom `Item` subclass into the global registries in place.
 
     Validates that `model` is a concrete `Item` subclass declaring its own
-    unique `type` literal that does not collide with a built-in type. Safe to
-    call repeatedly with the same model.
+    unique `type` literal that does not collide with a built-in type. A type
+    that is not already namespaced (i.e. does not begin with an underscore) is
+    rewritten in place by `_namespace_item_model`, so a model declaring
+    `my_samples` is registered and served as `_my_samples`. Safe to call
+    repeatedly with the same model.
     """
     if not (isinstance(model, type) and issubclass(model, Item)):
         raise TypeError(f"{model!r} must be a subclass of Item to be registered as an item type.")
@@ -101,13 +162,7 @@ def register_item_model(model: type[Item]) -> None:
         )
 
     if not item_type.startswith("_"):
-        raise ValueError(
-            f"Custom item model {model.__name__!r} declares the un-namespaced type {item_type!r}; "
-            "custom types must be namespaced with a leading underscore, e.g. '_my_samples'. "
-            "This reserves the un-prefixed namespace for built-in types and allows a future "
-            "release to rewrite custom types into a per-deployment namespace "
-            "(e.g. '_exmpl:my_samples') without a migration."
-        )
+        item_type = _namespace_item_model(model, f"_{item_type}")
 
     existing = ITEM_MODELS.get(item_type)
     if existing is not None and existing is not model:

--- a/pydatalab/src/pydatalab/models/__init__.py
+++ b/pydatalab/src/pydatalab/models/__init__.py
@@ -100,6 +100,15 @@ def register_item_model(model: type[Item]) -> None:
             "custom types must declare their own unique `type` literal."
         )
 
+    if not item_type.startswith("_"):
+        raise ValueError(
+            f"Custom item model {model.__name__!r} declares the un-namespaced type {item_type!r}; "
+            "custom types must be namespaced with a leading underscore, e.g. '_my_samples'. "
+            "This reserves the un-prefixed namespace for built-in types and allows a future "
+            "release to rewrite custom types into a per-deployment namespace "
+            "(e.g. '_exmpl:my_samples') without a migration."
+        )
+
     existing = ITEM_MODELS.get(item_type)
     if existing is not None and existing is not model:
         raise ValueError(
@@ -109,6 +118,23 @@ def register_item_model(model: type[Item]) -> None:
 
     ITEM_MODELS[item_type] = model
     ITEM_SCHEMAS[item_type] = model.model_json_schema(by_alias=False)
+
+
+def constituent_item_types() -> set[str]:
+    """Return the set of registered item types that may be referenced as a
+    constituent of another item (e.g. in `synthesis_constituents`).
+
+    An item can be a constituent if its model carries substance information
+    (i.e. mixes in `HasSubstanceInfo`), which is true of the built-in `samples`
+    and `starting_materials` types and of any custom item type that opts in.
+    This is computed from the live registry on each call, so custom item types
+    registered at startup are included.
+    """
+    from pydatalab.models.traits import HasSubstanceInfo
+
+    return {
+        item_type for item_type, model in ITEM_MODELS.items() if issubclass(model, HasSubstanceInfo)
+    }
 
 
 def flagged_summary_fields(types) -> list[str]:
@@ -170,4 +196,5 @@ __all__ = (
     "refresh_item_models",
     "load_custom_item_models",
     "flagged_summary_fields",
+    "constituent_item_types",
 )

--- a/pydatalab/src/pydatalab/models/_example_custom.py
+++ b/pydatalab/src/pydatalab/models/_example_custom.py
@@ -1,0 +1,62 @@
+"""Example custom item models, used to demonstrate and test the registration of
+deployment-specific item types via ``CONFIG.CUSTOM_ITEM_MODELS``.
+
+These are intentionally *not* registered by default; a deployment (or the test
+suite) opts in by listing their dotted paths in ``CUSTOM_ITEM_MODELS``::
+
+    CUSTOM_ITEM_MODELS = [
+        "pydatalab.models._example_custom:MySample",
+        "pydatalab.models._example_custom:MyItem",
+    ]
+
+Once registered they are served through the generic item endpoints
+(``/new-sample/``, ``/items/<refcode>``, ``/save-item/``) and advertised at
+``/info/types`` with no further code.
+"""
+
+from typing import Literal
+
+from pydantic import Field
+
+from pydatalab.models.items import Item
+from pydatalab.models.samples import Sample
+from pydatalab.models.utils import BaseModel
+
+
+class CustomProperties(BaseModel):
+    """A nested object demonstrating that custom item fields may themselves be
+    structured models, not just scalars."""
+
+    batch: str | None = None
+    """An arbitrary batch identifier."""
+
+    purity: float | None = None
+    """A fractional purity between 0 and 1."""
+
+
+class MySample(Sample):
+    """An example custom sample type with a couple of extra fields, including a
+    nested object, demonstrating top-level schema extension of a built-in."""
+
+    type: Literal["my_samples"] = "my_samples"  # type: ignore[assignment]
+
+    drying_time: float | None = Field(
+        None, json_schema_extra={"datalab_include_field_in_summary": True}
+    )
+    """An example extra top-level scalar field (hours), surfaced in list views."""
+
+    custom_properties: CustomProperties | None = None
+    """An example extra nested field."""
+
+
+class MyItem(Item):
+    """An example wholly custom item type (not sample-derived) with custom
+    'dimension' fields."""
+
+    type: Literal["my_items"] = "my_items"  # type: ignore[assignment]
+
+    width: float | None = Field(None, json_schema_extra={"datalab_include_field_in_summary": True})
+    """An example custom dimension (mm), surfaced in list views."""
+
+    height: float | None = None
+    """An example custom dimension (mm)."""

--- a/pydatalab/src/pydatalab/models/_example_custom.py
+++ b/pydatalab/src/pydatalab/models/_example_custom.py
@@ -38,7 +38,7 @@ class MySample(Sample):
     """An example custom sample type with a couple of extra fields, including a
     nested object, demonstrating top-level schema extension of a built-in."""
 
-    type: Literal["my_samples"] = "my_samples"  # type: ignore[assignment]
+    type: Literal["_my_samples"] = "_my_samples"  # type: ignore[assignment]
 
     drying_time: float | None = Field(
         None, json_schema_extra={"datalab_include_field_in_summary": True}
@@ -53,7 +53,7 @@ class MyItem(Item):
     """An example wholly custom item type (not sample-derived) with custom
     'dimension' fields."""
 
-    type: Literal["my_items"] = "my_items"  # type: ignore[assignment]
+    type: Literal["_my_items"] = "_my_items"  # type: ignore[assignment]
 
     width: float | None = Field(None, json_schema_extra={"datalab_include_field_in_summary": True})
     """An example custom dimension (mm), surfaced in list views."""

--- a/pydatalab/src/pydatalab/models/_example_custom.py
+++ b/pydatalab/src/pydatalab/models/_example_custom.py
@@ -12,6 +12,10 @@ suite) opts in by listing their dotted paths in ``CUSTOM_ITEM_MODELS``::
 Once registered they are served through the generic item endpoints
 (``/new-sample/``, ``/items/<refcode>``, ``/save-item/``) and advertised at
 ``/info/types`` with no further code.
+
+Note that the types declared below are deliberately *not* namespaced: they are
+rewritten at registration time, so they are served as ``_my_samples`` and
+``_my_items``.
 """
 
 from typing import Literal
@@ -38,7 +42,7 @@ class MySample(Sample):
     """An example custom sample type with a couple of extra fields, including a
     nested object, demonstrating top-level schema extension of a built-in."""
 
-    type: Literal["_my_samples"] = "_my_samples"  # type: ignore[assignment]
+    type: Literal["my_samples"] = "my_samples"  # type: ignore[assignment]
 
     drying_time: float | None = Field(
         None, json_schema_extra={"datalab_include_field_in_summary": True}
@@ -53,7 +57,7 @@ class MyItem(Item):
     """An example wholly custom item type (not sample-derived) with custom
     'dimension' fields."""
 
-    type: Literal["_my_items"] = "_my_items"  # type: ignore[assignment]
+    type: Literal["my_items"] = "my_items"  # type: ignore[assignment]
 
     width: float | None = Field(None, json_schema_extra={"datalab_include_field_in_summary": True})
     """An example custom dimension (mm), surfaced in list views."""

--- a/pydatalab/src/pydatalab/models/relationships.py
+++ b/pydatalab/src/pydatalab/models/relationships.py
@@ -44,8 +44,13 @@ class TypedRelationship(BaseModel):
     relation: RelationshipType | None = None
     """The type of relationship between the two items. If the type is 'other', then a human-readable description should be provided."""
 
-    type: KnownType
-    """The type of the related resource."""
+    type: str
+    """The type of the related resource.
+
+    Validated dynamically against the registered item types plus the other
+    known entry types (see `KnownType`), so that custom item types can also
+    participate in relationships.
+    """
 
     immutable_id: PyObjectId | None = None
     """The immutable ID of the entry that is related to this entry."""
@@ -55,6 +60,22 @@ class TypedRelationship(BaseModel):
 
     refcode: Refcode | None = None
     """The refcode of the entry that is related to this entry."""
+
+    @field_validator("type")
+    @classmethod
+    def check_known_type(cls, v):
+        """Check that the related resource is of a type known to this deployment.
+
+        The set of valid types is resolved at validation time from the item
+        registry (which includes any custom item types) together with the
+        non-item entry types enumerated by `KnownType`.
+        """
+        from pydatalab.models import ITEM_MODELS
+
+        known = set(ITEM_MODELS) | {known_type.value for known_type in KnownType}
+        if v not in known:
+            raise ValueError(f"`type` must be one of {sorted(known)!r}, not {v!r}")
+        return v
 
     @field_validator("relation")
     @classmethod

--- a/pydatalab/src/pydatalab/models/traits.py
+++ b/pydatalab/src/pydatalab/models/traits.py
@@ -121,6 +121,7 @@ class HasSynthesisInfo(BaseModel):
     @model_validator(mode="after")
     def add_missing_synthesis_relationships(self):
         """Add any missing sample synthesis constituents to parent relationships"""
+        from pydatalab.models import constituent_item_types
         from pydatalab.models.relationships import RelationshipType, TypedRelationship
 
         constituents_set = set()
@@ -171,7 +172,9 @@ class HasSynthesisInfo(BaseModel):
                 constituents_set.update(i for i in (refcode, item_id) if i)
 
         # Finally, filter out any parent relationships with item that were removed
-        # from the synthesis constituents
+        # from the synthesis constituents. The set of constituent-capable types is
+        # resolved dynamically so that custom item types are also cleaned up.
+        removable_types = constituent_item_types()
         self.relationships = [
             rel
             for rel in self.relationships
@@ -179,7 +182,7 @@ class HasSynthesisInfo(BaseModel):
                 rel.refcode not in constituents_set
                 and rel.item_id not in constituents_set
                 and rel.relation == RelationshipType.PARENT
-                and rel.type in ("samples", "starting_materials")
+                and rel.type in removable_types
             )
         ]
 

--- a/pydatalab/src/pydatalab/models/utils.py
+++ b/pydatalab/src/pydatalab/models/utils.py
@@ -50,7 +50,14 @@ class BaseModel(PydanticBaseModel):
 
 
 class ItemType(str, Enum):
-    """An enumeration of the types of items known by this implementation, should be made dynamic in the future."""
+    """An enumeration of the built-in item types that can act as a constituent
+    of another item.
+
+    Retained for backwards compatibility only: the set of types accepted as a
+    constituent is now resolved dynamically from the item registry, via
+    `pydatalab.models.constituent_item_types`, so that custom item types are
+    also included.
+    """
 
     SAMPLES = "samples"
     STARTING_MATERIALS = "starting_materials"
@@ -372,9 +379,19 @@ class Constituent(BaseModel):
     @field_validator("item")
     @classmethod
     def check_itemhood(cls, v):
-        """Check that the reference within the constituent is to an item type."""
-        if hasattr(v, "type") and v.type not in [item_type.value for item_type in ItemType]:
-            raise ValueError(f"`type` must be one of {[t.value for t in ItemType]!r}")
+        """Check that the reference within the constituent is to an item type
+        that can act as a constituent, i.e. one that carries substance
+        information.
+
+        The allowed types are resolved from the live item registry rather than
+        hardcoded, so that custom item types (see `docs/plugins.md`) can be used
+        as constituents.
+        """
+        from pydatalab.models import constituent_item_types
+
+        allowed = constituent_item_types()
+        if hasattr(v, "type") and v.type not in allowed:
+            raise ValueError(f"`type` must be one of {sorted(allowed)!r}")
         return v
 
     @field_validator("item", mode="before")

--- a/pydatalab/src/pydatalab/routes/v0_1/collections.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/collections.py
@@ -97,7 +97,9 @@ def create_collection():
     request_json = request.get_json()  # noqa: F821 pylint: disable=undefined-variable
     data = request_json.get("data", {})
     copy_from_id = request_json.get("copy_from_collection_id", None)
-    starting_members = data.get("starting_members", [])
+    starting_members = data.pop("starting_members", [])
+    # Consumed below to populate `creator_ids`; not a field of `Collection` itself.
+    additional_creators = data.pop("additional_creators", None)
 
     if not current_user.is_authenticated and not CONFIG.TESTING:
         return (
@@ -124,8 +126,8 @@ def create_collection():
             }
         ]
 
-    if data.get("additional_creators"):
-        for c in data["additional_creators"]:
+    if additional_creators:
+        for c in additional_creators:
             creator_id = c.get("_id") or c.get("immutable_id")
             if creator_id:
                 data["creator_ids"].append(ObjectId(creator_id))

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -16,7 +16,7 @@ from werkzeug.exceptions import BadRequest, Conflict, InternalServerError, NotFo
 from pydatalab.apps import BLOCK_TYPES
 from pydatalab.config import CONFIG
 from pydatalab.logger import LOGGER
-from pydatalab.models import ITEM_MODELS, ItemVersion
+from pydatalab.models import ITEM_MODELS, ItemVersion, flagged_summary_fields
 from pydatalab.models.items import Item
 from pydatalab.models.relationships import RelationshipType
 from pydatalab.models.utils import InlineSubstance, generate_unique_refcode
@@ -77,6 +77,9 @@ def get_equipment_summary():
         "status": 1,
     }
 
+    for field in flagged_summary_fields(("equipment",)):
+        _project.setdefault(field, 1)
+
     items = [
         doc
         for doc in flask_mongo.db.items.aggregate(
@@ -95,6 +98,44 @@ def get_equipment_summary():
 
 @ITEMS.route("/starting-materials/", methods=["GET"])
 def get_starting_materials():
+    _project = {
+        "_id": 0,
+        "item_id": 1,
+        "blocks": {
+            "$map": {
+                "input": {"$objectToArray": {"$ifNull": ["$blocks_obj", {}]}},
+                "as": "b",
+                "in": {
+                    "blocktype": "$$b.v.blocktype",
+                    "title": "$$b.v.title",
+                },
+            }
+        },
+        "collections": {
+            "collection_id": 1,
+        },
+        "nblocks": {"$size": "$display_order"},
+        "nfiles": {"$size": "$file_ObjectIds"},
+        "date": 1,
+        "chemform": 1,
+        "smiles": 1,
+        "inchi_key": 1,
+        "GHS_codes": 1,
+        "molar_mass": 1,
+        "name": 1,
+        "type": 1,
+        "chemical_purity": 1,
+        "barcode": 1,
+        "refcode": 1,
+        "supplier": 1,
+        "location": 1,
+        "status": 1,
+        "CAS": 1,
+    }
+
+    for field in flagged_summary_fields(("starting_materials",)):
+        _project.setdefault(field, 1)
+
     items = [
         doc
         for doc in flask_mongo.db.items.aggregate(
@@ -212,6 +253,11 @@ def get_items_summary(match: dict | None = None, project: dict | None = None) ->
         "status": 1,
     }
 
+    # Include any fields (across all registered item types, including custom
+    # ones) that opt into summaries via `datalab_include_field_in_summary`.
+    for field in flagged_summary_fields(ITEM_MODELS):
+        _project.setdefault(field, 1)
+
     # Cannot mix 0 and 1 keys in MongoDB project so must loop and check
     if project:
         for key in project:
@@ -288,6 +334,11 @@ def get_samples_summary(match: dict | None = None, project: dict | None = None) 
         "refcode": 1,
         "status": 1,
     }
+
+    # Include any fields on samples/cells (including custom subclasses) that opt
+    # into summaries via `datalab_include_field_in_summary`.
+    for field in flagged_summary_fields(("samples", "cells")):
+        _project.setdefault(field, 1)
 
     # Cannot mix 0 and 1 keys in MongoDB project so must loop and check
     if project:

--- a/pydatalab/tests/server/conftest.py
+++ b/pydatalab/tests/server/conftest.py
@@ -400,7 +400,6 @@ def fixture_default_collection():
         **{
             "collection_id": "test_collection",
             "title": "My Test Collection",
-            "date": "1970-02-02",
             "type": "collections",
         }
     )

--- a/pydatalab/tests/server/test_custom_item_types.py
+++ b/pydatalab/tests/server/test_custom_item_types.py
@@ -136,3 +136,48 @@ def test_unknown_custom_type_rejected(client, custom_item_models):
         json={"new_sample_data": {"type": "not_a_real_type", "item_id": "bad-1"}},
     )
     assert response.status_code == 400, response.json
+
+
+def test_bad_custom_item_type_rejected():
+    """A custom model is rejected at registration time if it reuses a reserved
+    built-in `type`, or if it is not an `Item` subclass at all."""
+    from typing import Literal
+
+    from pydatalab.models import register_item_model
+    from pydatalab.models.samples import Sample
+
+    class ClashingSample(Sample):
+        # Reuses the built-in "samples" type instead of declaring its own.
+        type: Literal["samples"] = "samples"  # type: ignore[assignment]
+
+    with pytest.raises(ValueError, match="reserved built-in type"):
+        register_item_model(ClashingSample)
+
+    # Anything that is not an `Item` subclass is also rejected.
+    with pytest.raises(TypeError):
+        register_item_model(dict)
+
+
+def test_extra_fields_on_builtin_sample_are_ignored(client):
+    """Stuffing custom-schema fields into a plain `samples` item does not persist
+    them: the built-in `Sample` model ignores unknown fields (`extra="ignore"`),
+    so custom data only "sticks" on a registered custom type."""
+    response = client.post(
+        "/new-sample/",
+        json={
+            "new_sample_data": {
+                "type": "samples",
+                "item_id": "plain-sample-extra",
+                "drying_time": 99.0,
+                "custom_properties": {"batch": "X", "purity": 0.1},
+            }
+        },
+    )
+    assert response.status_code == 201, response.json
+
+    response = client.get("/get-item-data/plain-sample-extra")
+    assert response.status_code == 200, response.json
+    item_data = response.json["item_data"]
+    assert item_data["type"] == "samples"
+    assert "drying_time" not in item_data
+    assert "custom_properties" not in item_data

--- a/pydatalab/tests/server/test_custom_item_types.py
+++ b/pydatalab/tests/server/test_custom_item_types.py
@@ -1,0 +1,138 @@
+"""Integration tests for custom item types registered via the server config.
+
+Registers the in-repo example custom models (`pydatalab.models._example_custom`)
+through `CONFIG.CUSTOM_ITEM_MODELS` / `load_custom_item_models` (the same path
+used at server startup), then checks that they are advertised at `/info/types`
+and can be created and read back through the generic item endpoints on the
+standard test server.
+
+The models are registered into the *global* item registries (and the `CONFIG`
+singleton), so the fixture restores both afterwards to avoid leaking the custom
+types into other test modules.
+"""
+
+import copy
+
+import pytest
+
+EXAMPLE_CUSTOM_MODELS = [
+    "pydatalab.models._example_custom:MySample",
+    "pydatalab.models._example_custom:MyItem",
+]
+
+
+@pytest.fixture(scope="module")
+def custom_item_models():
+    """Register the example custom item models with the running server, mirroring
+    the `CONFIG.CUSTOM_ITEM_MODELS` startup path, and restore the registries and
+    config afterwards.
+
+    The item routes and `/info/types` read the registries live, so registering
+    after the app has been created is sufficient and needs no second app.
+    """
+    import pydatalab.models as models
+    from pydatalab.config import CONFIG
+
+    models_snapshot = copy.copy(models.ITEM_MODELS)
+    schemas_snapshot = copy.copy(models.ITEM_SCHEMAS)
+    config_snapshot = list(CONFIG.CUSTOM_ITEM_MODELS)
+
+    CONFIG.CUSTOM_ITEM_MODELS = list(EXAMPLE_CUSTOM_MODELS)
+    models.load_custom_item_models(CONFIG.CUSTOM_ITEM_MODELS)
+
+    try:
+        yield
+    finally:
+        models.ITEM_MODELS.clear()
+        models.ITEM_MODELS.update(models_snapshot)
+        models.ITEM_SCHEMAS.clear()
+        models.ITEM_SCHEMAS.update(schemas_snapshot)
+        CONFIG.CUSTOM_ITEM_MODELS = config_snapshot
+
+
+def test_custom_types_listed_in_info_types(client, custom_item_models):
+    """The configured custom types and their extra fields appear at /info/types."""
+    response = client.get("/info/types", follow_redirects=True)
+    assert response.status_code == 200
+
+    types = {entry["id"] for entry in response.json["data"]}
+    assert "my_samples" in types
+    assert "my_items" in types
+
+    sample_schema = client.get("/info/types/my_samples", follow_redirects=True).json["data"][
+        "attributes"
+    ]["schema"]
+    properties = sample_schema["properties"]
+    # Extra top-level scalar, nested object, and inherited Sample fields are all present.
+    assert "drying_time" in properties
+    assert "custom_properties" in properties
+    assert "chemform" in properties
+    # The summary flag is carried through into the schema.
+    assert properties["drying_time"].get("datalab_include_field_in_summary") is True
+
+    item_schema = client.get("/info/types/my_items", follow_redirects=True).json["data"][
+        "attributes"
+    ]["schema"]
+    assert "width" in item_schema["properties"]
+    assert "height" in item_schema["properties"]
+
+
+def test_create_and_read_custom_sample(client, custom_item_models):
+    """A custom Sample subclass can be created and round-tripped, including a
+    nested custom field, through the generic endpoints."""
+    response = client.post(
+        "/new-sample/",
+        json={
+            "new_sample_data": {
+                "type": "my_samples",
+                "item_id": "custom-sample-1",
+                "drying_time": 3.5,
+                "custom_properties": {"batch": "B7", "purity": 0.95},
+            }
+        },
+    )
+    assert response.status_code == 201, response.json
+    assert response.json["status"] == "success"
+    assert response.json["sample_list_entry"]["type"] == "my_samples"
+
+    response = client.get("/get-item-data/custom-sample-1")
+    assert response.status_code == 200, response.json
+    item_data = response.json["item_data"]
+    assert item_data["type"] == "my_samples"
+    assert item_data["drying_time"] == 3.5
+    assert item_data["custom_properties"]["batch"] == "B7"
+    assert item_data["custom_properties"]["purity"] == 0.95
+
+
+def test_create_wholly_custom_item(client, custom_item_models):
+    """An item type subclassing `Item` directly can be created and read back."""
+    response = client.post(
+        "/new-sample/",
+        json={
+            "new_sample_data": {
+                "type": "my_items",
+                "item_id": "custom-item-1",
+                "width": 12.0,
+                "height": 4.0,
+            }
+        },
+    )
+    assert response.status_code == 201, response.json
+    assert response.json["status"] == "success"
+
+    response = client.get("/get-item-data/custom-item-1")
+    assert response.status_code == 200, response.json
+    item_data = response.json["item_data"]
+    assert item_data["type"] == "my_items"
+    assert item_data["width"] == 12.0
+    assert item_data["height"] == 4.0
+
+
+def test_unknown_custom_type_rejected(client, custom_item_models):
+    """A type that was not registered is still rejected by the generic create
+    endpoint."""
+    response = client.post(
+        "/new-sample/",
+        json={"new_sample_data": {"type": "not_a_real_type", "item_id": "bad-1"}},
+    )
+    assert response.status_code == 400, response.json

--- a/pydatalab/tests/server/test_custom_item_types.py
+++ b/pydatalab/tests/server/test_custom_item_types.py
@@ -56,10 +56,10 @@ def test_custom_types_listed_in_info_types(client, custom_item_models):
     assert response.status_code == 200
 
     types = {entry["id"] for entry in response.json["data"]}
-    assert "my_samples" in types
-    assert "my_items" in types
+    assert "_my_samples" in types
+    assert "_my_items" in types
 
-    sample_schema = client.get("/info/types/my_samples", follow_redirects=True).json["data"][
+    sample_schema = client.get("/info/types/_my_samples", follow_redirects=True).json["data"][
         "attributes"
     ]["schema"]
     properties = sample_schema["properties"]
@@ -70,7 +70,7 @@ def test_custom_types_listed_in_info_types(client, custom_item_models):
     # The summary flag is carried through into the schema.
     assert properties["drying_time"].get("datalab_include_field_in_summary") is True
 
-    item_schema = client.get("/info/types/my_items", follow_redirects=True).json["data"][
+    item_schema = client.get("/info/types/_my_items", follow_redirects=True).json["data"][
         "attributes"
     ]["schema"]
     assert "width" in item_schema["properties"]
@@ -84,7 +84,7 @@ def test_create_and_read_custom_sample(client, custom_item_models):
         "/new-sample/",
         json={
             "new_sample_data": {
-                "type": "my_samples",
+                "type": "_my_samples",
                 "item_id": "custom-sample-1",
                 "drying_time": 3.5,
                 "custom_properties": {"batch": "B7", "purity": 0.95},
@@ -93,12 +93,12 @@ def test_create_and_read_custom_sample(client, custom_item_models):
     )
     assert response.status_code == 201, response.json
     assert response.json["status"] == "success"
-    assert response.json["sample_list_entry"]["type"] == "my_samples"
+    assert response.json["sample_list_entry"]["type"] == "_my_samples"
 
     response = client.get("/get-item-data/custom-sample-1")
     assert response.status_code == 200, response.json
     item_data = response.json["item_data"]
-    assert item_data["type"] == "my_samples"
+    assert item_data["type"] == "_my_samples"
     assert item_data["drying_time"] == 3.5
     assert item_data["custom_properties"]["batch"] == "B7"
     assert item_data["custom_properties"]["purity"] == 0.95
@@ -110,7 +110,7 @@ def test_create_wholly_custom_item(client, custom_item_models):
         "/new-sample/",
         json={
             "new_sample_data": {
-                "type": "my_items",
+                "type": "_my_items",
                 "item_id": "custom-item-1",
                 "width": 12.0,
                 "height": 4.0,
@@ -123,9 +123,73 @@ def test_create_wholly_custom_item(client, custom_item_models):
     response = client.get("/get-item-data/custom-item-1")
     assert response.status_code == 200, response.json
     item_data = response.json["item_data"]
-    assert item_data["type"] == "my_items"
+    assert item_data["type"] == "_my_items"
     assert item_data["width"] == 12.0
     assert item_data["height"] == 4.0
+
+
+def test_custom_type_as_synthesis_constituent(client, custom_item_models):
+    """A custom sample-derived type can be used as a synthesis constituent of
+    another item, since the allowed constituent types are resolved from the live
+    item registry rather than a fixed enum."""
+    response = client.post(
+        "/new-sample/",
+        json={
+            "new_sample_data": {
+                "type": "_my_samples",
+                "item_id": "custom-constituent-1",
+                "name": "A custom precursor",
+            }
+        },
+    )
+    assert response.status_code == 201, response.json
+
+    response = client.post(
+        "/new-sample/",
+        json={
+            "new_sample_data": {
+                "type": "samples",
+                "item_id": "sample-with-custom-constituent",
+                "synthesis_constituents": [
+                    {
+                        "item": {"item_id": "custom-constituent-1", "type": "_my_samples"},
+                        "quantity": 1.0,
+                        "unit": "g",
+                    }
+                ],
+            }
+        },
+    )
+    assert response.status_code == 201, response.json
+
+    response = client.get("/get-item-data/sample-with-custom-constituent")
+    assert response.status_code == 200, response.json
+    item_data = response.json["item_data"]
+    assert item_data["synthesis_constituents"][0]["item"]["item_id"] == "custom-constituent-1"
+
+    # The constituent should also have been turned into a parent relationship
+    parents = [
+        relationship
+        for relationship in item_data["relationships"]
+        if relationship["relation"] == "parent"
+    ]
+    assert len(parents) == 1
+    assert parents[0]["item_id"] == "custom-constituent-1"
+
+
+def test_equipment_rejected_as_synthesis_constituent(client):
+    """Types without substance information (e.g. `equipment`) remain invalid as
+    synthesis constituents."""
+    from pydantic import ValidationError
+
+    from pydatalab.models.utils import Constituent
+
+    with pytest.raises(ValidationError, match="`type` must be one of"):
+        Constituent(
+            item={"item_id": "some-equipment", "type": "equipment"},
+            quantity=1.0,
+            unit="g",
+        )
 
 
 def test_unknown_custom_type_rejected(client, custom_item_models):
@@ -140,7 +204,8 @@ def test_unknown_custom_type_rejected(client, custom_item_models):
 
 def test_bad_custom_item_type_rejected():
     """A custom model is rejected at registration time if it reuses a reserved
-    built-in `type`, or if it is not an `Item` subclass at all."""
+    built-in `type`, declares an un-namespaced `type`, or is not an `Item`
+    subclass at all."""
     from typing import Literal
 
     from pydatalab.models import register_item_model
@@ -152,6 +217,13 @@ def test_bad_custom_item_type_rejected():
 
     with pytest.raises(ValueError, match="reserved built-in type"):
         register_item_model(ClashingSample)
+
+    class UnNamespacedSample(Sample):
+        # Declares its own type, but without the required leading underscore.
+        type: Literal["my_samples"] = "my_samples"  # type: ignore[assignment]
+
+    with pytest.raises(ValueError, match="un-namespaced type"):
+        register_item_model(UnNamespacedSample)
 
     # Anything that is not an `Item` subclass is also rejected.
     with pytest.raises(TypeError):

--- a/pydatalab/tests/server/test_custom_item_types.py
+++ b/pydatalab/tests/server/test_custom_item_types.py
@@ -14,6 +14,7 @@ types into other test modules.
 import copy
 
 import pytest
+from pydantic import ValidationError
 
 EXAMPLE_CUSTOM_MODELS = [
     "pydatalab.models._example_custom:MySample",
@@ -204,8 +205,7 @@ def test_unknown_custom_type_rejected(client, custom_item_models):
 
 def test_bad_custom_item_type_rejected():
     """A custom model is rejected at registration time if it reuses a reserved
-    built-in `type`, declares an un-namespaced `type`, or is not an `Item`
-    subclass at all."""
+    built-in `type`, or is not an `Item` subclass at all."""
     from typing import Literal
 
     from pydatalab.models import register_item_model
@@ -217,13 +217,6 @@ def test_bad_custom_item_type_rejected():
 
     with pytest.raises(ValueError, match="reserved built-in type"):
         register_item_model(ClashingSample)
-
-    class UnNamespacedSample(Sample):
-        # Declares its own type, but without the required leading underscore.
-        type: Literal["my_samples"] = "my_samples"  # type: ignore[assignment]
-
-    with pytest.raises(ValueError, match="un-namespaced type"):
-        register_item_model(UnNamespacedSample)
 
     # Anything that is not an `Item` subclass is also rejected.
     with pytest.raises(TypeError):
@@ -253,3 +246,81 @@ def test_extra_fields_on_builtin_sample_are_ignored(client):
     assert item_data["type"] == "samples"
     assert "drying_time" not in item_data
     assert "custom_properties" not in item_data
+
+
+def test_un_namespaced_type_is_namespaced_in_place():
+    """A custom model declaring an un-namespaced `type` is registered under the
+    namespaced type, with the declaring class itself rewritten so that directly
+    constructed instances agree with the registry."""
+    from typing import Literal
+
+    from pydatalab.models import ITEM_MODELS, ITEM_SCHEMAS, register_item_model
+    from pydatalab.models.samples import Sample
+
+    class UnNamespacedSample(Sample):
+        # Declares its own type, but without the leading underscore.
+        type: Literal["needs_namespacing"] = "needs_namespacing"  # type: ignore[assignment]
+
+    try:
+        register_item_model(UnNamespacedSample)
+
+        assert "_needs_namespacing" in ITEM_MODELS
+        assert "needs_namespacing" not in ITEM_MODELS
+        # The declaring class is registered, not a synthesised subclass.
+        assert ITEM_MODELS["_needs_namespacing"] is UnNamespacedSample
+        assert (
+            ITEM_SCHEMAS["_needs_namespacing"]["properties"]["type"]["default"]
+            == "_needs_namespacing"
+        )
+
+        # Instances constructed directly by plugin code carry the namespaced type...
+        item = UnNamespacedSample(item_id="namespaced-in-place")
+        assert item.type == "_needs_namespacing"
+        assert item.model_dump()["type"] == "_needs_namespacing"
+        assert isinstance(item, Sample)
+
+        # ...and the original, un-namespaced literal is no longer accepted.
+        with pytest.raises(ValidationError):
+            UnNamespacedSample(item_id="namespaced-in-place", type="needs_namespacing")
+
+        # Rewriting the subclass must not disturb the built-in it inherits from.
+        assert Sample.model_fields["type"].default == "samples"
+        assert Sample(item_id="still-a-sample").type == "samples"
+
+        # Registration is idempotent: a second call must not double-prefix.
+        register_item_model(UnNamespacedSample)
+        assert "__needs_namespacing" not in ITEM_MODELS
+    finally:
+        ITEM_MODELS.pop("_needs_namespacing", None)
+        ITEM_SCHEMAS.pop("_needs_namespacing", None)
+
+
+def test_refresh_item_models_ignores_custom_types(custom_item_models):
+    """`refresh_item_models` rebuilds only the built-in entries: it must neither
+    drop registered custom types nor rediscover them (and their un-namespaced
+    `type` literals) through the `Item` subclass walk."""
+    from typing import Literal
+
+    from pydatalab.models import ITEM_MODELS, ITEM_SCHEMAS, refresh_item_models
+    from pydatalab.models.samples import Sample
+
+    class NeverRegisteredSample(Sample):
+        """An un-namespaced subclass that is defined but never registered, e.g. a
+        custom model that has merely been imported."""
+
+        type: Literal["never_registered"] = "never_registered"  # type: ignore[assignment]
+
+    refresh_item_models()
+
+    # A merely-imported subclass is not registered by the refresh, so its
+    # un-namespaced type cannot sneak into the registry.
+    assert "never_registered" not in ITEM_MODELS
+    assert "never_registered" not in ITEM_SCHEMAS
+
+    assert "samples" in ITEM_MODELS
+    # Registered custom types survive the refresh...
+    assert "_my_samples" in ITEM_MODELS
+    assert "_my_samples" in ITEM_SCHEMAS
+    # ...and are not re-registered under the un-namespaced type they declare.
+    assert "my_samples" not in ITEM_MODELS
+    assert "my_items" not in ITEM_MODELS

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -751,6 +751,30 @@ def test_create_collections(client, default_collection, database):
 
 
 @pytest.mark.dependency(depends=["test_create_collections"])
+def test_create_collection_with_additional_creators(client, default_collection):
+    """`additional_creators` is consumed by the endpoint to populate `creator_ids` and is
+    not a field of `Collection` itself, so it must not be passed through to the model.
+
+    Kept explicit so the payload stays valid if unknown fields are rejected outright in
+    the future, rather than relying on them being silently ignored.
+    """
+    collection_id = "test_collection_creators"
+    data = json.loads(default_collection.model_dump_json())
+    data.update({"collection_id": collection_id, "additional_creators": None})
+
+    response = client.put("/collections", json={"data": data})
+    assert response.status_code == 201, response.json
+    assert "additional_creators" not in response.json["data"]
+
+    response = client.get(f"/collections/{collection_id}")
+    assert response.status_code == 200, response.json
+    assert "additional_creators" not in response.json["data"]
+
+    # Remove it again so that the collection counts asserted by later tests still hold.
+    assert client.delete(f"/collections/{collection_id}").status_code == 200
+
+
+@pytest.mark.dependency(depends=["test_create_collections"])
 def test_items_added_to_existing_collection(client, default_collection, default_sample_dict):
     # Create a new item that is inside the default collection by passing collection_id
     new_id = "testing_collection_insert_by_id"


### PR DESCRIPTION
c.f. #1767 -- blocked by and based on pydantic 2 PR at #1820

cc @davidwaroquiers / @jbouquiaux 

# Generated summary

This pull request introduces a robust system for registering and serving custom item types in the datalab platform, enabling deployments and plugins to extend the core data model without modifying the core codebase. The changes include backend support for custom item types, mechanisms for registering these types via plugins or configuration, and updates to the summary endpoints to include custom fields.

**Custom item type support and registration:**

* Added support for custom item types, allowing deployments or plugins to register new top-level item models that are served through the generic item endpoints and advertised at `/info/types` (`pydatalab/docs/plugins.md`, `pydatalab/src/pydatalab/models/__init__.py`, `pydatalab/src/pydatalab/apps/__init__.py`, `pydatalab/src/pydatalab/config.py`, `pydatalab/src/pydatalab/main.py`). [[1]](diffhunk://#diff-1f83ec7e96fa0bdadb594e4635856089020defdd6f4690fa041572094c1692f2L3-L6) [[2]](diffhunk://#diff-1f83ec7e96fa0bdadb594e4635856089020defdd6f4690fa041572094c1692f2L15-L20) [[3]](diffhunk://#diff-1f83ec7e96fa0bdadb594e4635856089020defdd6f4690fa041572094c1692f2R71-R131) [[4]](diffhunk://#diff-249661fcbbca4ba1b39c0a1cea91c5f7d607a8bf4d10e10d41c6b5e244595b0cR15-R155) [[5]](diffhunk://#diff-249661fcbbca4ba1b39c0a1cea91c5f7d607a8bf4d10e10d41c6b5e244595b0cR168-R172) [[6]](diffhunk://#diff-63e174e5c11284b7c56c533e8ebe20ab2126778a53f255377dc52abf287e19d0R143-R172) [[7]](diffhunk://#diff-dd66be12d843d12e8e42398467f77debf7a45dcd4840843209c94886601f24efR256-R260) [[8]](diffhunk://#diff-5997482b008999d1eba8d3328501b8b5a62f6441f8bb6d6355bc4eca1fe7a0bcR123-R128)
* Introduced two ways to register custom item types: via plugin entry points (`pydatalab.item_types`) or by listing dotted import paths in the `CUSTOM_ITEM_MODELS` config setting. [[1]](diffhunk://#diff-1f83ec7e96fa0bdadb594e4635856089020defdd6f4690fa041572094c1692f2R71-R131) [[2]](diffhunk://#diff-dd66be12d843d12e8e42398467f77debf7a45dcd4840843209c94886601f24efR256-R260) [[3]](diffhunk://#diff-5997482b008999d1eba8d3328501b8b5a62f6441f8bb6d6355bc4eca1fe7a0bcR123-R128) [[4]](diffhunk://#diff-249661fcbbca4ba1b39c0a1cea91c5f7d607a8bf4d10e10d41c6b5e244595b0cR15-R155) [[5]](diffhunk://#diff-249661fcbbca4ba1b39c0a1cea91c5f7d607a8bf4d10e10d41c6b5e244595b0cR168-R172) [[6]](diffhunk://#diff-63e174e5c11284b7c56c533e8ebe20ab2126778a53f255377dc52abf287e19d0R143-R172)
* Implemented validation to ensure custom item types declare a unique `type` literal and do not collide with built-in types. [[1]](diffhunk://#diff-249661fcbbca4ba1b39c0a1cea91c5f7d607a8bf4d10e10d41c6b5e244595b0cR15-R155) [[2]](diffhunk://#diff-249661fcbbca4ba1b39c0a1cea91c5f7d607a8bf4d10e10d41c6b5e244595b0cR168-R172)

**Summary and documentation improvements:**

* Updated the plugin documentation to describe the new custom item type mechanism, including examples and usage instructions. [[1]](diffhunk://#diff-1f83ec7e96fa0bdadb594e4635856089020defdd6f4690fa041572094c1692f2L3-L6) [[2]](diffhunk://#diff-1f83ec7e96fa0bdadb594e4635856089020defdd6f4690fa041572094c1692f2L15-L20) [[3]](diffhunk://#diff-1f83ec7e96fa0bdadb594e4635856089020defdd6f4690fa041572094c1692f2R71-R131)
* Added an example module (`_example_custom.py`) demonstrating how to define and register custom item types, including both subclassing built-ins and defining wholly new types.

**API and summary endpoint enhancements:**

* Updated summary endpoints for items, samples, equipment, and starting materials to dynamically include any fields flagged with `datalab_include_field_in_summary`, allowing custom fields to appear in list/summary views without code changes. [[1]](diffhunk://#diff-d0ec59b2e0fe74644da77b7cea6d3c6696d66cde441ff9890140182b99819683L19-R19) [[2]](diffhunk://#diff-d0ec59b2e0fe74644da77b7cea6d3c6696d66cde441ff9890140182b99819683R74-R76) [[3]](diffhunk://#diff-d0ec59b2e0fe74644da77b7cea6d3c6696d66cde441ff9890140182b99819683R95-R132) [[4]](diffhunk://#diff-d0ec59b2e0fe74644da77b7cea6d3c6696d66cde441ff9890140182b99819683R247-R251) [[5]](diffhunk://#diff-d0ec59b2e0fe74644da77b7cea6d3c6696d66cde441ff9890140182b99819683R328-R332)

These changes collectively make the datalab platform more extensible and enable deployments to tailor the data model to their needs without forking or patching the core.