### PR TITLE
Tools for backward incompatible DB upgrades

### DIFF
--- a/pydatalab/src/pydatalab/main.py
+++ b/pydatalab/src/pydatalab/main.py
@@ -23,6 +23,23 @@ from pydatalab.utils import BSONProvider
 COMPRESS = Compress()
 
 
+def _check_database_version() -> None:
+    """Run the non-fatal schema-version check at startup.
+
+    The server always starts; depending on the recorded version it may stamp the
+    current version (when provably safe) or log guidance to run
+    ``invoke admin.initialise-schema-version`` / ``invoke migration.upgrade``. See
+    :mod:`pydatalab.upgrade`.
+    """
+    try:
+        from pydatalab.mongo import get_database
+        from pydatalab.upgrade import check_database_version_on_startup
+
+        check_database_version_on_startup(get_database())
+    except Exception as exc:
+        LOGGER.warning("Could not check the database schema version: %s", exc)
+
+
 def create_app(
     config_override: dict[str, Any] | None = None, env_file: pathlib.Path | None = None
 ) -> Flask:
@@ -107,6 +124,7 @@ def create_app(
 
     pydatalab.mongo.create_default_indices()
     pydatalab.mongo.run_startup_migrations()
+    _check_database_version()
 
     if CONFIG.FILE_DIRECTORY is not None:
         pathlib.Path(CONFIG.FILE_DIRECTORY).mkdir(parents=False, exist_ok=True)

--- a/pydatalab/src/pydatalab/mongo.py
+++ b/pydatalab/src/pydatalab/mongo.py
@@ -20,6 +20,7 @@ __all__ = (
     "insert_pydantic_model_fork_safe",
     "gravatar_hash_for",
     "run_startup_migrations",
+    "METADATA_COLLECTION",
     "ITEMS_FTS_FIELDS",
     "USERS_FTS_FIELDS",
     "COLLECTIONS_FTS_FIELDS",
@@ -188,6 +189,10 @@ def _get_active_mongo_client(timeoutMS: int = 1000) -> pymongo.MongoClient:
 def get_database() -> pymongo.database.Database:
     """Returns the configured database."""
     return _get_active_mongo_client().get_database()
+
+
+# Collection name for small, singleton application/database metadata documents.
+METADATA_COLLECTION = "database_metadata"
 
 
 def check_mongo_connection() -> None:
@@ -417,6 +422,10 @@ STARTUP_MIGRATIONS = (_backfill_user_gravatar_hashes,)
 
 Each entry takes a pymongo database handle and returns the number of documents
 updated. Keep migrations idempotent and cheap — they run on every boot.
+
+For version-gated, potentially expensive, backward-incompatible upgrades that an
+administrator runs deliberately (via ``invoke migration.upgrade``), use
+:mod:`pydatalab.upgrade` instead.
 """
 
 

--- a/pydatalab/src/pydatalab/upgrade.py
+++ b/pydatalab/src/pydatalab/upgrade.py
@@ -1,0 +1,552 @@
+"""Administrator-driven database upgrades for backward-incompatible changes.
+
+This module provides the machinery for applying *backward-incompatible* changes
+to the database when a datalab deployment is upgraded to a new version. The
+intended workflow is to stop the server, run ``invoke migration.upgrade`` on a
+host with access to the database, and then start the new version.
+
+To register an upgrade, decorate a function with
+:meth:`DatabaseUpgrader.register_upgrade`. The function receives the database
+handle, an optional session (for transactions), and a ``dry_run`` flag, and must
+return the list of :class:`UpgradeAction` it performed (or would have performed,
+when ``dry_run`` is set).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import enum
+import functools
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, ClassVar
+
+from packaging.version import InvalidVersion, Version
+from packaging.version import parse as parse_version
+
+from pydatalab import __version__
+from pydatalab.logger import LOGGER
+from pydatalab.mongo import METADATA_COLLECTION
+
+if TYPE_CHECKING:
+    import pymongo.database
+    from pymongo.client_session import ClientSession
+
+# ``_id`` of the document (in :data:`~pydatalab.mongo.METADATA_COLLECTION`) that
+# holds the database schema version.
+SCHEMA_VERSION_ID = "datalab_schema_version"
+# Sentinel "start of history" used as the lower bound when collecting upgrades
+# for a database whose starting version is not otherwise known.
+BASELINE_VERSION = Version("0.0.0")
+
+
+class UpgradeConditionsFailedError(Exception):
+    """Raised when an upgrade is blocked because its preconditions are not satisfied."""
+
+
+class UninitialisedDatabaseError(RuntimeError):
+    """Raised when an operation needs a recorded schema version but none exists.
+
+    An unstamped database is ambiguous: it could be a pristine new installation
+    (which must be stamped at the current version with no upgrades applied) or an
+    existing database from before schema versioning (which may need upgrades).
+    The system never guesses between these; the operator must disambiguate with
+    ``admin.initialise-schema-version`` (new install) or
+    ``migration.upgrade --from-version`` (existing database).
+    """
+
+
+class DatabaseVersionStatus(enum.Enum):
+    """Outcome of comparing the recorded schema version with the code version."""
+
+    #: Development install (code version unknown); no check performed.
+    DEV = "dev"
+    #: Recorded version matches the code version.
+    CURRENT = "current"
+    #: Version was missing or behind but nothing needed applying, so it was
+    #: stamped to the current version automatically.
+    AUTO_STAMPED = "auto_stamped"
+    #: Recorded version is behind and registered upgrades need to be applied.
+    UPGRADE_PENDING = "upgrade_pending"
+    #: No version recorded and upgrades exist: the operator must initialise or
+    #: upgrade explicitly (see :class:`UninitialisedDatabaseError`).
+    UNINITIALISED = "uninitialised"
+    #: Recorded version is newer than the code (e.g. an attempted downgrade).
+    AHEAD = "ahead"
+
+
+def code_version() -> Version | None:
+    """The version of the installed ``datalab-server`` package.
+
+    Returns ``None`` for development builds. A build is considered "development"
+    when the version cannot be parsed or is_devrelease.
+    """
+    try:
+        version = parse_version(__version__)
+    except InvalidVersion:
+        return None
+    if version.local is not None or version.is_devrelease:
+        return None
+    return version
+
+
+@dataclass
+class UpgradeAction:
+    """Details of a single upgrade action to be performed."""
+
+    description: str
+    collection: str
+    action_type: str
+    details: dict
+    required: bool = False
+
+
+# Declared ``kw_only`` so that subclasses can introduce required fields.
+@dataclass(kw_only=True)
+class UpgradeCondition:
+    """A generic precondition that must hold before an upgrade can be applied."""
+
+    description: str
+    check_func: Callable[[DatabaseUpgrader, UpgradeCondition], dict | None] | None = None
+    skippable: bool = False
+
+    def check(self, upgrader: DatabaseUpgrader) -> dict | None:
+        if self.check_func is None:
+            raise NotImplementedError("check_func must be defined")
+        result = self.check_func(upgrader, self)
+        if result and self.skippable:
+            result["message"] += (
+                " This condition can be bypassed by running the upgrade with the `--force` option."
+            )
+        return result
+
+
+@dataclass(kw_only=True)
+class NoDocumentsIn(UpgradeCondition):
+    """Condition: a collection must contain no document matching a query."""
+
+    collection: str
+    query: dict | None = None
+    description: str = None  # type: ignore[assignment]
+
+    def __post_init__(self):
+        if not self.description:
+            q_str = f" matching {self.query}" if self.query else ""
+            self.description = (
+                f"There should be no document in the '{self.collection}' collection{q_str}"
+            )
+
+        def _check(upgrader: DatabaseUpgrader, _condition: UpgradeCondition) -> dict | None:
+            count = upgrader.db[self.collection].count_documents(self.query or {})
+            if count == 0:
+                return None
+            return {
+                "condition": self,
+                "message": f"Found {count} document(s)",
+                "count": count,
+            }
+
+        self.check_func = _check
+
+
+class DatabaseUpgrader:
+    """Handles upgrading the datalab database between versions.
+
+    Upgrade functions are registered against the version that introduces the
+    backward-incompatible change via :meth:`register_upgrade`. When run, the
+    upgrader collects every registered upgrade between the database's current
+    schema version and the target version and applies them in order, recording
+    the new version in the database after each step.
+    """
+
+    _upgrade_registry: ClassVar[dict[Version, Callable]] = {}
+    _upgrade_conditions_registry: ClassVar[dict[Version, list[UpgradeCondition]]] = {}
+
+    def __init__(self, db: pymongo.database.Database):
+        self.db = db
+        self.current_version = code_version()
+        self._supports_transactions: bool | None = None
+
+    @classmethod
+    def register_upgrade(
+        cls, version: str, upgrade_conditions: list[UpgradeCondition] | None = None
+    ):
+        """Decorator registering an upgrade function for the given version.
+
+        Parameters:
+            version: The version that introduces the change handled by ``func``.
+            upgrade_conditions: Preconditions that must hold before the upgrade
+                can be applied.
+        """
+
+        def decorator(func: Callable):
+            @functools.wraps(func)
+            def wrapper(*args, **kwargs):
+                LOGGER.info("Executing upgrade to version %s", version)
+                start_time = time.perf_counter()
+                result = func(*args, **kwargs)
+                duration = time.perf_counter() - start_time
+                LOGGER.info("Completed upgrade to %s in %.2fs", version, duration)
+                return result
+
+            vv = parse_version(version)
+            cls._upgrade_registry[vv] = wrapper
+            if upgrade_conditions:
+                cls._upgrade_conditions_registry[vv] = upgrade_conditions
+            return wrapper
+
+        return decorator
+
+    @property
+    def registered_upgrades(self) -> list[Version]:
+        return sorted(self._upgrade_registry.keys())
+
+    def get_db_version(self) -> Version | None:
+        """Return the schema version recorded in the database, or ``None``.
+
+        This is a pure read: it never infers a version from database contents and
+        never writes. ``None`` means the database has no recorded schema version
+        (see :class:`UninitialisedDatabaseError`).
+        """
+        doc = self.db[METADATA_COLLECTION].find_one({"_id": SCHEMA_VERSION_ID})
+        if doc and doc.get("version"):
+            return parse_version(doc["version"])
+        return None
+
+    def is_initialised(self) -> bool:
+        """Whether the database has a recorded schema version."""
+        return self.get_db_version() is not None
+
+    def update_db_version(
+        self,
+        version: Version,
+        session: ClientSession | None = None,
+        action: str = "upgrade",
+    ) -> None:
+        """Record ``version`` as the database schema version.
+
+        Every write also appends an entry to the ``history`` array of the metadata
+        document (version, action, timestamp and the running datalab version), as
+        an audit trail of how the recorded version evolved.
+
+        Parameters:
+            version: The version to record.
+            session: Optional session when running inside a transaction.
+            action: What caused the write: ``"upgrade"``, ``"initialise"`` or
+                ``"auto_stamp"``.
+        """
+        history_entry = {
+            "version": str(version),
+            "action": action,
+            "timestamp": datetime.now(timezone.utc),
+            "datalab_version": __version__,
+        }
+        self.db[METADATA_COLLECTION].update_one(
+            {"_id": SCHEMA_VERSION_ID},
+            {
+                "$set": {"version": str(version)},
+                "$push": {"history": history_entry},
+            },
+            upsert=True,
+            session=session,
+        )
+
+    def supports_transactions(self) -> bool:
+        """Whether the connected MongoDB supports multi-document transactions.
+
+        Transactions require a replica set (or sharded cluster); datalab can also
+        run against a standalone ``mongod``, where they are unavailable.
+        """
+        if self._supports_transactions is None:
+            try:
+                hello = self.db.client.admin.command("hello")
+                self._supports_transactions = bool(
+                    hello.get("setName") or hello.get("msg") == "isdbgrid"
+                )
+            except Exception:
+                self._supports_transactions = False
+        return self._supports_transactions
+
+    @contextlib.contextmanager
+    def open_transaction(self):
+        """Yield a transaction session if supported, otherwise yield ``None``."""
+        if self.supports_transactions():
+            with (
+                self.db.client.start_session() as session,
+                session.start_transaction(),
+            ):
+                yield session
+        else:
+            yield None
+
+    def collect_upgrades(self, from_version: Version, target_version: Version) -> list[Version]:
+        """Versions with a registered upgrade in ``(from_version, target_version]``."""
+        return [v for v in self.registered_upgrades if from_version < v <= target_version]
+
+    def check_upgrade_conditions(
+        self, versions: list[Version], force: bool = False
+    ) -> list[tuple[Version, dict]]:
+        """Return any failed preconditions for the given ``versions``."""
+        failed_conditions = []
+        for version in versions:
+            for condition in self._upgrade_conditions_registry.get(version, []):
+                if force and condition.skippable:
+                    continue
+                if (check := condition.check(self)) is not None:
+                    failed_conditions.append((version, check))
+        return failed_conditions
+
+    def _resolve_target(self, target_version: str | None) -> Version:
+        """The version to upgrade towards (explicit, else the code version)."""
+        if target_version:
+            return parse_version(target_version)
+        if self.current_version is not None:
+            return self.current_version
+        # Development install with no explicit target: aim at the last upgrade.
+        return self.registered_upgrades[-1] if self.registered_upgrades else BASELINE_VERSION
+
+    def _resolve_versions(
+        self, from_version: str | None, target_version: str | None
+    ) -> tuple[Version, Version]:
+        """Resolve the (from, target) versions for an upgrade.
+
+        The starting version is the recorded schema version. If the database is
+        unstamped and no explicit ``from_version`` is given, this raises
+        :class:`UninitialisedDatabaseError` *unless* no registered upgrade could
+        apply anyway (e.g. the release that first introduces this framework), in
+        which case :data:`BASELINE_VERSION` is used and the upgrade simply records
+        the target version without applying anything.
+
+        An explicit ``from_version`` exists solely to disambiguate an *unstamped*
+        pre-versioning database; if it contradicts a recorded version this raises
+        ``RuntimeError`` rather than re-running upgrades that may already have
+        been applied.
+        """
+        target = self._resolve_target(target_version)
+        stamped = self.get_db_version()
+
+        if from_version:
+            explicit = parse_version(from_version)
+            if stamped is not None and stamped != explicit:
+                raise RuntimeError(
+                    f"--from-version={explicit} contradicts the schema version "
+                    f"recorded in the database ({stamped}). The recorded version is "
+                    "used automatically, so --from-version is only needed for a "
+                    "database with no recorded version. If the recorded version is "
+                    "wrong, fix it explicitly with "
+                    "`invoke admin.initialise-schema-version --force` first."
+                )
+            return explicit, target
+
+        if stamped is not None:
+            return stamped, target
+
+        # Unstamped and no explicit starting point: only safe to proceed if there
+        # is nothing that could be applied; otherwise the operator must decide.
+        if self.collect_upgrades(BASELINE_VERSION, target):
+            raise UninitialisedDatabaseError(
+                "The database has no recorded schema version. If this is a new "
+                "installation, run `invoke admin.initialise-schema-version`. If "
+                "this is an existing database, run `invoke migration.upgrade "
+                "--from-version=<the datalab version it last ran>`."
+            )
+        return BASELINE_VERSION, target
+
+    def initialise(self, version: str | None = None, force: bool = False) -> Version:
+        """Record the schema version *without applying any upgrades*.
+
+        This is the new-installation path: a pristine database is stamped at the
+        current code version (or an explicit ``version``) so that subsequent
+        upgrades are computed from the right point.
+
+        Raises:
+            RuntimeError: if the database is already initialised and ``force`` is
+                not set, or if the version cannot be determined.
+        """
+        target = parse_version(version) if version else self.current_version
+        if target is None:
+            raise RuntimeError(
+                "Cannot determine the version to initialise to on a development "
+                "install; pass an explicit version."
+            )
+        existing = self.get_db_version()
+        if existing is not None and not force:
+            raise RuntimeError(
+                f"Database is already initialised at version {existing}. "
+                "Pass force=True to overwrite the recorded version."
+            )
+        self.update_db_version(target, action="initialise")
+        LOGGER.info("Recorded database schema version as %s.", target)
+        return target
+
+    def check_and_stamp_version(self) -> DatabaseVersionStatus:
+        """Compare the recorded version with the code version (startup check).
+
+        Updates the version in the DB to the current version only when it is safe,
+        i.e. when the database is unstamped or behind but no registered upgrade
+        falls in the range, so nothing could be skipped.
+        Never applies upgrades and never guesses an unstamped database is current
+        when upgrades exist.
+        """
+        code = self.current_version
+        if code is None:
+            return DatabaseVersionStatus.DEV
+
+        stamped = self.get_db_version()
+        if stamped is None:
+            if self.collect_upgrades(BASELINE_VERSION, code):
+                return DatabaseVersionStatus.UNINITIALISED
+            # If there are no upgrades available yet, it is safe to set the
+            # version in the db.
+            self.update_db_version(code, action="auto_stamp")
+            return DatabaseVersionStatus.AUTO_STAMPED
+
+        if stamped == code:
+            return DatabaseVersionStatus.CURRENT
+        if stamped > code:
+            return DatabaseVersionStatus.AHEAD
+        # stamped < code
+        if self.collect_upgrades(stamped, code):
+            return DatabaseVersionStatus.UPGRADE_PENDING
+        # DB is stamped, but no upgrades available for the current version of the code.
+        # safe to upgrade the DB version automatically.
+        self.update_db_version(code, action="auto_stamp")
+        return DatabaseVersionStatus.AUTO_STAMPED
+
+    def dry_run(
+        self,
+        from_version: str | None = None,
+        target_version: str | None = None,
+        force: bool = False,
+    ) -> tuple[list[UpgradeAction], list[tuple[Version, dict]]]:
+        """Simulate the upgrade, returning the actions and any failed conditions.
+
+        Makes no changes to the database.
+        """
+        db_version, target = self._resolve_versions(from_version, target_version)
+        if db_version >= target:
+            return [], []
+
+        versions_needing_upgrade = self.collect_upgrades(db_version, target)
+        failed_conditions = self.check_upgrade_conditions(versions_needing_upgrade, force=force)
+
+        all_actions: list[UpgradeAction] = []
+        for version in versions_needing_upgrade:
+            all_actions.extend(self._upgrade_registry[version](self.db, dry_run=True))
+
+        all_actions.append(
+            UpgradeAction(
+                description=f"Update database schema version to {target}",
+                collection=METADATA_COLLECTION,
+                action_type="update",
+                details={
+                    "filter": {"_id": SCHEMA_VERSION_ID},
+                    "update": {"$set": {"version": str(target)}},
+                    "upsert": True,
+                },
+            )
+        )
+        return all_actions, failed_conditions
+
+    def upgrade(
+        self,
+        from_version: str | None = None,
+        target_version: str | None = None,
+        force: bool = False,
+    ) -> bool:
+        """Apply the database upgrades from the current to the target version.
+
+        Returns ``True`` if any upgrade was applied, ``False`` if the database
+        was already at the target version. Raises
+        :class:`UpgradeConditionsFailedError` if any precondition is not satisfied.
+        """
+        db_version, target = self._resolve_versions(from_version, target_version)
+        if db_version >= target:
+            LOGGER.info("Database is already at version %s; nothing to upgrade.", db_version)
+            return False
+
+        versions_needing_upgrade = self.collect_upgrades(db_version, target)
+
+        if failed_conditions := self.check_upgrade_conditions(
+            versions_needing_upgrade, force=force
+        ):
+            err = ["Some upgrade conditions were not satisfied:"]
+            for vv, failed in failed_conditions:
+                err.append(
+                    f" - {failed['condition'].description} (for version {vv}): {failed['message']}"
+                )
+            message = "\n".join(err)
+            LOGGER.error(message)
+            raise UpgradeConditionsFailedError(message)
+
+        LOGGER.info("Starting upgrade from version %s to %s", db_version, target)
+        for version in versions_needing_upgrade:
+            with self.open_transaction() as session:
+                LOGGER.info("Applying upgrade to version %s", version)
+                self._upgrade_registry[version](self.db, session=session)
+                self.update_db_version(version, session=session)
+
+        # Record the final target version (covers the case where the target is
+        # ahead of the last registered upgrade); skip it when the last applied
+        # upgrade already recorded exactly the target version.
+        if not versions_needing_upgrade or versions_needing_upgrade[-1] != target:
+            self.update_db_version(target)
+        LOGGER.info("Database upgrade completed successfully (now at %s).", target)
+        return True
+
+
+def check_database_version_on_startup(db: pymongo.database.Database) -> DatabaseVersionStatus:
+    """Run the startup schema-version check and log guidance as needed.
+
+    Does not raise. It auto-stamps the current version only when provably safe,
+    and otherwise logs an actionable message. Returns the resolved status.
+    """
+    upgrader = DatabaseUpgrader(db)
+    try:
+        status = upgrader.check_and_stamp_version()
+    except Exception as exc:
+        LOGGER.warning("Could not check the database schema version: %s", exc)
+        return DatabaseVersionStatus.DEV
+
+    if status is DatabaseVersionStatus.UPGRADE_PENDING:
+        LOGGER.warning(
+            "\n"
+            "============================================================\n"
+            "A DATABASE UPGRADE IS PENDING for this datalab version.\n"
+            "The server will keep running, but some data may fail to load\n"
+            "until you stop the server and run:\n"
+            "    invoke migration.upgrade\n"
+            "Take a backup first with `invoke admin.create-backup`.\n"
+            "============================================================"
+        )
+    elif status is DatabaseVersionStatus.UNINITIALISED:
+        LOGGER.warning(
+            "\n"
+            "============================================================\n"
+            "The database has no recorded schema version.\n"
+            "  - New installation? Run:  invoke admin.initialise-schema-version\n"
+            "  - Existing database?      invoke migration.upgrade \\\n"
+            "                                --from-version=<previous datalab version>\n"
+            "The server will keep running in the meantime.\n"
+            "============================================================"
+        )
+    elif status is DatabaseVersionStatus.AHEAD:
+        LOGGER.warning(
+            "The recorded database schema version is newer than this datalab "
+            "version. This server may be running an older release than the one "
+            "that last wrote the database."
+        )
+
+    return status
+
+
+# ---------------------------------------------------------------------------
+# Registered upgrades
+#
+# Add backward-incompatible upgrades below using the
+# ``@DatabaseUpgrader.register_upgrade("<version>")`` decorator. Each function
+# takes ``(db, session=None, dry_run=False)`` and returns the list of
+# ``UpgradeAction`` it performed. There are currently no registered upgrades.
+# ---------------------------------------------------------------------------

--- a/pydatalab/tasks.py
+++ b/pydatalab/tasks.py
@@ -415,6 +415,123 @@ def add_missing_refcodes(_):
 migration.add_task(add_missing_refcodes)
 
 
+@task(
+    help={
+        "version": "Version to record (defaults to the installed datalab version).",
+        "force": "Overwrite an already-recorded schema version.",
+    }
+)
+def initialise_schema_version(_, version=None, force=False):
+    """Record the database schema version for a NEW installation.
+
+    Use this once on a fresh deployment. It stamps the current version without
+    applying any upgrades (there is no pre-existing data to migrate). For an
+    existing database that predates schema versioning, use `migration.upgrade`
+    with `--from-version` instead.
+    """
+    from pydatalab.mongo import get_database
+    from pydatalab.upgrade import DatabaseUpgrader
+
+    upgrader = DatabaseUpgrader(get_database())
+    try:
+        recorded = upgrader.initialise(version=version, force=force)
+    except RuntimeError as exc:
+        raise SystemExit(str(exc))
+    print(f"Database schema version recorded as {recorded}.")
+
+
+admin.add_task(initialise_schema_version)
+
+
+@task(
+    help={
+        "dry-run": "Show the actions that would be performed without applying them.",
+        "force": "Apply the upgrade even if skippable preconditions are not satisfied.",
+        "yes": "Skip the confirmation prompt (assume 'yes').",
+        "from-version": (
+            "Starting version for an unstamped (pre-versioning) database; required "
+            "when the database has no recorded version and upgrades exist."
+        ),
+        "target-version": "Override the version to upgrade to (defaults to the installed version).",
+    }
+)
+def upgrade(_, dry_run=False, force=False, yes=False, from_version=None, target_version=None):
+    """Apply backward-incompatible database upgrades for the current datalab version.
+
+    Run this with the server stopped and direct access to the database. Take a
+    backup first with `invoke admin.create-backup`. For a brand-new installation,
+    use `admin.initialise-schema-version` instead.
+    """
+    from pydatalab.mongo import get_database
+    from pydatalab.upgrade import DatabaseUpgrader, UpgradeConditionsFailedError
+
+    upgrader = DatabaseUpgrader(get_database())
+    target = target_version or (
+        str(upgrader.current_version) if upgrader.current_version else "(latest registered)"
+    )
+
+    try:
+        actions, failed_conditions = upgrader.dry_run(
+            from_version=from_version, target_version=target_version, force=force
+        )
+    except RuntimeError as exc:
+        # Covers both an unstamped database needing an operator decision and a
+        # --from-version that contradicts the recorded schema version.
+        raise SystemExit(str(exc))
+
+    stamped = upgrader.get_db_version()
+    db_version = from_version or (str(stamped) if stamped is not None else "uninitialised")
+
+    if not actions:
+        print(f"Database is already up to date (version {db_version}); nothing to do.")
+        return
+
+    print(f"Planned upgrade: {db_version} -> {target}")
+    print("\nThe following actions would be performed:")
+    for action in actions:
+        print(f"  - [{action.collection}] {action.description}")
+
+    if failed_conditions:
+        print("\nThe following preconditions are NOT satisfied:")
+        for vv, failed in failed_conditions:
+            print(f"  - {failed['condition'].description} (for version {vv}): {failed['message']}")
+        if not force:
+            print(
+                "\nResolve the issues above, or re-run with `--force` to bypass skippable conditions."
+            )
+
+    if dry_run:
+        print("\nDry run only; no changes were made.")
+        return
+
+    print(
+        "\nWARNING: this will modify the database in place. Make sure the server is"
+        " stopped and that you have run `invoke admin.create-backup` first."
+    )
+    if not yes:
+        response = input("Proceed with the upgrade? [y/N] ").strip().lower()
+        if response not in ("y", "yes"):
+            print("Aborted; no changes were made.")
+            return
+
+    try:
+        upgraded = upgrader.upgrade(
+            from_version=from_version, target_version=target_version, force=force
+        )
+    except UpgradeConditionsFailedError:
+        raise SystemExit(
+            "Upgrade aborted because some preconditions were not satisfied (see above)."
+        )
+
+    if upgraded:
+        print("Database upgrade completed successfully.")
+    else:
+        print("Database was already up to date; nothing to do.")
+
+
+migration.add_task(upgrade)
+
+
 def _check_id(id=None, base_url=None, api_key=None):
     from pydatalab.logger import setup_log
 

--- a/pydatalab/tests/server/test_upgrade.py
+++ b/pydatalab/tests/server/test_upgrade.py
@@ -1,0 +1,400 @@
+"""Tests for the administrator-driven database upgrade framework."""
+
+import pytest
+from packaging.version import Version
+
+from pydatalab.upgrade import (
+    METADATA_COLLECTION,
+    SCHEMA_VERSION_ID,
+    DatabaseUpgrader,
+    DatabaseVersionStatus,
+    NoDocumentsIn,
+    UninitialisedDatabaseError,
+    UpgradeAction,
+    UpgradeConditionsFailedError,
+    check_database_version_on_startup,
+    code_version,
+)
+
+# A marker collection written to by the throwaway test upgrades.
+MARKER_COLLECTION = "__upgrade_test_marker__"
+
+# A fixed "code version" the startup-check tests pin onto the upgrader, so they
+# exercise the status logic deterministically regardless of the installed
+# package version (which is ``None`` on development / setuptools-scm builds).
+PINNED_CODE = Version("1.0.0")
+
+
+@pytest.fixture
+def clean_registry():
+    """Snapshot and restore the class-level upgrade registries around a test."""
+    upgrades = dict(DatabaseUpgrader._upgrade_registry)
+    conditions = dict(DatabaseUpgrader._upgrade_conditions_registry)
+    DatabaseUpgrader._upgrade_registry.clear()
+    DatabaseUpgrader._upgrade_conditions_registry.clear()
+    try:
+        yield
+    finally:
+        DatabaseUpgrader._upgrade_registry.clear()
+        DatabaseUpgrader._upgrade_registry.update(upgrades)
+        DatabaseUpgrader._upgrade_conditions_registry.clear()
+        DatabaseUpgrader._upgrade_conditions_registry.update(conditions)
+
+
+@pytest.fixture(autouse=True)
+def clean_collections(database):
+    """Drop the collections these tests touch, before and after each test."""
+    for coll in (METADATA_COLLECTION, MARKER_COLLECTION, "items"):
+        database[coll].delete_many({})
+    yield
+    for coll in (METADATA_COLLECTION, MARKER_COLLECTION, "items"):
+        database[coll].delete_many({})
+
+
+def _make_marker_upgrade(version: str, conditions=None):
+    """Register a throwaway upgrade that writes a marker document."""
+
+    @DatabaseUpgrader.register_upgrade(version, upgrade_conditions=conditions)
+    def _upgrade(db, session=None, dry_run=False):
+        action = UpgradeAction(
+            description=f"Write marker for {version}",
+            collection=MARKER_COLLECTION,
+            action_type="insert",
+            details={"version": version},
+            required=True,
+        )
+        if not dry_run:
+            db[MARKER_COLLECTION].insert_one({"version": version}, session=session)
+        return [action]
+
+    return _upgrade
+
+
+# --- code_version() resolution ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "version_str, expected",
+    [
+        # Clean release tags are honoured.
+        ("0.8.0", Version("0.8.0")),
+        # A genuine post-release (no local segment) is still a release.
+        ("0.7.0.post1", Version("0.7.0.post1")),
+        # setuptools-scm dev builds carry a local segment -> development.
+        ("0.1.0.post1407+g019fc0478", None),
+        # An explicit local segment alone is enough -> development.
+        ("1.0.0+local", None),
+        # A .dev pre-release -> development.
+        ("0.8.0.dev3", None),
+        # The unparseable fallback used when the package is not installed.
+        ("develop", None),
+    ],
+)
+def test_code_version_resolution(monkeypatch, version_str, expected):
+    """`code_version()` returns a Version only for real releases, else None."""
+    monkeypatch.setattr("pydatalab.upgrade.__version__", version_str)
+    assert code_version() == expected
+
+
+# --- pure version read --------------------------------------------------------
+
+
+def test_unstamped_db_reads_as_none(database, clean_registry):
+    upgrader = DatabaseUpgrader(database)
+    assert upgrader.get_db_version() is None
+    assert upgrader.is_initialised() is False
+    # Reading must not write anything.
+    assert database[METADATA_COLLECTION].find_one({"_id": SCHEMA_VERSION_ID}) is None
+
+
+def test_update_and_read_roundtrip(database, clean_registry):
+    upgrader = DatabaseUpgrader(database)
+    upgrader.update_db_version(Version("1.2.3"))
+    assert upgrader.get_db_version() == Version("1.2.3")
+    assert upgrader.is_initialised() is True
+
+
+# --- initialise (new installation) -------------------------------------------
+
+
+def test_initialise_records_version_without_running_upgrades(database, clean_registry):
+    """initialise() stamps the version and never applies registered upgrades."""
+    _make_marker_upgrade("99.0.0")
+    upgrader = DatabaseUpgrader(database)
+
+    recorded = upgrader.initialise(version="50.0.0")
+
+    assert recorded == Version("50.0.0")
+    assert upgrader.get_db_version() == Version("50.0.0")
+    # The registered upgrade must NOT have run.
+    assert database[MARKER_COLLECTION].count_documents({}) == 0
+
+
+def test_initialise_refuses_when_already_initialised(database, clean_registry):
+    upgrader = DatabaseUpgrader(database)
+    upgrader.initialise(version="1.0.0")
+
+    with pytest.raises(RuntimeError):
+        upgrader.initialise(version="2.0.0")
+
+    assert upgrader.get_db_version() == Version("1.0.0")
+
+    # force overwrites.
+    assert upgrader.initialise(version="2.0.0", force=True) == Version("2.0.0")
+    assert upgrader.get_db_version() == Version("2.0.0")
+
+
+def test_initialise_defaults_to_code_version(database, clean_registry):
+    upgrader = DatabaseUpgrader(database)
+    upgrader.current_version = PINNED_CODE
+    recorded = upgrader.initialise()
+    assert recorded == PINNED_CODE
+
+
+# --- collect / dry-run / upgrade ---------------------------------------------
+
+
+def test_collect_upgrades(database, clean_registry):
+    _make_marker_upgrade("1.0.0")
+    _make_marker_upgrade("2.0.0")
+    _make_marker_upgrade("3.0.0")
+    upgrader = DatabaseUpgrader(database)
+
+    assert upgrader.collect_upgrades(Version("1.0.0"), Version("3.0.0")) == [
+        Version("2.0.0"),
+        Version("3.0.0"),
+    ]
+    assert upgrader.collect_upgrades(Version("2.0.0"), Version("2.0.0")) == []
+
+
+def test_dry_run_makes_no_changes(database, clean_registry):
+    _make_marker_upgrade("99.0.0")
+    upgrader = DatabaseUpgrader(database)
+    upgrader.update_db_version(Version("98.0.0"))
+
+    actions, failed = upgrader.dry_run(target_version="99.0.0")
+
+    assert failed == []
+    assert any(a.collection == MARKER_COLLECTION for a in actions)
+    assert any(a.collection == METADATA_COLLECTION for a in actions)
+    # Nothing was actually written.
+    assert database[MARKER_COLLECTION].count_documents({}) == 0
+    assert upgrader.get_db_version() == Version("98.0.0")
+
+
+def test_upgrade_applies_and_records_version(database, clean_registry):
+    _make_marker_upgrade("99.0.0")
+    upgrader = DatabaseUpgrader(database)
+    upgrader.update_db_version(Version("98.0.0"))
+
+    assert upgrader.upgrade(target_version="99.0.0") is True
+
+    assert database[MARKER_COLLECTION].count_documents({"version": "99.0.0"}) == 1
+    assert upgrader.get_db_version() == Version("99.0.0")
+
+
+def test_upgrade_noop_when_already_at_target(database, clean_registry):
+    _make_marker_upgrade("99.0.0")
+    upgrader = DatabaseUpgrader(database)
+    upgrader.update_db_version(Version("99.0.0"))
+
+    assert upgrader.upgrade(target_version="99.0.0") is False
+    assert database[MARKER_COLLECTION].count_documents({}) == 0
+
+
+# --- unstamped database: must not guess --------------------------------------
+
+
+def test_upgrade_unstamped_with_pending_raises(database, clean_registry):
+    """An unstamped DB with applicable upgrades refuses to run without a decision."""
+    _make_marker_upgrade("99.0.0")
+    upgrader = DatabaseUpgrader(database)
+
+    with pytest.raises(UninitialisedDatabaseError):
+        upgrader.upgrade(target_version="99.0.0")
+
+    # Nothing applied or recorded.
+    assert database[MARKER_COLLECTION].count_documents({}) == 0
+    assert upgrader.get_db_version() is None
+
+
+def test_upgrade_unstamped_with_from_version_applies(database, clean_registry):
+    """Declaring --from-version lets an unstamped (pre-versioning) DB upgrade."""
+    _make_marker_upgrade("99.0.0")
+    upgrader = DatabaseUpgrader(database)
+
+    assert upgrader.upgrade(from_version="98.0.0", target_version="99.0.0") is True
+    assert database[MARKER_COLLECTION].count_documents({"version": "99.0.0"}) == 1
+    assert upgrader.get_db_version() == Version("99.0.0")
+
+
+def test_upgrade_unstamped_no_applicable_upgrades_just_stamps(database, clean_registry):
+    """With nothing that could apply, an unstamped DB is simply stamped (no guess needed)."""
+    _make_marker_upgrade("99.0.0")
+    upgrader = DatabaseUpgrader(database)
+
+    # Target below the registered upgrade -> nothing in range -> safe.
+    assert upgrader.upgrade(target_version="1.0.0") is True
+    assert database[MARKER_COLLECTION].count_documents({}) == 0
+    assert upgrader.get_db_version() == Version("1.0.0")
+
+
+def test_from_version_contradicting_stamp_refuses(database, clean_registry):
+    """--from-version must not override a recorded version (risk of re-running upgrades)."""
+    _make_marker_upgrade("99.0.0")
+    upgrader = DatabaseUpgrader(database)
+    upgrader.update_db_version(Version("98.0.0"))
+
+    with pytest.raises(RuntimeError, match="contradicts"):
+        upgrader.upgrade(from_version="0.5.0", target_version="99.0.0")
+
+    assert database[MARKER_COLLECTION].count_documents({}) == 0
+    assert upgrader.get_db_version() == Version("98.0.0")
+
+
+def test_from_version_matching_stamp_is_allowed(database, clean_registry):
+    _make_marker_upgrade("99.0.0")
+    upgrader = DatabaseUpgrader(database)
+    upgrader.update_db_version(Version("98.0.0"))
+
+    assert upgrader.upgrade(from_version="98.0.0", target_version="99.0.0") is True
+    assert upgrader.get_db_version() == Version("99.0.0")
+
+
+# --- audit trail ----------------------------------------------------------------
+
+
+def test_history_audit_trail(database, clean_registry):
+    """Every stamp appends a history entry with version, action and timestamp."""
+    _make_marker_upgrade("98.5.0")
+    _make_marker_upgrade("99.0.0")
+    upgrader = DatabaseUpgrader(database)
+    upgrader.initialise(version="98.0.0")
+
+    assert upgrader.upgrade(target_version="99.0.0") is True
+
+    doc = database[METADATA_COLLECTION].find_one({"_id": SCHEMA_VERSION_ID})
+    assert [(h["version"], h["action"]) for h in doc["history"]] == [
+        ("98.0.0", "initialise"),
+        ("98.5.0", "upgrade"),
+        ("99.0.0", "upgrade"),
+    ]
+    assert all("timestamp" in h and "datalab_version" in h for h in doc["history"])
+
+
+def test_auto_stamp_recorded_in_history(database, clean_registry):
+    upgrader = DatabaseUpgrader(database)
+    upgrader.current_version = PINNED_CODE
+
+    assert upgrader.check_and_stamp_version() is DatabaseVersionStatus.AUTO_STAMPED
+
+    doc = database[METADATA_COLLECTION].find_one({"_id": SCHEMA_VERSION_ID})
+    assert doc["history"][-1]["action"] == "auto_stamp"
+
+
+# --- preconditions ------------------------------------------------------------
+
+
+def test_failed_precondition_blocks_upgrade(database, clean_registry):
+    database.items.insert_one({"type": "samples", "item_id": "x"})
+    condition = NoDocumentsIn(collection="items")
+    _make_marker_upgrade("99.0.0", conditions=[condition])
+    upgrader = DatabaseUpgrader(database)
+    upgrader.update_db_version(Version("98.0.0"))
+
+    with pytest.raises(UpgradeConditionsFailedError):
+        upgrader.upgrade(target_version="99.0.0")
+
+    assert database[MARKER_COLLECTION].count_documents({}) == 0
+    assert upgrader.get_db_version() == Version("98.0.0")
+
+
+def test_skippable_precondition_bypassed_with_force(database, clean_registry):
+    database.items.insert_one({"type": "samples", "item_id": "x"})
+    condition = NoDocumentsIn(collection="items", skippable=True)
+    _make_marker_upgrade("99.0.0", conditions=[condition])
+    upgrader = DatabaseUpgrader(database)
+    upgrader.update_db_version(Version("98.0.0"))
+
+    _, failed = upgrader.dry_run(target_version="99.0.0")
+    assert failed
+    assert upgrader.upgrade(target_version="99.0.0", force=True) is True
+    assert database[MARKER_COLLECTION].count_documents({"version": "99.0.0"}) == 1
+
+
+def test_open_transaction_does_not_raise(database, clean_registry):
+    _make_marker_upgrade("99.0.0")
+    upgrader = DatabaseUpgrader(database)
+    upgrader.update_db_version(Version("98.0.0"))
+
+    with upgrader.open_transaction() as session:
+        assert session is None or session is not None  # never raises
+
+    assert upgrader.upgrade(target_version="99.0.0") is True
+
+
+# --- startup version check ----------------------------------------------------
+
+
+def test_check_and_stamp_version_current(database, clean_registry):
+    upgrader = DatabaseUpgrader(database)
+    upgrader.current_version = PINNED_CODE
+    upgrader.update_db_version(PINNED_CODE)
+    assert upgrader.check_and_stamp_version() is DatabaseVersionStatus.CURRENT
+
+
+def test_check_and_stamp_version_ahead(database, clean_registry):
+    upgrader = DatabaseUpgrader(database)
+    upgrader.current_version = PINNED_CODE
+    upgrader.update_db_version(Version("999.0.0"))
+    assert upgrader.check_and_stamp_version() is DatabaseVersionStatus.AHEAD
+
+
+def test_check_and_stamp_version_unstamped_no_upgrades_auto_stamps(database, clean_registry):
+    """The framework-introduction release: nothing registered -> auto-stamp current."""
+    upgrader = DatabaseUpgrader(database)
+    upgrader.current_version = PINNED_CODE
+
+    assert upgrader.check_and_stamp_version() is DatabaseVersionStatus.AUTO_STAMPED
+    assert upgrader.get_db_version() == PINNED_CODE
+
+
+def test_check_and_stamp_version_unstamped_with_upgrades_is_uninitialised(database, clean_registry):
+    """An unstamped DB on a release that has upgrades must be disambiguated."""
+    upgrader = DatabaseUpgrader(database)
+    upgrader.current_version = PINNED_CODE
+    # An upgrade in (baseline, code] makes the unstamped state ambiguous.
+    _make_marker_upgrade("0.0.1")
+
+    assert upgrader.check_and_stamp_version() is DatabaseVersionStatus.UNINITIALISED
+    # No auto-stamp, no upgrade applied.
+    assert upgrader.get_db_version() is None
+    assert database[MARKER_COLLECTION].count_documents({}) == 0
+
+
+def test_check_and_stamp_version_behind_with_upgrades_pending(database, clean_registry):
+    upgrader = DatabaseUpgrader(database)
+    upgrader.current_version = PINNED_CODE
+    upgrader.update_db_version(Version("0.0.1"))
+    _make_marker_upgrade("0.0.5")  # in (0.0.1, code]
+
+    assert upgrader.check_and_stamp_version() is DatabaseVersionStatus.UPGRADE_PENDING
+    # Pending check does not apply the upgrade or move the version.
+    assert upgrader.get_db_version() == Version("0.0.1")
+    assert database[MARKER_COLLECTION].count_documents({}) == 0
+
+
+def test_check_and_stamp_version_behind_no_upgrades_auto_stamps(database, clean_registry):
+    upgrader = DatabaseUpgrader(database)
+    upgrader.current_version = PINNED_CODE
+    upgrader.update_db_version(Version("0.0.1"))
+
+    assert upgrader.check_and_stamp_version() is DatabaseVersionStatus.AUTO_STAMPED
+    assert upgrader.get_db_version() == PINNED_CODE
+
+
+def test_startup_helper_returns_status(database, clean_registry):
+    # On a development build this resolves to DEV; on a release build to a real
+    # status. Either way the helper returns a DatabaseVersionStatus.
+    status = check_database_version_on_startup(database)
+    assert isinstance(status, DatabaseVersionStatus)


### PR DESCRIPTION
As mentioned in #48 we would like to introduce a backward incompatible change to split the blocks data from the items. We are thus proposing a general procedure for handling backward incompatible upgrades to the DB (see  #1184).

The whole implementation is heavily based on the one we have developed for [jobflow-remote](https://github.com/Matgenix/jobflow-remote/blob/develop/src/jobflow_remote/jobs/upgrade.py) and should be used only when truly needed, as we recongnize the pain and the potential issues associated with DB migrations.

## Overview

The main change is the addition of the `upgrade` module that contains a `DatabaseUpgrader`. A new migration requires writing a function that performs the required updates on the DB and decorating it with`@DatabaseUpgrader.register_upgrade("X.Y.Z")`, where `"X.Y.Z"` is the new version that will be released.

In order to determine the datalab version associated with the DB a new collection (`database_metadata`) is created, where a document stores the current version number of datalab. 

When the code is updated to a newer version, the upgrade procedure checks the datalab version stored in the DB and compares it with the version of the code being executed, applying sequentially all the intermediate upgrades to the DB, and finally updating the document in `database_metadata` with the current datalab version. This allows to build incremental upgrades between different versions. 

This upgrade can be executed with an invoke task: `migration.upgrade`.

## Initialization

A downside of the current proposal is that storing the datalab version in the DB requires an initialization. This is done through the invoke task `admin.initialise-schema-version` that needs to be executed during the initial deployment. We have considered doing this automatically in the `create_app`, but the main issue is to tell apart a DB associated to an already existing deplyoment from a pristine one, since in both cases the `database_metadata` will be empty. In principle one could imagine defining a procedure to guess the status of the DB (e.g., no items present or all the collections should be empty), but it would be easy to imagine cases where these checks might lead to the wrong conclusion. For example, if checking that all the collections are empty, this may fail to recognize a new deployment if in the future someone adds some other metadata document or if a user is added to the DB before starting the server. So, we ended up proposing this manual initialization procedure. It would be easy to switch to an automated one if preferred or if a reliable criteria can be determined.

## Example
 
As an example of how to create a new upgrade, here is a draft to modify `relationships` to be based on `refcode` instead of `item_id` (see #1184). I don't think this covers properly all the cases and I did not attempt to make a complete one here, as it is beyond the scope of this PR. Just an idea of how this would work. Some more example can be found in jobflow remote, whose implementation is very similar.

<details>

<summary>relationships upgrade example</summary>

```python
@DatabaseUpgrader.register_upgrade("0.8.0")
def pin_item_id_references_to_refcodes(
    db: pymongo.database.Database,
    session: ClientSession | None = None,
    dry_run: bool = False,
) -> list[UpgradeAction]:
    # Build a lookup from item_id to refcode
    item_id_to_refcode = {
        doc["item_id"]: doc["refcode"]
        for doc in db.items.find(
            {"item_id": {"$ne": None}, "refcode": {"$ne": None}},
            projection={"item_id": 1, "refcode": 1},
            session=session,
        )
    }

    pinned = 0
    deprecated = 0

    for item in db.items.find({}, projection={"_id": 1, "relationships": 1}, session=session):
        relationships = item.get("relationships") or []

        changed = False
        for rel in relationships:
            # Skip relationships that already use refcode or don't use an item_id.
            if rel.get("refcode") or not rel.get("item_id"):
                continue

            refcode = item_id_to_refcode.get(rel["item_id"])
            if refcode is not None:
                rel["refcode"] = refcode
                pinned += 1
            else:
                # Deprecate when no item matches
                rel["deprecated"] = True
                deprecated += 1
            changed = True

        if changed and not dry_run:
            db.items.update_one(
                {"_id": item["_id"]},
                {"$set": {"relationships": relationships}},
                session=session,
            )

    return [
        UpgradeAction(
            description=f"Pin {pinned} item_id reference(s) to their refcode",
            collection="items",
            action_type="update",
            details={"pinned": pinned},
        ),
        UpgradeAction(
            description=f"Deprecate {deprecated} unresolvable item_id reference(s)",
            collection="items",
            action_type="update",
            details={"deprecated": deprecated},
        ),
    ]
```

</details>

## TODO

Document the upgrade and initialize procedure if approved.

Let us know what you think or if you need more details.