### PR TITLE
add LocationInput component for hierarchical location editing

### DIFF
--- a/webapp/cypress/e2e/equipment.cy.js
+++ b/webapp/cypress/e2e/equipment.cy.js
@@ -141,7 +141,8 @@ describe("Equipment edit page", () => {
     cy.findByText("test_e3").click();
     cy.findByLabelText("Description").type("this is a description of testB.");
     cy.findByLabelText("Date").type("2000-01-01T00:00");
-    cy.findByLabelText("Location").type("room 101");
+    cy.get("#equip-location").click();
+    cy.get(".location-segment-input").first().type("room 101");
 
     cy.get('[data-testid="add-block-button-top"]').click();
     cy.get('[data-testid="add-block-dropdown"]').findByText("Comment").click();

--- a/webapp/src/components/EquipmentInformation.vue
+++ b/webapp/src/components/EquipmentInformation.vue
@@ -50,15 +50,8 @@
         <input id="equip-manufacturer" v-model="Manufacturer" class="form-control" />
       </div>
       <div class="form-group col-md-6">
-        <label for="equip-location" class="mr-2">Location</label>
-        <AutoComplete
-          v-model="Location"
-          input-id="equip-location"
-          :suggestions="filteredLocations"
-          class="form-control p-0 border-0"
-          input-class="form-control"
-          @complete="filterLocations"
-        />
+        <label class="mr-2">Location</label>
+        <LocationInput v-model="Location" :suggestions="uniqueLocations" />
       </div>
     </div>
     <div class="form-row">
@@ -86,6 +79,7 @@
 import AutoComplete from "primevue/autocomplete";
 import { getStartingMaterialList, getEquipmentList } from "@/server_fetch_utils.js";
 import { createComputedSetterForItemField } from "@/field_utils.js";
+import LocationInput from "@/components/LocationInput";
 import TiptapInline from "@/components/TiptapInline";
 import TableOfContents from "@/components/TableOfContents";
 import CollectionList from "@/components/CollectionList";
@@ -104,13 +98,13 @@ export default {
     ToggleableCreatorsFormGroup,
     ToggleableItemStatusFormGroup,
     ToggleableGroupsFormGroup,
+    LocationInput,
   },
   props: {
     item_id: { type: String, required: true },
   },
   data() {
     return {
-      filteredLocations: [],
       tableOfContentsSections: [
         { title: "Equipment Information", targetID: "equipment-information" },
         { title: "Table of Contents", targetID: "table-of-contents" },
@@ -160,12 +154,7 @@ export default {
       getEquipmentList();
     }
   },
-  methods: {
-    filterLocations(event) {
-      const query = event.query.toLowerCase();
-      this.filteredLocations = this.uniqueLocations.filter((l) => l.toLowerCase().includes(query));
-    },
-  },
+  methods: {},
 };
 </script>
 

--- a/webapp/src/components/EquipmentInformation.vue
+++ b/webapp/src/components/EquipmentInformation.vue
@@ -50,8 +50,12 @@
         <input id="equip-manufacturer" v-model="Manufacturer" class="form-control" />
       </div>
       <div class="form-group col-md-6">
-        <label class="mr-2">Location</label>
-        <LocationInput v-model="Location" :suggestions="uniqueLocations" />
+        <label for="equip-location" class="mr-2">Location</label>
+        <LocationInput
+          v-model="Location"
+          :suggestions="uniqueLocations"
+          input-id="equip-location"
+        />
       </div>
     </div>
     <div class="form-row">

--- a/webapp/src/components/EquipmentInformation.vue
+++ b/webapp/src/components/EquipmentInformation.vue
@@ -50,7 +50,7 @@
         <input id="equip-manufacturer" v-model="Manufacturer" class="form-control" />
       </div>
       <div class="form-group col-md-6">
-        <label for="equip-location" class="mr-2">Location</label>
+        <label class="mr-2">Location</label>
         <LocationInput
           v-model="Location"
           :suggestions="uniqueLocations"

--- a/webapp/src/components/LocationInput.vue
+++ b/webapp/src/components/LocationInput.vue
@@ -1,0 +1,202 @@
+<template>
+  <div class="location-input" @focusout="onFocusOut">
+    <div
+      v-if="!isEditing"
+      class="form-control location-display"
+      :class="{ 'location-display--readonly': readonly }"
+      :tabindex="readonly ? -1 : 0"
+      @click="startEditing"
+      @keydown.enter.prevent="startEditing"
+    >
+      <span v-if="modelValue">{{ modelValue }}</span>
+      <span v-else class="text-muted placeholder-text">Add location…</span>
+    </div>
+    <div v-else class="location-inline d-flex align-items-center flex-wrap">
+      <template v-for="(segment, i) in editableSegments" :key="i">
+        <font-awesome-icon v-if="i > 0" icon="chevron-right" class="location-chevron" />
+        <div class="location-segment-wrap">
+          <AutoComplete
+            :model-value="segment"
+            :suggestions="filteredSuggestions[i] || []"
+            input-class="form-control location-segment-input"
+            @complete="(e) => onComplete(e, i)"
+            @update:model-value="(val) => updateSegment(i, val)"
+          />
+          <button
+            v-if="editableSegments.length > 1"
+            type="button"
+            class="remove-btn"
+            @click="removeSegment(i)"
+          >
+            <font-awesome-icon icon="times" />
+          </button>
+        </div>
+      </template>
+      <button type="button" class="add-btn" @click="addSegment">+</button>
+    </div>
+  </div>
+</template>
+
+<script>
+import AutoComplete from "primevue/autocomplete";
+
+export default {
+  components: { AutoComplete },
+  props: {
+    modelValue: { type: String, default: "" },
+    suggestions: { type: Array, default: () => [] },
+    readonly: { type: Boolean, default: false },
+  },
+  emits: ["update:modelValue"],
+  data() {
+    return {
+      editableSegments: this.parseSegments(this.modelValue),
+      filteredSuggestions: {},
+      isEditing: false,
+    };
+  },
+  watch: {
+    modelValue(val) {
+      if (val !== this.buildValue(this.editableSegments)) {
+        this.editableSegments = this.parseSegments(val);
+      }
+    },
+  },
+  methods: {
+    parseSegments(val) {
+      if (!val) return [""];
+      const parts = val
+        .split(" > ")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      return parts.length ? parts : [""];
+    },
+    buildValue(segs) {
+      return segs.filter(Boolean).join(" > ");
+    },
+    startEditing() {
+      if (this.readonly) return;
+      this.isEditing = true;
+      this.$nextTick(() => {
+        const input = this.$el.querySelector("input");
+        if (input) input.focus();
+      });
+    },
+    onFocusOut() {
+      setTimeout(() => {
+        if (this.$el && !this.$el.contains(document.activeElement)) {
+          this.isEditing = false;
+        }
+      }, 200);
+    },
+    updateSegment(index, val) {
+      const segs = this.editableSegments.map((s, i) => (i === index ? val : s));
+      this.editableSegments = segs;
+      this.$emit("update:modelValue", this.buildValue(segs));
+    },
+    addSegment() {
+      this.editableSegments = [...this.editableSegments, ""];
+    },
+    removeSegment(index) {
+      const segs = this.editableSegments.filter((_, i) => i !== index);
+      this.editableSegments = segs.length ? segs : [""];
+      this.$emit("update:modelValue", this.buildValue(this.editableSegments));
+    },
+    getSegmentOptions(level) {
+      const parentPath = this.editableSegments.slice(0, level).filter(Boolean).join(" > ");
+      return [
+        ...new Set(
+          this.suggestions
+            .filter((loc) => {
+              if (level === 0) return true;
+              return loc.startsWith(parentPath + " > ");
+            })
+            .map((loc) => {
+              const parts = loc.split(" > ");
+              return parts[level]?.trim() || null;
+            })
+            .filter(Boolean),
+        ),
+      ].sort();
+    },
+    onComplete(event, level) {
+      const query = event.query.toLowerCase();
+      const options = this.getSegmentOptions(level);
+      this.filteredSuggestions = {
+        ...this.filteredSuggestions,
+        [level]: options.filter((s) => s.toLowerCase().includes(query)),
+      };
+    },
+  },
+};
+</script>
+
+<style scoped>
+.location-display {
+  cursor: pointer;
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+}
+.location-display--readonly {
+  cursor: default;
+  background-color: #e9ecef;
+}
+.placeholder-text {
+  font-style: italic;
+}
+.location-inline {
+  gap: 4px;
+}
+.location-chevron {
+  color: var(--color-text-secondary, #64748b);
+  font-size: 0.8rem;
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+.location-segment-wrap {
+  position: relative;
+  display: inline-flex;
+}
+.remove-btn {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: #94a3b8;
+  padding: 0;
+  font-size: 0.7rem;
+  cursor: pointer;
+  z-index: 1;
+  line-height: 1;
+}
+.remove-btn:hover {
+  color: #dc3545;
+}
+.add-btn {
+  background: none;
+  border: 1px solid var(--color-border, #e2e8f0);
+  border-radius: 4px;
+  color: var(--color-text-secondary, #64748b);
+  padding: 0 10px;
+  font-size: 1rem;
+  cursor: pointer;
+  height: 38px;
+  line-height: 1;
+}
+.add-btn:hover {
+  background: var(--color-accent-light, #eef2ff);
+  border-color: var(--color-accent, #6366f1);
+  color: var(--color-accent, #6366f1);
+}
+:deep(.p-autocomplete) {
+  display: inline-flex;
+  width: 160px;
+}
+:deep(.location-segment-input) {
+  padding-right: 28px;
+  width: 100%;
+}
+</style>

--- a/webapp/src/components/LocationInput.vue
+++ b/webapp/src/components/LocationInput.vue
@@ -2,6 +2,7 @@
   <div class="location-input" @focusout="onFocusOut">
     <div
       v-if="!isEditing"
+      :id="inputId || undefined"
       class="form-control location-display"
       :class="{ 'location-display--readonly': readonly }"
       :tabindex="readonly ? -1 : 0"
@@ -46,6 +47,7 @@ export default {
     modelValue: { type: String, default: "" },
     suggestions: { type: Array, default: () => [] },
     readonly: { type: Boolean, default: false },
+    inputId: { type: String, default: "" },
   },
   emits: ["update:modelValue"],
   data() {

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -49,11 +49,12 @@
 
         <div class="form-row">
           <div class="form-group col-lg-12 col-sm-12">
-            <label>Location</label>
+            <label for="startmat-location">Location</label>
             <LocationInput
               v-model="Location"
               :suggestions="uniqueLocations"
               :readonly="!isEditable"
+              input-id="startmat-location"
             />
           </div>
         </div>

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -49,15 +49,11 @@
 
         <div class="form-row">
           <div class="form-group col-lg-12 col-sm-12">
-            <label for="startmat-location">Location</label>
-            <AutoComplete
+            <label>Location</label>
+            <LocationInput
               v-model="Location"
-              input-id="startmat-location"
-              :suggestions="filteredLocations"
-              :disabled="!isEditable"
-              class="form-control p-0 border-0"
-              input-class="form-control"
-              @complete="filterLocations"
+              :suggestions="uniqueLocations"
+              :readonly="!isEditable"
             />
           </div>
         </div>
@@ -129,6 +125,7 @@ import SynthesisInformation from "@/components/SynthesisInformation";
 import ItemRelationshipVisualization from "@/components/ItemRelationshipVisualization";
 import ToggleableCreatorsFormGroup from "@/components/ToggleableCreatorsFormGroup";
 import ToggleableGroupsFormGroup from "@/components/ToggleableGroupsFormGroup";
+import LocationInput from "@/components/LocationInput";
 
 import AutoComplete from "primevue/autocomplete";
 import { getStartingMaterialList, getEquipmentList } from "@/server_fetch_utils.js";
@@ -149,6 +146,7 @@ export default {
     SubstanceInformation,
     ToggleableCreatorsFormGroup,
     ToggleableGroupsFormGroup,
+    LocationInput,
   },
   props: {
     item_id: { type: String, required: true },
@@ -156,7 +154,6 @@ export default {
   data() {
     return {
       filteredSuppliers: [],
-      filteredLocations: [],
       tableOfContentsSections: [
         { title: "Starting Material Information", targetID: "starting-material-information" },
         { title: "Table of Contents", targetID: "table-of-contents" },
@@ -224,10 +221,6 @@ export default {
     filterSuppliers(event) {
       const query = event.query.toLowerCase();
       this.filteredSuppliers = this.uniqueSuppliers.filter((s) => s.toLowerCase().includes(query));
-    },
-    filterLocations(event) {
-      const query = event.query.toLowerCase();
-      this.filteredLocations = this.uniqueLocations.filter((l) => l.toLowerCase().includes(query));
     },
   },
 };

--- a/webapp/src/components/VersionHistoryModal.vue
+++ b/webapp/src/components/VersionHistoryModal.vue
@@ -137,7 +137,7 @@
           <div v-if="previewData.location" class="row mb-3">
             <div class="col-md-6">
               <strong>Location:</strong>
-              <p>{{ previewData.location }}</p>
+              <p><LocationInput :model-value="previewData.location" :readonly="true" /></p>
             </div>
           </div>
 
@@ -204,10 +204,12 @@ import Modal from "@/components/Modal.vue";
 import { getItemVersions, getItemVersion, restoreItemVersion } from "@/server_fetch_utils";
 import { formatDistanceToNow } from "date-fns";
 import { DialogService } from "@/services/DialogService";
+import LocationInput from "@/components/LocationInput";
 
 export default {
   components: {
     Modal,
+    LocationInput,
   },
   props: {
     modelValue: Boolean,

--- a/webapp/src/components/VersionHistoryModal.vue
+++ b/webapp/src/components/VersionHistoryModal.vue
@@ -135,7 +135,7 @@
           </div>
 
           <div v-if="previewData.location" class="row mb-3">
-            <div class="col-md-6">
+            <div class="col-12">
               <strong>Location:</strong>
               <p><LocationInput :model-value="previewData.location" :readonly="true" /></p>
             </div>


### PR DESCRIPTION
Closes #1711

- Adds `LocationInput.vue`, a dedicated component that splits the `" > "`-delimited location string into individually editable segments, each with context-aware autocomplete

- Uses `LocationInput` in read-only mode in `VersionHistoryModal.vue` so location values render consistently in version history

