### PR TITLE
Fix bug where only admins could be set as managers

### DIFF
--- a/webapp/src/components/UserManagersCell.vue
+++ b/webapp/src/components/UserManagersCell.vue
@@ -16,7 +16,7 @@
         <div class="d-flex align-items-center">
           <UserBubble :creator="option" :size="20" />
           <span class="ml-2">{{ option.display_name }}</span>
-          <span class="ml-auto"><RoleBadge :role="option.role" /></span>
+          <span class="ml-2"><RoleBadge :role="option.role" /></span>
         </div>
       </template>
       <template #selected-option="option">

--- a/webapp/src/components/UserManagersCell.vue
+++ b/webapp/src/components/UserManagersCell.vue
@@ -64,10 +64,7 @@ export default {
       if (!this.allUsers || !Array.isArray(this.allUsers)) {
         return [];
       }
-      return this.allUsers.filter(
-        (u) =>
-          u.immutable_id !== this.user.immutable_id && (u.role === "admin" || u.role === "manager"),
-      );
+      return this.allUsers.filter((u) => u.immutable_id !== this.user.immutable_id);
     },
   },
   watch: {


### PR DESCRIPTION
At some point, the admin panel started only letting admins be set as user managers. The issue seems to be some code that checks if the user is an admin OR already a manager before letting them be set as a manager. This PR removes that, and also fixed a spacing issue in the vSelect.

closes #1816 