### PR TITLE
Add Docker-based development environment

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:22.22-bullseye-slim AS build
+FROM node:22.22-bullseye-slim AS base
 SHELL ["/bin/bash", "--login", "-c"]
 
 WORKDIR /app
@@ -13,6 +13,12 @@ COPY webapp/package.json webapp/yarn.lock ./
 # Using a custom node_modules location to avoid mounting it outside of docker
 RUN --mount=type=cache,target=/root/.cache/yarn yarn install --frozen-lockfile --modules-folder /node_modules
 
+# dev target: deps installed, source mounted at runtime — no production build.
+FROM base AS dev
+COPY webapp ./
+
+# build target: runs the production webpack bundle on top of dev.
+FROM dev AS build
 # These get replaced by the entrypoint script for production builds.
 # Set the real values in `.env` files or an external docker-compose.
 ENV NODE_ENV=production
@@ -28,7 +34,6 @@ ARG VUE_APP_AUTOMATICALLY_GENERATE_ID_DEFAULT=magic-generate-id-setting
 ARG VUE_APP_GIT_VERSION=0.0.0+ci
 ENV VUE_APP_GIT_VERSION=${VUE_APP_GIT_VERSION}
 
-COPY webapp ./
 RUN /node_modules/.bin/vue-cli-service build
 
 FROM node:22.22-bullseye-slim AS production

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,71 @@
+# Development
+
+Hot-reloading datalab stack (API + web app + MongoDB) in Docker. Only Docker is required.
+
+## Quick start
+
+```bash
+cp pydatalab/.env.example pydatalab/.env     # backend config (edit it, see below)
+cp webapp/.env.example webapp/.env           # web app config
+
+docker compose --profile dev up --build      # first run builds; later just `up`
+docker compose exec api-dev /opt/.venv/bin/invoke dev.seed   # optional: spawn example data in the DB
+```
+
+- Web app: http://localhost:8081
+- API: http://localhost:5001
+- Database: `mongodb://localhost:27018`
+
+Edits to `pydatalab/` and `webapp/` hot-reload. Editing `.env` does not — restart the
+service: `docker compose --profile dev restart api-dev` (or `app-dev`).
+
+## Logging in
+
+The web app needs a logged-in session. Set up GitHub OAuth once:
+
+1. Create an OAuth App at https://github.com/settings/developers
+   - Homepage URL: `http://localhost:8081`
+   - Authorization callback URL: `http://localhost:5001/login/github/authorized`
+2. Put the credentials in `pydatalab/.env` (see the commented GitHub block in
+   `.env.example`), set `PYDATALAB_TESTING=false`, restart `api-dev`.
+3. Set `PYDATALAB_SECRET_KEY` to a real value (generate one with
+   `python3 -c 'import secrets; print(secrets.token_hex(64))'`).
+4. **Login via GitHub** in the web app.
+
+
+## Handy commands
+
+```bash
+# Make yourself admin (display name = the name shown in the web app)
+docker compose exec api-dev /opt/.venv/bin/invoke admin.change-user-role \
+  --display-name "Your Name" --role admin
+
+docker compose logs -f api-dev          # follow API logs
+docker compose --profile dev down       # stop (add -v to wipe the DB + files)
+
+# Use a custom database name (default: datalabvue). Set in your shell before
+# running `docker compose up` — it is not read from pydatalab/.env.
+export DATALAB_DB_NAME=my_project
+docker compose --profile dev up
+```
+
+Backend tests run natively (the Docker dev image ships without test deps); from
+`pydatalab/` use `uv sync --all-extras --dev` once, then `uv run pytest`.
+
+
+## `dev` vs `prod` profiles
+
+Both profiles are in `docker-compose.yml` and share the same Dockerfiles; the `dev`
+services target earlier build stages and override the run command.
+
+| | `prod` (`app`, `api`, `database`) | `dev` (`app-dev`, `api-dev`, `database-dev`) |
+|---|---|---|
+| Code | baked into the image at build time | bind-mounted from your checkout |
+| Reload | none (rebuild to change code) | hot reload (Flask `--reload`, Vue HMR) |
+| Server | gunicorn / static build | dev servers (`dev.serve`, `vue-cli-service serve`) |
+| Database | host path `/data/db`, port not exposed | Docker volume, port `27018`, isolated per dev |
+| Files/backups | mounted host paths under `/data` | a throwaway Docker volume |
+| Restart policy | `unless-stopped` | none |
+
+Run with `docker compose --profile prod up` or `--profile dev up`. Don't run both at
+once — they share ports 5001/8081.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,68 @@ services:
     networks:
       - backend
 
+  # ---------------------------------------------------------------------------
+  # Development services (`docker compose --profile dev up`).
+  #
+  # These give a hot-reloading, source-mounted environment for local
+  # development. A small database can be populated
+  # separately with `invoke dev.seed`.
+  # ---------------------------------------------------------------------------
+  database-dev:
+    profiles: ["dev"]
+    build:
+      context: .
+      dockerfile: .docker/mongo/Dockerfile
+    volumes:
+      - datalab-dev-dbdata:/data/db
+    ports:
+      # Published on host port 27018 to avoid clashing with a
+      # developer's native MongoDB.
+      - "27018:27017"
+    networks:
+      - backend
+
+  api-dev:
+    profiles: ["dev"]
+    build:
+      context: .
+      dockerfile: .docker/server/Dockerfile
+      target: api
+    command: ["/opt/.venv/bin/invoke", "dev.serve", "--host", "0.0.0.0", "--port", "5001"]
+    depends_on:
+      - database-dev
+    volumes:
+      - ./pydatalab:/app
+      - datalab-dev-files:/app/files
+    ports:
+      - "5001:5001"
+    networks:
+      - backend
+    environment:
+      - PYDATALAB_MONGO_URI=mongodb://database-dev:27017/${DATALAB_DB_NAME:-datalabvue}
+      - PYDATALAB_FILE_DIRECTORY=/app/files
+
+  app-dev:
+    profiles: ["dev"]
+    build:
+      context: .
+      dockerfile: .docker/app/Dockerfile
+      target: dev
+    command:
+      ["/node_modules/.bin/vue-cli-service", "serve", "--host", "0.0.0.0", "--port", "8081"]
+    volumes:
+      - ./webapp:/app
+    ports:
+      - "8081:8081"
+    environment:
+      - NODE_ENV=development
+      - VUE_APP_API_URL=${VUE_APP_API_URL:-http://localhost:5001}
+      - CHOKIDAR_USEPOLLING=${CHOKIDAR_USEPOLLING:-true}
+
 networks:
   backend:
     driver: bridge
+
+volumes:
+  datalab-dev-dbdata:
+  datalab-dev-files:

--- a/pydatalab/.env.example
+++ b/pydatalab/.env.example
@@ -1,0 +1,32 @@
+# Example environment for the pydatalab API server during development.
+#
+# Copy this to `pydatalab/.env` and edit. It is loaded by `invoke dev.serve`
+# natively, and inside the Docker dev container (the ./pydatalab:/app bind-mount
+# maps it to /app/.env). `.env` is gitignored; this template is not.
+# Full reference: https://docs.datalab-org.io/en/latest/config/
+#
+# --- Core ---------------------------------------------------------------------
+# A short prefix prepended to every entry's refcode (make it unique to you/your group).
+PYDATALAB_IDENTIFIER_PREFIX=dev
+# Stable secret key for sessions (needed for OAuth). Generate with:
+#   python3 -c 'import secrets; print(secrets.token_hex(64))'
+PYDATALAB_SECRET_KEY= edit me
+
+# --- Authentication -----------------------------------------------------------
+# Option A: no auth (API-only). Every API call runs as authenticated; good for
+# backend/block work. NOTE: the web app UI still shows a login prompt in this mode.
+PYDATALAB_TESTING=true
+
+# Option B: real GitHub login (lets you use the web app UI). Set TESTING=false
+# above and uncomment the block below.
+#   1. Create an OAuth App: https://github.com/settings/developers
+#        Homepage URL:               http://localhost:8081
+#        Authorization callback URL: http://localhost:5001/login/github/authorized
+#   2. Fill in the client id/secret (these are NOT prefixed with PYDATALAB_).
+#
+# PYDATALAB_BEHIND_REVERSE_PROXY=False   # keep the OAuth redirect_uri as http:// for local dev
+# PYDATALAB_AUTO_ACTIVATE_ACCOUNTS=True  # skip manual account activation
+# PYDATALAB_GITHUB_ORG_ALLOW_LIST=null   # allow any GitHub user (no org restriction)
+# OAUTHLIB_INSECURE_TRANSPORT=1          # local HTTP only; never set in production
+# GITHUB_OAUTH_CLIENT_ID=
+# GITHUB_OAUTH_CLIENT_SECRET=

--- a/pydatalab/tasks.py
+++ b/pydatalab/tasks.py
@@ -165,6 +165,337 @@ def serve(_, host: str = "127.0.0.1", port: int = 5001, reload: bool = True, tes
 dev.add_task(serve)
 
 
+# Example data for `dev.seed`, grouped by the block that renders it. Each group
+# is expanded by `_build_seed_items` into one seeded item per file (a single
+# block per item), so a fresh dev instance exercises every block type that has
+# example data. Groups flagged `single_item` instead produce one item carrying
+# the whole file list -- used for multi-file blocks (uv-vis: first file is the
+# background) and file-less blocks (comment). All paths are relative to
+# `pydatalab/example_data/` and only list files the parser actually accepts;
+# companion files (Biologic .mps/.sta, gzipped JEOL, READMEs) are omitted.
+_SEED_BLOCK_GROUPS: list[dict] = [
+    {
+        "block_type": "xrd",
+        "item_type": "samples",
+        "files": [
+            "XRD/CG20396_jdb12-1.xrdml",
+            "XRD/HL1-2_5-90_60min.xrdml",
+            "XRD/JO_KL_16_ZF_3_60deg_0.02step_12degpermin_001.rasx",
+            "XRD/TiO2.raw",
+            "XRD/TiOF.brml",
+            "XRD/cod_9004112.cif",
+            "XRD/example_bmb.xye",
+            "XRD/example_evadiffract.xy",
+            "XRD/example_mac.xye",
+            "XRD/example_mythen.dat",
+            "XRD/example_mythen.xye",
+            "XRD/example_ocx.xy",
+            "XRD/Scan_C1.xrdml",
+            "XRD/Scan_C2.xrdml",
+            "XRD/Scan_C3.xrdml",
+            "XRD/Scan_C4.xrdml",
+            "XRD/Scan_C5.xrdml",
+            "XRD/Scan_C6.xrdml",
+            "XRD/Scan_C7.xrdml",
+            "XRD/Scan_C8.xrdml",
+            "XRD/Scan_C9.xrdml",
+            "XRD/Scan_C10.xrdml",
+        ],
+    },
+    {
+        "block_type": "raman",
+        "item_type": "samples",
+        "files": [
+            "raman/labspec_raman_example.txt",
+            "raman/raman_example.txt",
+            "raman/raman_example.wdf",
+        ],
+    },
+    {
+        "block_type": "cycle",
+        "item_type": "cells",
+        "files": [
+            "echem/arbin_example.bdf.csv",
+            "echem/jdb11-1_c3_gcpl_5cycles_2V-3p8V_C-24_data_C09.mpr",
+            "echem/jdb11-1_e1_s3_squidTest_data_C15.mpr",
+        ],
+    },
+    {
+        "block_type": "nmr",
+        "item_type": "samples",
+        "files": [
+            "NMR/1.zip",  # Bruker 1D
+            "NMR/1h.dx",  # JCAMP-DX
+            "NMR/13c.jdx",  # JCAMP-DX
+            "NMR/71.zip",  # Bruker 1D
+            # 72.zip (2D dataset: metadata only, no plot) and multi_nuclei.zip
+            # (selects an experiment with no Bruker binary) are omitted -- the
+            # block only renders 1D data.
+        ],
+    },
+    {
+        "block_type": "ftir",
+        "item_type": "samples",
+        "files": [
+            "FTIR/2024-10-10_FeSO4_ref.asp",
+            "FTIR/[FTIRText]020.txt",
+        ],
+    },
+    {
+        "block_type": "ms",
+        "item_type": "samples",
+        "files": [
+            "TGA-MS/20221128 134958 TGA MS Megan.asc",
+            # mp2028_281122_LNO+C.txt is omitted: the ms parser decodes as UTF-8
+            # and that file contains a latin-1 degree sign, raising a decode error.
+        ],
+    },
+    {
+        "block_type": "tabular",
+        "item_type": "samples",
+        "files": [
+            "csv/simple.csv",
+            "csv/simple.xlsx",
+        ],
+    },
+    {
+        "block_type": "media",
+        "item_type": "samples",
+        "files": [
+            "media/grey_group_logo.jpeg",
+            "media/grey_group_logo.tif",
+        ],
+    },
+    {
+        # A single uv-vis block needs >=2 files; the first is the background scan.
+        "block_type": "uv-vis",
+        "item_type": "samples",
+        "single_item": True,
+        "name": "UV-Vis example (background + scans)",
+        "files": [
+            "UV-Vis/1908047U1_0000.Raw8.TXT",
+            "UV-Vis/1908047U1_0001.Raw8.txt",
+            "UV-Vis/1908047U1_0060.Raw8.txt",
+        ],
+    },
+    {
+        # File-less block: the text lives in the `freeform_comment` field.
+        "block_type": "comment",
+        "item_type": "samples",
+        "single_item": True,
+        "name": "Comment example",
+        "files": [],
+        "block_data": {
+            "freeform_comment": "Seeded comment block — rich-text notes attached to a sample.",
+        },
+    },
+]
+
+# Items seeded without any block, for item-type variety.
+_SEED_EXTRA_ITEMS: list[dict] = [
+    {
+        "payload": {
+            "item_id": "seed_starting_material",
+            "type": "starting_materials",
+            "name": "Example starting material",
+            "chemform": "Na2CO3",
+            "description": "Seeded starting material.",
+        },
+        "block_type": None,
+        "files": [],
+        "block_data": {},
+    },
+]
+
+
+# `item_id` is validated to be at most this many characters (see the item models),
+# so generated ids are truncated to fit.
+_MAX_ITEM_ID_LENGTH = 40
+
+
+def _slug(value: str) -> str:
+    """Lowercase `value` and collapse any run of non-alphanumerics into a single underscore."""
+    return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+
+
+def _make_item_id(base: str, used: set[str]) -> str:
+    """Slugify `base`, truncate to the item-id length limit, and disambiguate collisions.
+
+    Deterministic given a stable input order, so re-running `dev.seed` yields the same
+    ids (keeping it idempotent).
+    """
+    candidate = _slug(base)[:_MAX_ITEM_ID_LENGTH].rstrip("_")
+    if candidate not in used:
+        used.add(candidate)
+        return candidate
+    i = 2
+    while True:
+        suffix = f"_{i}"
+        candidate = (_slug(base)[: _MAX_ITEM_ID_LENGTH - len(suffix)].rstrip("_")) + suffix
+        if candidate not in used:
+            used.add(candidate)
+            return candidate
+        i += 1
+
+
+def _build_seed_items() -> list[dict]:
+    """Expand `_SEED_BLOCK_GROUPS` into a flat list of item specs for `dev.seed`.
+
+    Each spec is a dict with keys `payload` (the `/new-sample/` body), `block_type`
+    (or `None` for no block), `files` (example_data-relative paths) and `block_data`
+    (extra fields merged into the block before rendering).
+    """
+    items: list[dict] = []
+    used_ids: set[str] = set()
+    for group in _SEED_BLOCK_GROUPS:
+        block_type = group["block_type"]
+        item_type = group["item_type"]
+        block_data = group.get("block_data", {})
+
+        if group.get("single_item"):
+            name = group.get("name", f"{block_type} example")
+            items.append(
+                {
+                    "payload": {
+                        "item_id": _make_item_id(f"seed_{block_type}", used_ids),
+                        "type": item_type,
+                        "name": name,
+                        "description": group.get("description", f"Seeded {block_type} example."),
+                    },
+                    "block_type": block_type,
+                    "files": list(group["files"]),
+                    "block_data": dict(block_data),
+                }
+            )
+            continue
+
+        for rel_path in group["files"]:
+            filename = pathlib.PurePosixPath(rel_path).name
+            items.append(
+                {
+                    "payload": {
+                        "item_id": _make_item_id(f"seed_{block_type}_{filename}", used_ids),
+                        "type": item_type,
+                        "name": f"{block_type} example: {filename}",
+                        "description": f"Seeded {block_type} example from {filename}.",
+                    },
+                    "block_type": block_type,
+                    "files": [rel_path],
+                    "block_data": dict(block_data),
+                }
+            )
+
+    items.extend(_SEED_EXTRA_ITEMS)
+    return items
+
+
+_SEED_ITEMS = _build_seed_items()
+
+
+@task
+def seed(_):
+    """Populate the configured database with a comprehensive set of example items.
+
+    Seeds one item per example file under `pydatalab/example_data/`, attaching and
+    rendering the matching technique block, so a fresh development instance covers
+    every block type that has example data (xrd, raman, cycle, nmr, ftir, ms,
+    uv-vis, tabular, media), plus a comment block and a starting material. Connect
+    to whichever database `PYDATALAB_MONGO_URI` points at.
+
+    Idempotent: items that already exist (matched by `item_id`) are skipped, so
+    it is safe to re-run. Forces `CONFIG.TESTING` for this process so items and
+    files can be created without authentication.
+    """
+    import io
+
+    os.environ["PYDATALAB_TESTING"] = "1"
+    if "PYDATALAB_SECRET_KEY" not in os.environ:
+        os.environ["PYDATALAB_SECRET_KEY"] = "dev-insecure-secret-key-do-not-use-in-production"  # noqa: S105
+        os.environ["PYDATALAB_ALLOW_INSECURE_SECRET_KEY"] = "1"  # noqa: S105
+
+    from pydatalab.main import create_app
+
+    example_data = pathlib.Path(__file__).parent / "example_data"
+
+    app = create_app()
+    created = skipped = 0
+    with app.test_client() as client:
+        for spec in _SEED_ITEMS:
+            payload = spec["payload"]
+            item_id = payload["item_id"]
+            resp = client.post("/new-sample/", json={"new_sample_data": payload})
+
+            if resp.status_code == 409:
+                print(f"  - {item_id}: already exists, skipping")
+                skipped += 1
+                continue
+            if resp.status_code not in (200, 201):
+                print(
+                    f"  ! {item_id}: create failed ({resp.status_code}): {resp.get_data(as_text=True)}"
+                )
+                continue
+
+            print(f"  + {item_id}: created")
+            created += 1
+
+            block_type = spec["block_type"]
+            if block_type is None:
+                continue
+
+            # Upload each example file and attach it to the item, preserving order
+            # (the first file is the background scan for multi-file blocks).
+            file_ids: list[str] = []
+            for rel_path in spec["files"]:
+                file_path = example_data / rel_path
+                if not file_path.is_file():
+                    print(f"    ! example file not found, skipping: {file_path}")
+                    continue
+                with open(file_path, "rb") as handle:
+                    upload = client.post(
+                        "/upload-file/",
+                        data={
+                            "item_id": item_id,
+                            "replace_file": "null",
+                            "file": (io.BytesIO(handle.read()), file_path.name),
+                        },
+                        content_type="multipart/form-data",
+                    )
+                if upload.status_code != 201:
+                    print(f"    ! file upload failed for {file_path.name} ({upload.status_code})")
+                    continue
+                file_ids.append(upload.get_json()["file_id"])
+
+            # Create the data block, wire in the uploaded file(s) and any extra
+            # block fields, then render it.
+            add = client.post(
+                "/add-data-block/",
+                json={"block_type": block_type, "item_id": item_id, "index": 0},
+            )
+            if add.status_code != 200:
+                print(f"    ! adding {block_type} block failed ({add.status_code})")
+                continue
+            block_data = add.get_json()["new_block_obj"]
+            if len(file_ids) == 1:
+                block_data["file_id"] = file_ids[0]
+            elif len(file_ids) > 1:
+                # Multi-file blocks (e.g. uv-vis) read the ordered file list.
+                block_data["file_ids"] = file_ids
+                block_data["selected_file_order"] = file_ids
+            block_data.update(spec["block_data"])
+
+            update = client.post("/update-block/", json={"block_data": block_data})
+            detail = f"{len(file_ids)} file(s)" if file_ids else "no file"
+            if update.status_code == 200:
+                print(f"    ✓ rendered {block_type} block ({detail})")
+            else:
+                print(f"    ! rendering {block_type} block failed ({update.status_code})")
+
+    print(f"\nSeed complete: {created} created, {skipped} skipped.")
+
+
+dev.add_task(seed)
+
+
 @task
 def install(_, dev=True):
     """This task looks for a plugins.toml and attempts to

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -1,0 +1,22 @@
+# Example environment for the Vue web app during development.
+#
+# Copy this to `webapp/.env` and edit as needed (`.env` is gitignored, this
+# template is not). See https://docs.datalab-org.io/en/latest/config/ for the
+# full list of VUE_APP_* options.
+
+# URL of the datalab API the web app talks to (the dev API server default).
+VUE_APP_API_URL=http://localhost:5001
+
+# Title shown in the browser tab and header.
+VUE_APP_WEBSITE_TITLE=datalab (dev)
+
+# Whether the inventory can be edited by non-admin users.
+VUE_APP_EDITABLE_INVENTORY=true
+
+# Whether new entries auto-generate an ID by default (vs. requiring a checkbox).
+VUE_APP_AUTOMATICALLY_GENERATE_ID_DEFAULT=false
+
+# --- Optional branding / integrations ----------------------------------------
+# VUE_APP_LOGO_URL=
+# VUE_APP_HOMEPAGE_URL=
+# VUE_APP_QR_CODE_RESOLVER_URL=


### PR DESCRIPTION
Hello,

We have recently added a "dev" profile in the docker-compose of Matgenix fork so that we start our developments from consistent setups. Since I think this is quite general and could potentially benefits everyone, I'm opening this PR to suggest this new "dev" profile. There is also a new dev.seed invoke command that allows to quickly populate the DB with items containing blocks created from the example files.

### Summary  

Add Docker-based development environment

Sets up a hot-reloading, fully containerised dev stack so contributors only need Docker to get started.

- `docker-compose.yml`: adds a dev profile (database-dev, api-dev, app-dev) with source bind-mounts, hot reload (Flask --reload + Vue HMR), and an isolated MongoDB on port 27018. DB name is configurable via DATALAB_DB_NAME.
- `.docker/app/Dockerfile`: adds a dev stage that stops before the production webpack bundle, so app-dev builds faster and runs vue-cli-service serve instead.
- `pydatalab/.env.example`,  `webapp/.env.example`: annotated config templates to copy for local dev.
- `DEVELOPMENT.md`: quick-start guide covering first-run, login (GitHub OAuth), handy commands, and a dev vs prod profile comparison table.
- `pydatalab/tasks.py`: dev.seed to cover every block type that has example data (XRD, Raman, echem, NMR, FTIR, MS, UV-vis, tabular, media, comment) plus a starting material, one item per file, idempotent re-runs.
