### PR TITLE
Styling for readonly pages

### DIFF
--- a/webapp/src/components/CellInformation.vue
+++ b/webapp/src/components/CellInformation.vue
@@ -84,7 +84,7 @@
           </div>
           <div class="form-group col-lg-4 col-md-4 pr-3">
             <label for="cell-chemform">Active formula</label>
-            <ChemFormulaInput id="cell-chemform" v-model="ChemForm" />
+            <ChemFormulaInput id="cell-chemform" v-model="ChemForm" :readonly="!isEditable" />
           </div>
           <div class="form-group col-lg-3 col-md-4">
             <label for="cell-characteristic-molar-mass">Molar mass</label>

--- a/webapp/src/components/CellInformation.vue
+++ b/webapp/src/components/CellInformation.vue
@@ -115,7 +115,7 @@
 
     <TableOfContents :item_id="item_id" :information-sections="tableOfContentsSections" />
 
-    <CellPreparationInformation class="mt-3" :item_id="item_id" />
+    <CellPreparationInformation class="mt-3" :item_id="item_id" :is-editable="isEditable" />
   </div>
 </template>
 

--- a/webapp/src/components/CellInformation.vue
+++ b/webapp/src/components/CellInformation.vue
@@ -103,6 +103,7 @@
             <TiptapInline
               v-model="SampleDescription"
               aria-labelledby="cell-description-label"
+              :readonly="!isEditable"
             ></TiptapInline>
           </div>
         </div>
@@ -154,7 +155,7 @@ export default {
     },
     isEditable: {
       type: Boolean,
-      default: true,
+      default: false,
     },
   },
   data() {

--- a/webapp/src/components/CellInformation.vue
+++ b/webapp/src/components/CellInformation.vue
@@ -6,15 +6,15 @@
         <div id="sample-information" class="form-row">
           <div class="form-group col-sm-8">
             <label for="cell-name" class="mr-2">Name</label>
-            <input id="cell-name" v-model="Name" class="form-control" />
+            <StyledInput id="cell-name" v-model="Name" :readonly="!isEditable" />
           </div>
           <div class="form-group col-sm-4">
             <label for="cell-date" class="mr-2">Date Created</label>
-            <input
+            <StyledInput
               id="cell-date"
               v-model="DateCreated"
               type="datetime-local"
-              class="form-control"
+              :readonly="!isEditable"
             />
           </div>
         </div>
@@ -46,23 +46,27 @@
         <div class="form-row">
           <div class="form-group col-sm-4 pr-2">
             <label for="cell-format-dropdown">Cell format</label>
-            <select id="cell-format-dropdown" v-model="CellFormat" class="form-control">
-              <option
-                v-for="(description, key) in availableCellFormats"
-                :key="key"
-                :value="description"
-              >
-                {{ description }}
+            <select
+              v-if="isEditable"
+              id="cell-format-dropdown"
+              v-model="CellFormat"
+              class="form-control"
+            >
+              <option v-for="(format, key) in availableCellFormats" :key="key" :value="format">
+                {{ format }}
               </option>
             </select>
+            <div v-else class="form-control-plaintext">
+              {{ CellFormat }}
+            </div>
           </div>
           <div class="form-group col-sm-8">
             <label for="cell-format-description">Cell format description</label>
-            <input
+            <StyledInput
               id="cell-format-description"
               v-model="CellFormatDescription"
               type="text"
-              class="form-control"
+              :readonly="!isEditable"
             />
           </div>
         </div>
@@ -70,12 +74,12 @@
         <div class="form-row py-4">
           <div class="form-group col-lg-3 col-md-4 pr-3">
             <label for="cell-characteristic-mass">Active mass (mg)</label>
-            <input
+            <StyledInput
               id="cell-characteristic-mass"
               v-model="CharacteristicMass"
-              class="form-control"
               type="text"
-              :class="{ 'red-border': isNaN(CharacteristicMass) }"
+              :readonly="!isEditable"
+              :class="isNaN(CharacteristicMass) ? 'red-border' : ''"
             />
           </div>
           <div class="form-group col-lg-4 col-md-4 pr-3">
@@ -84,12 +88,12 @@
           </div>
           <div class="form-group col-lg-3 col-md-4">
             <label for="cell-characteristic-molar-mass">Molar mass</label>
-            <input
+            <StyledInput
               id="cell-characteristic-molar-mass"
               v-model="MolarMass"
-              class="form-control"
               type="text"
-              :class="{ 'red-border': isNaN(MolarMass) }"
+              :readonly="!isEditable"
+              :class="isNaN(MolarMass) ? 'red-border' : ''"
             />
           </div>
         </div>
@@ -126,6 +130,7 @@ import ToggleableCollectionFormGroup from "@/components/ToggleableCollectionForm
 import ToggleableCreatorsFormGroup from "@/components/ToggleableCreatorsFormGroup";
 import ToggleableItemStatusFormGroup from "@/components/ToggleableItemStatusFormGroup";
 import ToggleableGroupsFormGroup from "@/components/ToggleableGroupsFormGroup";
+import StyledInput from "@/components/StyledInput";
 import { cellFormats } from "@/resources.js";
 
 export default {
@@ -140,11 +145,16 @@ export default {
     ToggleableCreatorsFormGroup,
     ToggleableItemStatusFormGroup,
     ToggleableGroupsFormGroup,
+    StyledInput,
   },
   props: {
     item_id: {
       type: String,
       required: true,
+    },
+    isEditable: {
+      type: Boolean,
+      default: true,
     },
   },
   data() {

--- a/webapp/src/components/CellPreparationInformation.vue
+++ b/webapp/src/components/CellPreparationInformation.vue
@@ -12,6 +12,7 @@
             id="pos-electrode-table"
             v-model="PosElectrodeConstituents"
             :types-to-query="['starting_materials', 'samples']"
+            :readonly="!isEditable"
           />
         </div>
       </div>
@@ -27,6 +28,7 @@
             id="electrolyte-table"
             v-model="ElectrolyteConstituents"
             :types-to-query="['starting_materials', 'samples']"
+            :readonly="!isEditable"
           />
         </div>
       </div>
@@ -42,6 +44,7 @@
             id="neg-electrode-table"
             v-model="NegElectrodeConstituents"
             :types-to-query="['starting_materials', 'samples']"
+            :readonly="!isEditable"
           />
         </div>
       </div>
@@ -52,6 +55,7 @@
       <TiptapInline
         v-model="CellPreparationDescription"
         aria-labelledby="synthesis-procedure-label"
+        :readonly="!isEditable"
       />
     </div>
   </div>
@@ -74,6 +78,10 @@ export default {
   },
   props: {
     item_id: { type: String, required: true },
+    isEditable: {
+      type: Boolean,
+      default: true,
+    },
   },
   data() {
     return {

--- a/webapp/src/components/ChemFormulaInput.vue
+++ b/webapp/src/components/ChemFormulaInput.vue
@@ -1,13 +1,13 @@
 <template>
   <ChemicalFormula
-    v-show="!editable"
-    class="form-control"
+    v-show="readonly || !editable"
+    :class="readonly ? 'form-control-plaintext' : 'form-control'"
     :formula="internal_chemform"
     @click="handleSpanClick"
   />
 
   <input
-    v-show="editable"
+    v-show="!readonly && editable"
     v-bind="$attrs"
     ref="input"
     v-model="internal_chemform"
@@ -28,6 +28,10 @@ export default {
       type: String,
       default: "",
     },
+    readonly: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: ["update:modelValue"],
   data() {
@@ -45,6 +49,13 @@ export default {
       },
     },
   },
+  watch: {
+    readonly(value) {
+      if (value) {
+        this.editable = false;
+      }
+    },
+  },
   methods: {
     chemFormulaFormat(chemform) {
       if (!chemform) {
@@ -54,6 +65,9 @@ export default {
       return chemform.replace(re, "<sub>$1</sub>");
     },
     handleSpanClick() {
+      if (this.readonly) {
+        return;
+      }
       this.editable = true; // triggers the span to dissappear and the click to appear
       this.$nextTick(function () {
         // wait for the dom to update (i.e. wait for the input to appear) and then focus the input

--- a/webapp/src/components/CompactConstituentTable.vue
+++ b/webapp/src/components/CompactConstituentTable.vue
@@ -18,7 +18,7 @@
             /> -->
           <!-- </transition> -->
           <ItemSelect
-            v-if="selectShown[index]"
+            v-if="!readonly && selectShown[index]"
             :ref="`select${index}`"
             v-model="selectedChangedConstituent"
             class="select-in-row"
@@ -41,7 +41,7 @@
             :max-length="25"
             enable-click
             enable-modified-click
-            @dblclick="turnOnRowSelect(index)"
+            @dblclick="!readonly && turnOnRowSelect(index)"
           />
         </td>
         <!--         <td>
@@ -53,6 +53,7 @@
             class="form-control form-control-sm quantity-input"
             :class="{ 'red-border': isNaN(constituent.quantity) }"
             placeholder="quantity"
+            :readonly="readonly"
           />
         </td>
         <td>
@@ -60,11 +61,13 @@
             v-model="constituent.unit"
             class="form-control form-control-sm"
             placeholder="unit"
+            :readonly="readonly"
           />
         </td>
 
         <td>
           <button
+            v-if="!readonly"
             type="button"
             class="close"
             aria-label="delete"
@@ -74,7 +77,7 @@
           </button>
         </td>
       </tr>
-      <tr>
+      <tr v-if="!readonly">
         <td
           class="first-column"
           :class="{ clickable: !newSelectIsShown }"
@@ -125,6 +128,10 @@ export default {
     typesToQuery: {
       type: Array,
       default: () => ["samples", "starting_materials", "cells"],
+    },
+    readonly: {
+      type: Boolean,
+      default: false,
     },
   },
   emits: ["update:modelValue"],

--- a/webapp/src/components/SampleInformation.vue
+++ b/webapp/src/components/SampleInformation.vue
@@ -57,7 +57,11 @@
     <div class="row">
       <div class="col">
         <label id="samp-description-label">Description</label>
-        <TiptapInline v-model="SampleDescription" aria-labelledby="samp-description-label" />
+        <TiptapInline
+          v-model="SampleDescription"
+          aria-labelledby="samp-description-label"
+          :readonly="!isEditable"
+        />
       </div>
     </div>
 

--- a/webapp/src/components/SampleInformation.vue
+++ b/webapp/src/components/SampleInformation.vue
@@ -66,7 +66,7 @@
     </div>
 
     <TableOfContents :item_id="item_id" :information-sections="tableOfContentsSections" />
-    <SynthesisInformation class="mt-3" :item_id="item_id" />
+    <SynthesisInformation class="mt-3" :item_id="item_id" :is-editable="isEditable" />
   </div>
 </template>
 

--- a/webapp/src/components/SampleInformation.vue
+++ b/webapp/src/components/SampleInformation.vue
@@ -6,15 +6,15 @@
         <div id="sample-information" class="form-row">
           <div class="form-group col-sm-6 pr-2">
             <label for="samp-name">Name</label>
-            <input id="samp-name" v-model="Name" class="form-control" />
+            <StyledInput id="samp-name" v-model="Name" :readonly="!isEditable" />
           </div>
           <div class="form-group col-sm-6">
             <label for="samp-date">Date Created</label>
-            <input
+            <StyledInput
               id="samp-date"
               v-model="DateCreated"
               type="datetime-local"
-              class="form-control"
+              :readonly="!isEditable"
             />
           </div>
         </div>
@@ -78,6 +78,7 @@ import SynthesisInformation from "@/components/SynthesisInformation";
 import SubstanceInformation from "@/components/SubstanceInformation";
 import TableOfContents from "@/components/TableOfContents";
 import ItemRelationshipVisualization from "@/components/ItemRelationshipVisualization";
+import StyledInput from "@/components/StyledInput";
 
 export default {
   components: {
@@ -91,12 +92,17 @@ export default {
     ToggleableCreatorsFormGroup,
     ToggleableItemStatusFormGroup,
     ToggleableGroupsFormGroup,
+    StyledInput,
   },
   props: {
     item_id: { type: String, required: true },
     refcode: {
       type: String,
       default: null,
+    },
+    isEditable: {
+      type: Boolean,
+      default: true,
     },
   },
   data() {

--- a/webapp/src/components/SampleInformation.vue
+++ b/webapp/src/components/SampleInformation.vue
@@ -51,7 +51,7 @@
     </div>
     <div class="row">
       <div class="col">
-        <SubstanceInformation class="mt-3" :item_id="item_id" />
+        <SubstanceInformation class="mt-3" :item_id="item_id" :is-editable="isEditable" />
       </div>
     </div>
     <div class="row">

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -102,7 +102,11 @@
     </div>
 
     <label class="mr-2">Description</label>
-    <TiptapInline v-model="ItemDescription" data-testid="item-description"></TiptapInline>
+    <TiptapInline
+      v-model="ItemDescription"
+      data-testid="item-description"
+      :readonly="!isEditable"
+    ></TiptapInline>
 
     <TableOfContents
       class="mb-3"

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -5,7 +5,7 @@
         <div id="starting-material-information" class="form-row">
           <div class="form-group col-sm-6 pr-2">
             <label for="samp-name">Name</label>
-            <input id="samp-name" v-model="Name" class="form-control" />
+            <StyledInput id="samp-name" v-model="Name" :readonly="!isEditable" />
           </div>
           <div class="form-group col-sm-6">
             <label for="startmat-date-acquired">Date acquired</label>
@@ -13,7 +13,6 @@
               id="startmat-date-acquired"
               v-model="DateAcquired"
               type="datetime-local"
-              class="form-control"
               :readonly="!isEditable"
             />
           </div>
@@ -152,6 +151,10 @@ export default {
   },
   props: {
     item_id: { type: String, required: true },
+    isEditable: {
+      type: Boolean,
+      default: EDITABLE_INVENTORY,
+    },
   },
   data() {
     return {
@@ -212,7 +215,6 @@ export default {
     },
   },
   created() {
-    this.isEditable = EDITABLE_INVENTORY;
     if (this.$store.state.starting_material_list === null) {
       getStartingMaterialList();
     }

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -114,7 +114,7 @@
       :information-sections="tableOfContentsSections"
     />
 
-    <SynthesisInformation class="mt-3" :item_id="item_id" />
+    <SynthesisInformation class="mt-3" :item_id="item_id" :is-editable="isEditable" />
   </div>
 </template>
 

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -131,7 +131,6 @@ import ToggleableGroupsFormGroup from "@/components/ToggleableGroupsFormGroup";
 
 import AutoComplete from "primevue/autocomplete";
 import { getStartingMaterialList, getEquipmentList } from "@/server_fetch_utils.js";
-import { EDITABLE_INVENTORY } from "@/resources.js";
 
 export default {
   components: {
@@ -153,7 +152,7 @@ export default {
     item_id: { type: String, required: true },
     isEditable: {
       type: Boolean,
-      default: EDITABLE_INVENTORY,
+      default: true,
     },
   },
   data() {

--- a/webapp/src/components/StyledInput.vue
+++ b/webapp/src/components/StyledInput.vue
@@ -39,7 +39,7 @@ export default {
   },
   props: {
     modelValue: {
-      type: String,
+      type: [String, Number],
       default: "",
     },
     readonly: {

--- a/webapp/src/components/SubstanceInformation.vue
+++ b/webapp/src/components/SubstanceInformation.vue
@@ -2,21 +2,27 @@
   <div id="substance-information" ref="outerdiv" class="data-block" data-testid="substance-block">
     <div
       class="datablock-header"
-      :class="{ clickable: !isEditing, expanded: isEditing }"
-      @click="!isEditing && enterEditMode()"
+      :class="{ clickable: canEnterEditMode, expanded: isEditing }"
+      @click="enterEditMode"
     >
       <font-awesome-icon
+        v-if="isEditable"
         :icon="['fas', 'chevron-right']"
         fixed-width
         class="collapse-arrow"
         @click.stop="toggleEditMode"
       />
       <label class="block-title">Substance Information</label>
-      <font-awesome-icon v-if="!isEditing" id="edit-icon" class="ml-2" icon="pen" size="xs" />
+      <font-awesome-icon v-if="canEnterEditMode" id="edit-icon" class="ml-2" icon="pen" size="xs" />
     </div>
 
     <!-- VIEW MODE -->
-    <div v-if="!isEditing && hasAnyData" class="substance-card" @click="enterEditMode">
+    <div
+      v-if="!isEditing && hasAnyData"
+      class="substance-card"
+      :class="{ editable: isEditable }"
+      @click="enterEditMode"
+    >
       <div class="substance-card-content">
         <div class="substance-display-row">
           <div class="info-items">
@@ -214,6 +220,10 @@ export default {
   },
   props: {
     item_id: { type: String, required: true },
+    isEditable: {
+      type: Boolean,
+      default: true,
+    },
   },
   data() {
     return {
@@ -270,12 +280,26 @@ export default {
       if (!this.GHS_codes) return false;
       return getPictogramsFromHazardInformation(this.GHS_codes).size > 0;
     },
+
+    canEnterEditMode() {
+      return this.isEditable && !this.isEditing;
+    },
+  },
+  watch: {
+    isEditable(value) {
+      if (!value) {
+        this.exitEditMode();
+      }
+    },
   },
   mounted() {
     this.outerDivRef = this.$refs.outerdiv;
   },
   methods: {
     enterEditMode() {
+      if (!this.canEnterEditMode) {
+        return;
+      }
       this.isEditing = true;
     },
     exitEditMode() {
@@ -353,7 +377,6 @@ export default {
   border-radius: 0.375rem;
   padding: 1rem 1.25rem;
   background-color: var(--color-surface, #fff);
-  cursor: pointer;
   max-width: 680px;
   overflow: hidden;
   transition:
@@ -361,7 +384,11 @@ export default {
     box-shadow 0.15s ease;
 }
 
-.substance-card:hover {
+.substance-card.editable {
+  cursor: pointer;
+}
+
+.substance-card.editable:hover {
   border-color: var(--color-text-muted, #adb5bd);
   box-shadow: var(--shadow-sm, 0 2px 4px rgba(0, 0, 0, 0.05));
 }

--- a/webapp/src/components/SynthesisInformation.vue
+++ b/webapp/src/components/SynthesisInformation.vue
@@ -21,6 +21,7 @@
             id="synthesis-table"
             v-model="constituents"
             :types-to-query="['samples', 'starting_materials']"
+            :readonly="!isEditable"
           />
         </div>
       </div>
@@ -28,6 +29,7 @@
       <TiptapInline
         v-model="SynthesisDescription"
         aria-labelledby="synthesis-procedure-label"
+        :readonly="!isEditable"
       ></TiptapInline>
     </div>
   </div>
@@ -45,6 +47,10 @@ export default {
   },
   props: {
     item_id: { type: String, required: true },
+    isEditable: {
+      type: Boolean,
+      default: true,
+    },
   },
   data() {
     return {

--- a/webapp/src/components/TiptapInline.vue
+++ b/webapp/src/components/TiptapInline.vue
@@ -1,7 +1,7 @@
 <template>
   <div ref="editorContainer" class="position-relative" v-bind="$attrs">
     <div
-      v-if="editor && (showToolbar || markdownMode)"
+      v-if="editor && !readonly && (showToolbar || markdownMode)"
       ref="toolbarContainer"
       class="btn-toolbar mb-2 border rounded p-2 shadow-sm bg-white sticky-top overflow-auto flex-wrap"
       style="z-index: 10; gap: 0.5rem"
@@ -76,7 +76,7 @@
     </teleport>
 
     <editor-content
-      v-if="!markdownMode"
+      v-if="readonly || !markdownMode"
       :editor="editor"
       class="tiptap-editor-wrapper"
       :class="{ 'editor-focused': showToolbar }"
@@ -132,6 +132,7 @@ export default {
     modelValue: { type: String, default: "" },
     placeholder: { type: String, default: "Add a description" },
     inline: { type: Boolean, default: true },
+    readonly: { type: Boolean, default: false },
   },
 
   emits: ["update:modelValue"],
@@ -448,10 +449,20 @@ export default {
         this.editor.commands.setContent(value, false);
       }
     },
+    readonly(value) {
+      this.editor?.setEditable(!value);
+      if (value) {
+        this.markdownMode = false;
+        this.showToolbar = false;
+        this.showColorPicker = false;
+      }
+    },
   },
 
   mounted() {
+    const component = this;
     this.editor = new Editor({
+      editable: !this.readonly,
       extensions: [
         StarterKit.configure({ heading: { levels: [1, 2, 3, 4, 5, 6] } }),
         Underline,
@@ -486,6 +497,8 @@ export default {
                 props: {
                   handleDOMEvents: {
                     drop: (view, event) => {
+                      if (component.readonly) return false;
+
                       const hasFiles = event.dataTransfer?.files?.length > 0;
                       if (!hasFiles) return false;
 
@@ -518,6 +531,8 @@ export default {
                       return true;
                     },
                     paste: (view, event) => {
+                      if (component.readonly) return false;
+
                       const hasFiles = event.clipboardData?.files?.length > 0;
                       if (!hasFiles) return false;
 
@@ -574,6 +589,8 @@ export default {
           },
           inlineOptions: {
             onClick: (node, pos) => {
+              if (this.readonly) return;
+
               const currentLatex = node.attrs.latex || "";
               const newLatex = window.prompt("Edit Math formula (KaTeX):", currentLatex);
               if (newLatex !== null && this.editor) {
@@ -588,6 +605,8 @@ export default {
           },
           blockOptions: {
             onClick: (node, pos) => {
+              if (this.readonly) return;
+
               const currentLatex = node.attrs.latex || "";
               const newLatex = window.prompt("Edit Math formula (KaTeX):", currentLatex);
               if (newLatex !== null && this.editor) {

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -110,6 +110,7 @@
       :is="itemTypeEntry?.itemInformationComponent"
       ref="sampleInformation"
       :item_id="item_id"
+      :is-editable="itemInformationIsEditable"
     />
     <FileList :item_id="item_id" :stored_files="stored_files" />
 
@@ -190,7 +191,7 @@ import FormattedItemName from "@/components/FormattedItemName";
 
 import setupUppy from "@/file_upload.js";
 
-import { itemTypes, API_URL, customBlockTypes } from "@/resources.js";
+import { itemTypes, API_URL, customBlockTypes, EDITABLE_INVENTORY } from "@/resources.js";
 import BokehBlock from "@/components/datablocks/BokehBlock.vue";
 import ErrorBlock from "@/components/datablocks/ErrorBlock.vue";
 import { formatDistanceToNow } from "date-fns";
@@ -260,6 +261,12 @@ export default {
     },
     itemTypeEntry() {
       return itemTypes[this.itemType] || undefined;
+    },
+    itemInformationIsEditable() {
+      if (this.itemType === "starting_materials") {
+        return EDITABLE_INVENTORY;
+      }
+      return true;
     },
     navbarColor() {
       return this.itemTypeEntry?.navbarColor || "DarkGrey";


### PR DESCRIPTION
This in-progress PR creates consistent readonly styling across item views. 

Todo: 

- [x] Give each ItemInformation component an `isEditable` prop
- [x] Convert simple inputs to StyledInputs that can be set to `readonly` if the item is not editable
- [x] Give chemforminputs a readonly mode
- [x] give SubstanceInformation a readonly mode
- [x] give tiptap a readonly mode
- [ ] give the toggleable fields (collections, creators etc.) readonly modes
- [x] give the synthesis/construction information components readonly modes
- [ ] Figure out how to make blocks readonly neatly
- [ ] Use user permissions to decide whether to render the editable or readonly page for each time


Closes #1826