### PR TITLE
Fixes events from bokeh route to fire

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/blocks.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/blocks.py
@@ -75,7 +75,7 @@ def _process_block_async(
 
             block = BLOCK_TYPES[block_type].from_web(block_data)
 
-            if event_data and not event_data.get("trigger_async", True):
+            if event_data:
                 add_stage("Processing block events")
                 try:
                     block.process_events(event_data)

--- a/pydatalab/src/pydatalab/routes/v0_1/blocks.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/blocks.py
@@ -447,7 +447,7 @@ def update_block():
             202,
         )
     else:
-        if event_data and not event_data.get("trigger_async", True):
+        if event_data:
             try:
                 block.process_events(event_data)
             except NotImplementedError:

--- a/pydatalab/tests/server/test_blocks.py
+++ b/pydatalab/tests/server/test_blocks.py
@@ -509,6 +509,32 @@ def test_xrd_block_lifecycle(admin_client, client, user_id, default_sample_dict,
     assert "peak_data" in block["computed"]
     assert block["wavelength"] == 2.0
 
+    # Now check that an event can also change the wavelength
+    response = admin_client.post(
+        "/update-block/",
+        json={
+            "block_data": {"block_id": block_id, "item_id": sample_id, "blocktype": "xrd"},
+            "event_data": {
+                "block_id": block_id,
+                "event_name": "set_wavelength",
+                "wavelength": "1.5",
+            },
+        },
+    )
+    assert response.status_code == 200
+
+    # But they should still be in the database
+    response = admin_client.get(f"/get-item-data/{sample_id}")
+    assert response.status_code == 200
+
+    item_data = response.json["item_data"]
+    assert response.json["status"] == "success"
+    assert "blocks_obj" in item_data
+    block = item_data["blocks_obj"][block_id]
+    assert "computed" in block
+    assert "peak_data" in block["computed"]
+    assert block["wavelength"] == 1.5
+
 
 def test_comment_block_manipulation(admin_client, default_sample_dict, database):
     """Create a test sample with a comment block and test it for


### PR DESCRIPTION
`block.process_events(event_data)` was gated on `not event_data.get("trigger_async", True)`. Because `trigger_async` defaults to `True` when the key is absent — and the client never explicitly sets it to false — this condition was always `False`, meaning `process_events` was never called in either the sync or async processing path.

The result was that `@event()`-decorated handlers on block classes (e.g XRD setting the wavelength) were silently skipped on every request.

The fix removes the condition in both places: `process_events` is now called whenever `event_data` is present.

What `trigger_async` is actually for

`trigger_async` exists to decide whether a block update should be processed asynchronously (dispatched to the task scheduler) or synchronously. It is checked correctly at line 402 for that routing decision and is not touched by this PR. The bug was using the same flag to also gate `process_events` inside each path, which was incorrect — once you are already in the sync or async handler, `process_events` should always run if there is event data.

It is currently used for the insitu-blocks, where some "events" were triggered, e.g `onFolderSelected()`, this was presumably seen as a heavy event and so should be done asychronously. Lighter calls like `updateBlock()` pass `event_data = null`, which also defaults to async via the `if event_data else True` branch. No caller currently passes `trigger_async: false`. The bug was reusing this flag to gate `process_events` inside each path — once you are already in the sync or async handler, `process_events` should always run if event data is present.

Closes #1834 