### PR TITLE
Remove mentions of Jest in documentation and add component test runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,8 @@ yarn build
 # Run linting
 yarn lint
 
-# Run unit tests
-yarn test:unit
+# Run component tests
+yarn test:component
 
 # Run e2e tests (requires backend at localhost:5001)
 yarn test:e2e

--- a/pydatalab/docs/INSTALL.md
+++ b/pydatalab/docs/INSTALL.md
@@ -150,8 +150,8 @@ Similar to the Flask development server, these steps will provide a development 
 Various other development scripts are available through `yarn`:
 
 - `yarn lint`: Lint the JavaScript code using `eslint`, identifying issues and automatically fixing many. This linting process also runs automatically every time the development server reloads.
-- `yarn test:unit`: run the unit/component tests using `jest`. These test individual functions or components.
-- `yarn test:e2e`: run end-to-end tests using `cypress`. This will build and serve the app, and launch an instance of Chrome where the tests can be interactively viewed. The tests can also be run without the GUI using ```yarn test:e2e --headless```. Note: currently, the tests make requests to the server running on `localhost:5001`.
+- `yarn test:component`: run the component tests using `cypress`. These test individual functions or components, and run headless by default.
+- `yarn test:e2e`: run end-to-end tests using `cypress`. This will build and serve the app, and launch an instance of Chrome where the tests can be interactively viewed. Like the component tests, these tests can also be run without the GUI using `yarn test:e2e --headless`. Note: currently, the tests make requests to the server running on `localhost:5001`.
 - `yarn build`: Compile an optimised, minimised, version of the app for production.
 
 ## Development notes

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -17,12 +17,12 @@ yarn serve
 yarn build
 ```
 
-### Run your unit tests
+### Run component tests
 ```
-yarn test:unit
+yarn test:component
 ```
 
-### Run your end-to-end tests
+### Run end-to-end tests
 ```
 yarn test:e2e
 ```
@@ -33,4 +33,5 @@ yarn lint
 ```
 
 ### Customize configuration
+
 See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "serve": "VUE_APP_GIT_VERSION=$(node scripts/get-version.js) vue-cli-service serve",
     "build": "VUE_APP_GIT_VERSION=$(node scripts/get-version.js) vue-cli-service build",
-    "test:unit": "vue-cli-service test:unit",
-    "test:e2e": "vue-cli-service test:e2e --mode test_e2e",
+    "test:component": "cypress run --component",
+    "test:e2e": "vue-cli-service test:e2e",
     "lint": "vue-cli-service lint"
   },
   "resolutions": {

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -3672,9 +3672,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001646, caniuse-lite@^1.0.30001669, caniuse-lite@^1.0.30001759:
-  version "1.0.30001792"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz"
-  integrity sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==
+  version "1.0.30001799"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz"
+  integrity sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.4.0"


### PR DESCRIPTION
Switch the `yarn test:component` script to use cypress and update caniuse browser list.

Closes #1850.