### PR TITLE
Improvements to substance info display (rounding, toggle and styling)

### DIFF
--- a/webapp/src/components/SubstanceInfoSmall.vue
+++ b/webapp/src/components/SubstanceInfoSmall.vue
@@ -7,7 +7,12 @@
       </div>
       <div v-if="molarMass" class="substance-small-row">
         <span class="small-label">Mass</span>
-        <span class="small-value">{{ molarMass }} g/mol</span>
+        <span class="small-value"
+          >{{
+            Number.isFinite(Number(molarMass)) ? Number(molarMass).toFixed(2) : molarMass
+          }}
+          g/mol</span
+        >
       </div>
       <div v-if="ghsCodes && hasPictograms" class="substance-small-row">
         <span class="small-label">Hazards</span>

--- a/webapp/src/components/SubstanceInformation.vue
+++ b/webapp/src/components/SubstanceInformation.vue
@@ -3,7 +3,7 @@
     <div
       class="datablock-header"
       :class="{ clickable: !isEditing, expanded: isEditing }"
-      @click="!isEditing && enterEditMode()"
+      @click="toggleEditMode"
     >
       <font-awesome-icon
         :icon="['fas', 'chevron-right']"

--- a/webapp/src/components/SubstanceInformation.vue
+++ b/webapp/src/components/SubstanceInformation.vue
@@ -103,7 +103,7 @@
           <div class="form-group col-sm-6 pr-2">
             <label for="substance-smiles">SMILES</label>
             <div class="input-with-copy">
-              <InputText id="substance-smiles" v-model="smiles" fluid class="p-inputtext-sm" />
+              <input id="substance-smiles" v-model="smiles" type="text" class="form-control" />
               <button
                 v-if="smiles"
                 type="button"
@@ -120,7 +120,7 @@
           <div class="form-group col-sm-6 pr-2">
             <label for="substance-inchi">InChI</label>
             <div class="input-with-copy">
-              <InputText id="substance-inchi" v-model="inchi" fluid class="p-inputtext-sm" />
+              <input id="substance-inchi" v-model="inchi" type="text" class="form-control" />
               <button
                 v-if="inchi"
                 type="button"
@@ -135,11 +135,11 @@
           <div class="form-group col-sm-6 pr-2">
             <label for="substance-inchi-key">InChI Key</label>
             <div class="input-with-copy">
-              <InputText
+              <input
                 id="substance-inchi-key"
                 v-model="inchi_key"
-                fluid
-                class="p-inputtext-sm"
+                type="text"
+                class="form-control"
               />
               <button
                 v-if="inchi_key"
@@ -156,18 +156,18 @@
         <div class="form-row">
           <div class="form-group col-sm-6 pr-2">
             <label for="substance-mass">Molar mass (g/mol)</label>
-            <InputNumber
+            <input
               id="substance-mass"
-              v-model="molar_mass"
-              fluid
-              input-class="p-inputtext-sm"
-              style="width: 100%"
+              v-model.number="molar_mass"
+              type="number"
+              step="any"
+              class="form-control"
             />
           </div>
           <div class="form-group col-sm-6 pr-2">
             <label for="substance-cas">CAS</label>
             <div class="input-with-copy">
-              <InputText id="substance-cas" v-model="CAS" fluid class="p-inputtext-sm" />
+              <input id="substance-cas" v-model="CAS" type="text" class="form-control" />
               <button
                 v-if="CAS"
                 type="button"
@@ -202,8 +202,6 @@ import ChemFormulaInput from "@/components/ChemFormulaInput";
 import ChemicalFormula from "@/components/ChemicalFormula";
 import { OnClickOutside } from "@vueuse/components";
 import { getPictogramsFromHazardInformation } from "@/resources.js";
-import InputText from "primevue/inputtext";
-import InputNumber from "primevue/inputnumber";
 
 export default {
   components: {
@@ -212,8 +210,6 @@ export default {
     GHSHazardInformation,
     GHSHazardPictograms,
     OnClickOutside,
-    InputText,
-    InputNumber,
   },
   props: {
     item_id: { type: String, required: true },
@@ -463,7 +459,7 @@ export default {
   position: relative;
 }
 
-.input-with-copy :deep(.p-inputtext) {
+.input-with-copy .form-control {
   padding-right: 2rem;
 }
 

--- a/webapp/src/components/SubstanceInformation.vue
+++ b/webapp/src/components/SubstanceInformation.vue
@@ -26,7 +26,12 @@
             </div>
             <div v-if="molar_mass" class="info-item">
               <span class="display-label">Molar mass</span>
-              <span class="info-value">{{ molar_mass }} g/mol</span>
+              <span class="info-value"
+                >{{
+                  Number.isFinite(Number(molar_mass)) ? Number(molar_mass).toFixed(2) : molar_mass
+                }}
+                g/mol</span
+              >
             </div>
             <div v-if="CAS" class="info-item">
               <span class="display-label">CAS</span>
@@ -155,8 +160,6 @@
               id="substance-mass"
               v-model="molar_mass"
               fluid
-              :min-fraction-digits="0"
-              :max-fraction-digits="4"
               input-class="p-inputtext-sm"
               style="width: 100%"
             />


### PR DESCRIPTION
A few small tweaks to the very nice `SubstanceInfo` component:

1. Currently, it can display a large number of decimal places, especially due to floating point rounding errors:

<img width="803" height="155" alt="Screenshot 2026-06-12 at 4 17 03 PM" src="https://github.com/user-attachments/assets/d9950e16-fd33-4c91-848b-18ede94fb2cd" />

This is changed so that the displayed value is rounded to 2 decimals (the actual value can be set to any desired precision; it just won't be displayed)

2. The toggle behavior is tweaked, allowing the user to close the edit window by clicking on the header for more consistency.

3. Switched over from PrimeVue inputs to native HTML inputs with bootstrap styling (`.form-control`), for consistency across the app.

