### PR TITLE
Add support for nmrglue < 0.12 with import guard on jeol reader

### DIFF
--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -64,7 +64,7 @@ apps = [
     # General
     "scipy ~= 1.13",
     # NMR
-    "nmrglue ~= 0.12",
+    "nmrglue ~= 0.11",
     # Electrochemistry
     "navani >= 0.1.20",
     "pyarrow ~= 23.0.1",

--- a/pydatalab/src/pydatalab/apps/nmr/utils.py
+++ b/pydatalab/src/pydatalab/apps/nmr/utils.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import itertools
 import re
 import tempfile
@@ -156,6 +157,14 @@ def read_jeol_jdf_1d(
         nscans: The number of scans as read from the dictionaries
 
     """
+    nmrglue_version = tuple(int(x) for x in importlib.metadata.version("nmrglue").split("."))
+    nmrglue_has_no_jeol_jdf_support = nmrglue_version[0] == 0 and nmrglue_version[1] <= 11
+
+    if nmrglue_has_no_jeol_jdf_support:
+        raise RuntimeError(
+            "This version of nmrglue does not support reading JEOL .jdf files. "
+            "Please upgrade to nmrglue >= 0.12.0 (or git version if not yet released)."
+        )
 
     dic, data = ng.fileio.jeol.read(filename)
     udic = ng.jeol.guess_udic(dic, data)

--- a/pydatalab/src/pydatalab/apps/nmr/utils.py
+++ b/pydatalab/src/pydatalab/apps/nmr/utils.py
@@ -157,8 +157,16 @@ def read_jeol_jdf_1d(
         nscans: The number of scans as read from the dictionaries
 
     """
-    nmrglue_version = tuple(int(x) for x in importlib.metadata.version("nmrglue").split("."))
-    nmrglue_has_no_jeol_jdf_support = nmrglue_version[0] == 0 and nmrglue_version[1] <= 11
+    try:
+        nmrglue_version = tuple(x for x in importlib.metadata.version("nmrglue").split("."))
+        nmrglue_has_no_jeol_jdf_support = (
+            int(nmrglue_version[0]) == 0 and int(nmrglue_version[1]) <= 11
+        )
+    except Exception:
+        warnings.warn(
+            f"Could not detect nmrglue version ({nmrglue_version}) disabling JEOL support."
+        )
+        nmrglue_has_no_jeol_jdf_support = True
 
     if nmrglue_has_no_jeol_jdf_support:
         raise RuntimeError(


### PR DESCRIPTION
We're still waiting on an nmrglue PyPI release -- this had been silently breaking `pip`-only installs, which although we don't use them ourselves, are part of our installation docs (and are worth supporting). I decided against adding a CI job for this as it just opens us up to flaky tests based on subdependencies updating, which instead should be caught by dependabot (which cannot test this rare edge case that we are using an unreleased repo). 

Closes #1849.