### PR TITLE
Use native bokeh objects in callbacks rather than relying on `window.event`

### DIFF
--- a/pydatalab/src/pydatalab/blocks/base.py
+++ b/pydatalab/src/pydatalab/blocks/base.py
@@ -28,8 +28,9 @@ def generate_js_callback_single_float_parameter(
 
     """
 
-    cb_prop: str = "value_throttled" if throttled else "value"
-    event_target: str = f"(cb_obj.{cb_prop} ?? cb_obj.text)"
+    event_target: str = (
+        "(cb_obj.value_throttled ?? cb_obj.value ?? cb_obj.text)" if throttled else "(cb_obj.value ?? cb_obj.text)"
+    )
 
     code = (
         r"""

--- a/pydatalab/src/pydatalab/blocks/base.py
+++ b/pydatalab/src/pydatalab/blocks/base.py
@@ -28,9 +28,8 @@ def generate_js_callback_single_float_parameter(
 
     """
 
-    event_target: str = "event.target.value"
-    if throttled:
-        event_target += "_throttled"
+    cb_prop: str = "value_throttled" if throttled else "value"
+    event_target: str = f"(cb_obj.{cb_prop} ?? cb_obj.text)"
 
     code = (
         r"""

--- a/pydatalab/src/pydatalab/blocks/base.py
+++ b/pydatalab/src/pydatalab/blocks/base.py
@@ -29,7 +29,9 @@ def generate_js_callback_single_float_parameter(
     """
 
     event_target: str = (
-        "(cb_obj.value_throttled ?? cb_obj.value ?? cb_obj.text)" if throttled else "(cb_obj.value ?? cb_obj.text)"
+        "(cb_obj.value_throttled ?? cb_obj.value ?? cb_obj.text)"
+        if throttled
+        else "(cb_obj.value ?? cb_obj.text)"
     )
 
     code = (

--- a/pydatalab/src/pydatalab/bokeh_plots.py
+++ b/pydatalab/src/pydatalab/bokeh_plots.py
@@ -548,9 +548,8 @@ def selectable_axes_plot(
             input_widget = TextInput(title=parameter["label"], value=str(parameter["value"]))
             if parameter["event"]:
                 code = parameter["event"]
-                code += (
-                    f"console.log('Dispatched event for {parameter['label']}', event.target.value)"
-                )
+                label = parameter["label"]
+                code += f"\nconsole.log('Dispatched event for {label}', cb_obj.value)"
                 input_widget.js_on_change("value", *[CustomJS(code=code)])
             input_widgets.append(input_widget)
 

--- a/pydatalab/tests/test_base_block.py
+++ b/pydatalab/tests/test_base_block.py
@@ -21,7 +21,7 @@ def test_callback():
     detail: {
         block_id: 'test',
         event_name: 'set_wavelength',
-        wavelength: event.target.value,
+        wavelength: (cb_obj.value ?? cb_obj.text),
     }, bubbles: true
 });
 document.dispatchEvent(block_event);"""


### PR DESCRIPTION
`generate_js_callback_single_float_parameter` was using `event.target.value` which is not a parameter of Bokeh `js_on_change` callbacks — Bokeh passes `cb_obj` (the changed model) and `cb_data`, not a DOM event.

Changed to use `cb_obj.value ?? cb_obj.text`, which reads directly from the Bokeh model. The two properties cover different widget types: `cb_obj.value` for callbacks attached directly to a `TextInput` (XRD), and `cb_obj.text` for callbacks attached to a hidden `Div` (OMS, Viscosity, Surface tension).

After testing post #1853 was merged the old route appeared to work (`event.target.value`). Some debugging suggests this is window.event holds the last DOM event, meaning event.target.value resolves correctly. But we shouldn't rely on this going forwards.