### PR TITLE
Initial attempt at fixing ability to read TGA DTA .txt file

### DIFF
--- a/pydatalab/src/pydatalab/apps/tga/__init__.py
+++ b/pydatalab/src/pydatalab/apps/tga/__init__.py
@@ -1,4 +1,4 @@
 from .blocks import MassSpecBlock
-from .parsers import parse_mt_mass_spec_ascii
+from .parsers import parse_mt_mass_spec_ascii, parse_mt_mass_spec_txt
 
-__all__ = ("MassSpecBlock", "parse_mt_mass_spec_ascii")
+__all__ = ("MassSpecBlock", "parse_mt_mass_spec_ascii", "parse_mt_mass_spec_txt")

--- a/pydatalab/src/pydatalab/apps/tga/blocks.py
+++ b/pydatalab/src/pydatalab/apps/tga/blocks.py
@@ -71,6 +71,7 @@ class MassSpecBlock(DataBlock):
             ms_data = parse_mt_mass_spec_txt(Path(file_info["location"]))
             if ms_data:
                 return self._plot_ms_txt_data(ms_data)
+        return None
 
     def _plot_data_for_two_files(self, file_id0, file_id1):
         file_info_0 = get_file_info_by_id(file_id0, update_if_live=True)

--- a/pydatalab/src/pydatalab/apps/tga/blocks.py
+++ b/pydatalab/src/pydatalab/apps/tga/blocks.py
@@ -31,13 +31,14 @@ class MassSpecBlock(DataBlock):
         - .txt Differential Thermal Analysis data
         No other files are accepted.
         """
-        if self.data["file_ids"]:
+        if self.data.get("file_ids", False):
             file_ids = self.data["file_ids"]
         elif self.data["file_id"]:
             file_ids = [self.data["file_id"]]
         else:
             LOGGER.warning("No file set in the DataBlock")
             return
+
         if not file_ids:
             return
         if len(file_ids) == 1:
@@ -45,7 +46,8 @@ class MassSpecBlock(DataBlock):
         elif len(file_ids) > 2:
             LOGGER.warning("This datablock does not currently support more than two files")
             return
-        self.data["bokeh_plot_data"] = self._plot_data_for_two_files(file_ids[0], file_ids[1])
+        else:
+            self.data["bokeh_plot_data"] = self._plot_data_for_two_files(file_ids[0], file_ids[1])
 
     def _get_and_check_ext(self, file_info):
         ext = os.path.splitext(file_info["location"].split("/")[-1])[-1].lower()

--- a/pydatalab/src/pydatalab/apps/tga/blocks.py
+++ b/pydatalab/src/pydatalab/apps/tga/blocks.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 import bokeh
+import scipy
 from bokeh.layouts import gridplot
 from scipy.signal import savgol_filter
 
@@ -17,41 +18,111 @@ class MassSpecBlock(DataBlock):
     name = "Mass spectrometry"
     description = "Read and visualize mass spectrometry data as a grid plot per channel"
     accepted_file_extensions = (".asc", ".txt")
+    multi_file = True
 
     @property
     def plot_functions(self):
         return (self.generate_ms_plot,)
 
     def generate_ms_plot(self):
-        file_info = None
-        # all_files = None
-        ms_data = None
-
-        if "file_id" not in self.data:
+        """
+        Generates MS plot from uploaded files
+        - .asc: partial pressures data
+        - .txt Differential Thermal Analysis data
+        No other files are accepted.
+        """
+        if self.data["file_ids"]:
+            file_ids = self.data["file_ids"]
+        elif self.data["file_id"]:
+            file_ids = [self.data["file_id"]]
+        else:
             LOGGER.warning("No file set in the DataBlock")
             return
+        if not file_ids:
+            return
+        if len(file_ids) == 1:
+            self.data["bokeh_plot_data"] = self._plot_data_for_one_file(file_ids[0])
+        elif len(file_ids) > 2:
+            LOGGER.warning("This datablock does not currently support more than two files")
+            return
+        self.data["bokeh_plot_data"] = self._plot_data_for_two_files(file_ids[0], file_ids[1])
+
+    def _get_and_check_ext(self, file_info):
+        ext = os.path.splitext(file_info["location"].split("/")[-1])[-1].lower()
+        if ext not in self.accepted_file_extensions:
+            LOGGER.warning(
+                "Unsupported file extension (must be one of %s, not %s)",
+                self.accepted_file_extensions,
+                ext,
+            )
+        return ext, ext in self.accepted_file_extensions
+
+    def _plot_data_for_one_file(self, file_id):
+
+        file_info = get_file_info_by_id(file_id, update_if_live=True)
+        ext, acceptable = self._get_and_check_ext(file_info)
+        if ext == ".asc":
+            ms_data = parse_mt_mass_spec_ascii(Path(file_info["location"]))
+            if ms_data:
+                return self._plot_ms_data(ms_data)
+        elif ext == ".txt":
+            ms_data = parse_mt_mass_spec_txt(Path(file_info["location"]))
+            if ms_data:
+                return self._plot_ms_txt_data(ms_data)
+
+    def _plot_data_for_two_files(self, file_id0, file_id1):
+        file_info_0 = get_file_info_by_id(file_id0, update_if_live=True)
+        file_info_1 = get_file_info_by_id(file_id1, update_if_live=True)
+        ext_0, acceptable_0 = self._get_and_check_ext(file_info_0)
+        ext_1, acceptable_1 = self._get_and_check_ext(file_info_1)
+        exts = [ext_0, ext_1]
+        if not (acceptable_0 and acceptable_1) or not (".asc" in exts and ".txt" in exts):
+            LOGGER.warning(
+                "When using two files with this datablock, "
+                "one file with .asc and another file with .txt are required"
+            )
+            return None
+
+        if ext_0 == ".asc":
+            ms_asc_data = parse_mt_mass_spec_ascii(Path(file_info_0["location"]))
+            ms_txt_data = parse_mt_mass_spec_txt(Path(file_info_1["location"]))
+            return self._plot_txt_and_asc_data(ms_asc_data, ms_txt_data)
         else:
-            file_info = get_file_info_by_id(self.data["file_id"], update_if_live=True)
-            ext = os.path.splitext(file_info["location"].split("/")[-1])[-1].lower()
-            if ext not in self.accepted_file_extensions:
-                LOGGER.warning(
-                    "Unsupported file extension (must be one of %s, not %s)",
-                    self.accepted_file_extensions,
-                    ext,
-                )
-                return
-            if ext == ".asc":
-                ms_data = parse_mt_mass_spec_ascii(Path(file_info["location"]))
-                if ms_data:
-                    self.data["bokeh_plot_data"] = self._plot_ms_data(ms_data)
-            elif ext == ".txt":
-                ms_data = parse_mt_mass_spec_txt(Path(file_info["location"]))
-                if ms_data:
-                    self.data["bokeh_plot_data"] = self._plot_ms_txt_data(ms_data)
+            ms_asc_data = parse_mt_mass_spec_ascii(Path(file_info_1["location"]))
+            ms_txt_data = parse_mt_mass_spec_txt(Path(file_info_0["location"]))
+            return self._plot_txt_and_asc_data(ms_asc_data, ms_txt_data)
+
+    def _plot_txt_and_asc_data(self, ms_asc_data, ms_txt_data):
+        """
+        Plots txt and asc data together
+        Parameters:
+            ms_asc_data: partial pressures data
+            ms_txt_data: differential thermal analysis data
+        """
+        tsc = ms_txt_data["data"]["tga"]["Ts[°C]"]
+        trc = ms_txt_data["data"]["tga"]["Tr[°C]"]
+        ts = ms_txt_data["data"]["tga"]["t[s]"]
+        f_tsc = scipy.interpolate.interp1d(
+            ts, tsc, kind="nearest", fill_value=None, bounds_error=False
+        )
+        f_trc = scipy.interpolate.interp1d(
+            ts, trc, kind="nearest", fill_value=None, bounds_error=False
+        )
+        for species in ms_asc_data["data"]:
+            ms_asc_data["data"][species]["Ts[°C]"] = f_tsc(
+                ms_asc_data["data"][species]["Time Relative [s]"]
+            )
+            ms_asc_data["data"][species]["Tr[°C]"] = f_trc(
+                ms_asc_data["data"][species]["Time Relative [s]"]
+            )
+
+        return self._plot_ms_data(ms_asc_data, include_x_temperature=True, dta_data=ms_txt_data)
 
     @classmethod
-    def _plot_ms_data(cls, ms_data):
+    def _plot_ms_data(cls, ms_data, include_x_temperature=False, dta_data=None):
         x_options = ["Time Relative [s]"]
+        if include_x_temperature:
+            x_options.extend(["Ts[°C]", "Tr[°C]"])
 
         # collect the maximum value of the data key for each species for plot ordering
         max_vals: list[tuple[str, float]] = []
@@ -75,6 +146,7 @@ class MassSpecBlock(DataBlock):
             max_vals.append((species, ms_data["data"][species][data_key].max()))
 
         plots = []
+
         for ind, (species, _) in enumerate(sorted(max_vals, key=lambda x: x[1], reverse=True)):
             plots.append(
                 selectable_axes_plot(
@@ -94,8 +166,19 @@ class MassSpecBlock(DataBlock):
                     aspect_ratio=1.5,
                 )
             )
-
-            plots[-1].children[0].xaxis[0].ticker.desired_num_ticks = 2
+            plots[-1].children[0].xaxis[0].ticker.desired_num_ticks = 4
+        if include_x_temperature:
+            plots.append(
+                selectable_axes_plot(
+                    dta_data["data"]["tga"],
+                    x_options=["Ts[°C]", "Tr[°C]"],
+                    y_options=["Value[mg]"],
+                    plot_line=True,
+                    plot_points=False,
+                    plot_title="Differential thermal analysis (DTA)",
+                    aspect_ratio=1.5,
+                )
+            )
 
         # construct MxN grid of all species
         M = 3
@@ -108,7 +191,7 @@ class MassSpecBlock(DataBlock):
 
     @classmethod
     def _plot_ms_txt_data(cls, ms_data):
-        x_options = ["Ts[°C]"]
+        x_options = ["Ts[°C]", "t[s]", "Tr[°C]"]
         y_options = ["Value[mg]"]
         plot = selectable_axes_plot(
             ms_data["data"]["tga"],

--- a/pydatalab/src/pydatalab/apps/tga/blocks.py
+++ b/pydatalab/src/pydatalab/apps/tga/blocks.py
@@ -5,7 +5,7 @@ import bokeh
 from bokeh.layouts import gridplot
 from scipy.signal import savgol_filter
 
-from pydatalab.apps.tga.parsers import parse_mt_mass_spec_ascii
+from pydatalab.apps.tga.parsers import parse_mt_mass_spec_ascii, parse_mt_mass_spec_txt
 from pydatalab.blocks.base import DataBlock
 from pydatalab.bokeh_plots import DATALAB_BOKEH_GRID_THEME, selectable_axes_plot
 from pydatalab.file_utils import get_file_info_by_id
@@ -40,10 +40,14 @@ class MassSpecBlock(DataBlock):
                     ext,
                 )
                 return
-
-            ms_data = parse_mt_mass_spec_ascii(Path(file_info["location"]))
-            if ms_data:
-                self.data["bokeh_plot_data"] = self._plot_ms_data(ms_data)
+            if ext == ".asc":
+                ms_data = parse_mt_mass_spec_ascii(Path(file_info["location"]))
+                if ms_data:
+                    self.data["bokeh_plot_data"] = self._plot_ms_data(ms_data)
+            elif ext == ".txt":
+                ms_data = parse_mt_mass_spec_txt(Path(file_info["location"]))
+                if ms_data:
+                    self.data["bokeh_plot_data"] = self._plot_ms_txt_data(ms_data)
 
     @classmethod
     def _plot_ms_data(cls, ms_data):
@@ -101,3 +105,17 @@ class MassSpecBlock(DataBlock):
         p = gridplot(grid, sizing_mode="scale_width", toolbar_location="below")
 
         return bokeh.embed.json_item(p, theme=DATALAB_BOKEH_GRID_THEME)
+
+    @classmethod
+    def _plot_ms_txt_data(cls, ms_data):
+        x_options = ["Ts[°C]"]
+        y_options = ["Value[mg]"]
+        plot = selectable_axes_plot(
+            ms_data["data"]["tga"],
+            x_options=x_options,
+            y_options=y_options,
+            plot_line=True,
+            plot_points=False,
+            plot_title="Differential Thermal Analysis (DTA)",
+        )
+        return bokeh.embed.json_item(plot, theme=DATALAB_BOKEH_GRID_THEME)

--- a/pydatalab/src/pydatalab/apps/tga/parsers.py
+++ b/pydatalab/src/pydatalab/apps/tga/parsers.py
@@ -50,7 +50,6 @@ def parse_mt_mass_spec_ascii(path: Path) -> dict[str, pd.DataFrame | dict]:
             if "time" in key.lower():
                 header[key] = dateutil.parser.parse(header[key])  # type: ignore
 
-        reads = 0
         max_species_lines = 10
         for reads in range(max_species_lines):
             line = f.readline().strip()
@@ -64,7 +63,7 @@ def parse_mt_mass_spec_ascii(path: Path) -> dict[str, pd.DataFrame | dict]:
 
         # Read data with duplicated keys: will have (column number % number of data keys) appended to them
         # MT software also writes "---" if the value is missing, so parse these as NaNs to remove later
-        df = pd.read_csv(f, sep="\t", header=0, parse_dates=False, na_values=["---"])
+        df = pd.read_csv(f, sep=r"\t", header=0, parse_dates=False, na_values=["---"])
         ms_results: dict[str, pd.DataFrame | dict] = {}
         ms_results["meta"] = header
         ms_results["data"] = {}
@@ -124,10 +123,8 @@ def parse_mt_mass_spec_txt(path: Path) -> dict[str, pd.DataFrame | dict]:
                 f"Could not find all header keys in first {max_header_lines} lines of file."
             )
 
-        print(f"header = {header_end}")
-
         header["Performed"] = dateutil.parser.parse(header["Performed"])  # type: ignore
-        max_names_lines = 10
+        max_names_lines = 20
         expected_data_keys = ("t[s]", "Ts[°C]", "Tr[°C]", "Value[mg]")
         line = f.readline()
         for reads in range(max_names_lines):
@@ -171,6 +168,7 @@ def parse_mt_mass_spec_txt(path: Path) -> dict[str, pd.DataFrame | dict]:
             names=column_headers,
             na_values="---",
             index_col="Index",
+            engine="python",
         )
 
         ms_results: dict[str, pd.DataFrame | dict] = {}

--- a/pydatalab/src/pydatalab/apps/tga/parsers.py
+++ b/pydatalab/src/pydatalab/apps/tga/parsers.py
@@ -63,7 +63,7 @@ def parse_mt_mass_spec_ascii(path: Path) -> dict[str, pd.DataFrame | dict]:
 
         # Read data with duplicated keys: will have (column number % number of data keys) appended to them
         # MT software also writes "---" if the value is missing, so parse these as NaNs to remove later
-        df = pd.read_csv(f, sep=r"\t", header=0, parse_dates=False, na_values=["---"])
+        df = pd.read_csv(f, sep="\t", header=0, parse_dates=False, na_values=["---"])
         ms_results: dict[str, pd.DataFrame | dict] = {}
         ms_results["meta"] = header
         ms_results["data"] = {}

--- a/pydatalab/src/pydatalab/apps/tga/parsers.py
+++ b/pydatalab/src/pydatalab/apps/tga/parsers.py
@@ -1,9 +1,11 @@
+import re
+from io import StringIO
 from pathlib import Path
 
 import dateutil
 import pandas as pd
 
-__all__ = ("parse_mt_mass_spec_ascii",)
+__all__ = ("parse_mt_mass_spec_ascii", "parse_mt_mass_spec_txt")
 
 
 def parse_mt_mass_spec_ascii(path: Path) -> dict[str, pd.DataFrame | dict]:
@@ -29,11 +31,9 @@ def parse_mt_mass_spec_ascii(path: Path) -> dict[str, pd.DataFrame | dict]:
     with open(path) as f:
         # Read start of file until all header keys have been found
         max_header_lines = 8
-        reads = 0
         header_end = None
-        while reads < max_header_lines:
+        for reads in range(max_header_lines):
             line = f.readline().strip()
-            reads += 1
             if line:
                 for key in header_keys:
                     if key in line:
@@ -52,13 +52,11 @@ def parse_mt_mass_spec_ascii(path: Path) -> dict[str, pd.DataFrame | dict]:
 
         reads = 0
         max_species_lines = 10
-        while reads < max_species_lines:
+        for reads in range(max_species_lines):
             line = f.readline().strip()
-            reads += 1
-            if not line:
-                continue
-            species = line.split()
-            break
+            if line:
+                species = line.split()
+                break
         else:
             raise ValueError(
                 f"Could not find species list in lines {header_end}:{header_end + max_species_lines} lines of file."
@@ -87,5 +85,98 @@ def parse_mt_mass_spec_ascii(path: Path) -> dict[str, pd.DataFrame | dict]:
 
             # If the file was provided in an incomplete form, the final rows will be NaN, so drop them
             ms_results["data"][specie].dropna(inplace=True)
+
+        return ms_results
+
+
+def parse_mt_mass_spec_txt(path: Path) -> dict[str, pd.DataFrame | dict]:
+    """Parses an .txt file containing results associated with a tga experiment
+    The data that this parser is designed for is Differential Thermal Analysis (DTS).
+    This means we assume that there is a Tr column that is only recorded when there is a reference material
+    being compared against the sample. This file is from a simultaneous TGA-DTA  measurement.
+    (Simultaneous Thermal Analysis, STA).
+    The manual can be found here: https://www.mt.com/fr/fr/home/library/user-manuals/lab-analytical-instruments/ta-manuals.html
+     Parameters:
+         path: The path of the file to parse.
+    """
+
+    header_keys = ["Performed"]
+    header = {}
+
+    if not path.exists():
+        raise RuntimeError(f"Provided path does not exist: {path!r}")
+
+    with open(path, encoding="latin-1") as f:
+        # Read start of file until all header keys have been found
+        max_header_lines = 11
+
+        for reads in range(max_header_lines):
+            line = f.readline().strip()
+            if line:
+                for key in header_keys:
+                    if key in line:
+                        header[key] = line.split(key)[-1].strip()
+            if all(k in header for k in header_keys):
+                header_end = f.tell()
+                break
+        else:
+            raise ValueError(
+                f"Could not find all header keys in first {max_header_lines} lines of file."
+            )
+
+        print(f"header = {header_end}")
+
+        header["Performed"] = dateutil.parser.parse(header["Performed"])  # type: ignore
+        max_names_lines = 10
+        expected_data_keys = ("t[s]", "Ts[°C]", "Tr[°C]", "Value[mg]")
+        line = f.readline()
+        for reads in range(max_names_lines):
+            next_line = f.readline()
+
+            if line and next_line:
+                name = line.strip().split()[1:]
+                unit = next_line.strip().split()
+
+                column_headers = [f"{name}{unit}" for name, unit in zip(name, unit)]
+                column_headers.insert(0, "Index")
+
+                if set(expected_data_keys) & set(column_headers) == set(expected_data_keys):
+                    break
+                # Move to the next line
+                line = next_line
+        else:
+            raise ValueError(
+                f"Could not find names list in lines {header_end}:{header_end + max_names_lines} lines of file."
+            )
+
+        final_lines = f.readlines()
+
+        # Remove bottom header from the file
+        max_bottom_header_lines = 11
+        for index in range(1, max_bottom_header_lines):
+            if re.match(r"^[\d.\s-]*\d[\d.\s-]*$", final_lines[-index]):
+                final_lines = final_lines[: -(index - 1)]
+                break
+        else:
+            raise ValueError(f"Bottom header did not end within max size:{max_bottom_header_lines}")
+
+        csv_result = StringIO("\n".join(final_lines))
+        # Read data with duplicated keys: will have (column number % number of data keys) appended to them
+        # MT software also writes "---" if the value is missing, so parse these as NaNs to remove later
+        df = pd.read_csv(
+            csv_result,
+            sep=r"\s+",
+            header=None,
+            parse_dates=False,
+            names=column_headers,
+            na_values="---",
+            index_col="Index",
+        )
+
+        ms_results: dict[str, pd.DataFrame | dict] = {}
+        ms_results["meta"] = header
+        ms_results["data"] = {}
+
+        ms_results["data"]["tga"] = df
 
         return ms_results

--- a/pydatalab/src/pydatalab/bokeh_plots.py
+++ b/pydatalab/src/pydatalab/bokeh_plots.py
@@ -39,6 +39,11 @@ SELECTABLE_CALLBACK_x = """
   var column = cb_obj.value;
   if (circle1) {circle1.glyph.x.field = column;}
   if (line1) {line1.glyph.x.field = column;}
+  if (aux_lines) {
+    for (let i = 0; i < aux_lines.length; i++) {
+      aux_lines[i].glyph.x.field = column;
+    }
+  }
   source.change.emit();
   xaxis.axis_label = column;
 """
@@ -480,9 +485,10 @@ def selectable_axes_plot(
             else None  # Mode B
         )
 
-        if y_aux:
+        aux_line_renderers = []
+        if y_aux and plot_line:
             for y in y_aux:
-                aux_lines = (  # noqa
+                aux_line_renderers.append(
                     p.line(
                         x=x_default,
                         y=y,
@@ -490,13 +496,17 @@ def selectable_axes_plot(
                         color=line_color,
                         alpha=0.3,
                     )
-                    if plot_line
-                    else None
                 )
 
         callbacks_x.append(
             CustomJS(
-                args=dict(circle1=circles, line1=lines, source=source, xaxis=p.xaxis[0]),
+                args=dict(
+                    circle1=circles,
+                    line1=lines,
+                    aux_lines=aux_line_renderers,
+                    source=source,
+                    xaxis=p.xaxis[0],
+                ),
                 code=SELECTABLE_CALLBACK_x,
             )
         )

--- a/pydatalab/src/pydatalab/bokeh_plots.py
+++ b/pydatalab/src/pydatalab/bokeh_plots.py
@@ -39,6 +39,11 @@ SELECTABLE_CALLBACK_x = """
   var column = cb_obj.value;
   if (circle1) {circle1.glyph.x.field = column;}
   if (line1) {line1.glyph.x.field = column;}
+  if (aux_lines) {
+    for (let i = 0; i < aux_lines.length; i++) {
+      aux_lines[i].glyph.x.field = column;
+    }
+  }
   source.change.emit();
   xaxis.axis_label = column;
 """
@@ -482,9 +487,10 @@ def selectable_axes_plot(
             else None  # Mode B
         )
 
-        if y_aux:
+        aux_line_renderers = []
+        if y_aux and plot_line:
             for y in y_aux:
-                aux_lines = (  # noqa
+                aux_line_renderers.append(
                     p.line(
                         x=x_default,
                         y=y,
@@ -492,13 +498,17 @@ def selectable_axes_plot(
                         color=line_color,
                         alpha=0.3,
                     )
-                    if plot_line
-                    else None
                 )
 
         callbacks_x.append(
             CustomJS(
-                args=dict(circle1=circles, line1=lines, source=source, xaxis=p.xaxis[0]),
+                args=dict(
+                    circle1=circles,
+                    line1=lines,
+                    aux_lines=aux_line_renderers,
+                    source=source,
+                    xaxis=p.xaxis[0],
+                ),
                 code=SELECTABLE_CALLBACK_x,
             )
         )

--- a/pydatalab/tests/apps/test_tga.py
+++ b/pydatalab/tests/apps/test_tga.py
@@ -63,3 +63,21 @@ def test_ms_parse_no_validation(filename):
         )
         assert "Time Relative [s]" in ms["data"][species]
         assert "Time" not in ms["data"][species]
+
+
+@pytest.mark.parametrize(
+    "filename", (Path(__file__).parent.parent.parent / "example_data" / "TGA-MS").glob("*.txt")
+)
+def test_ms_parse_txt_no_validation(filename):
+    from pydatalab.apps.tga.parsers import parse_mt_mass_spec_txt
+
+    ms = parse_mt_mass_spec_txt(filename)
+    # check that the results exist
+    assert ms
+
+    assert "Performed" in ms["meta"]
+    for header in ms["data"]:
+        assert "t[s]" in ms["data"][header]
+        assert "Value[mg]" in ms["data"][header]
+        assert "Ts[°C]" in ms["data"][header]
+        assert "Tr[°C]" in ms["data"][header]

--- a/pydatalab/tests/apps/test_tga.py
+++ b/pydatalab/tests/apps/test_tga.py
@@ -65,10 +65,10 @@ def test_ms_parse_no_validation(filename):
         assert "Time" not in ms["data"][species]
 
 
-@pytest.mark.parametrize(
-    "filename", (Path(__file__).parent.parent.parent / "example_data" / "TGA-MS").glob("*.txt")
-)
-def test_ms_parse_txt_no_validation(filename):
+def test_ms_parse_txt_with_validation():
+    filename = (
+        Path(__file__).parent.parent.parent / "example_data" / "TGA-MS" / "mp2028_281122_LNO+C.txt"
+    )
     from pydatalab.apps.tga.parsers import parse_mt_mass_spec_txt
 
     ms = parse_mt_mass_spec_txt(filename)
@@ -76,8 +76,20 @@ def test_ms_parse_txt_no_validation(filename):
     assert ms
 
     assert "Performed" in ms["meta"]
-    for header in ms["data"]:
-        assert "t[s]" in ms["data"][header]
-        assert "Value[mg]" in ms["data"][header]
-        assert "Ts[°C]" in ms["data"][header]
-        assert "Tr[°C]" in ms["data"][header]
+    assert "t[s]" in ms["data"]["tga"]
+    assert "Value[mg]" in ms["data"]["tga"]
+    assert "Ts[°C]" in ms["data"]["tga"]
+    assert "Tr[°C]" in ms["data"]["tga"]
+
+    # regression test to check if means and standard deviations remain the same in the future
+    assert pytest.approx(ms["data"]["tga"]["t[s]"].mean(), rel=1e-3) == 2025
+    assert pytest.approx(ms["data"]["tga"]["t[s]"].std(), rel=1e-3) == 1169.57
+
+    assert pytest.approx(ms["data"]["tga"]["Ts[°C]"].mean(), rel=1e-3) == 352.45
+    assert pytest.approx(ms["data"]["tga"]["Ts[°C]"].std(), rel=1e-3) == 196.34
+
+    assert pytest.approx(ms["data"]["tga"]["Tr[°C]"].mean(), rel=1e-3) == 362.45
+    assert pytest.approx(ms["data"]["tga"]["Tr[°C]"].std(), rel=1e-3) == 194.93
+
+    assert pytest.approx(ms["data"]["tga"]["Value[mg]"].mean(), rel=1e-3) == 4.16899
+    assert pytest.approx(ms["data"]["tga"]["Value[mg]"].std(), rel=1e-3) == 0.004453

--- a/pydatalab/tests/apps/test_tga.py
+++ b/pydatalab/tests/apps/test_tga.py
@@ -64,3 +64,21 @@ def test_ms_parse_no_validation(filename):
         )
         assert "Time Relative [s]" in ms["data"][species]
         assert "Time" not in ms["data"][species]
+
+
+@pytest.mark.parametrize(
+    "filename", (Path(__file__).parent.parent.parent / "example_data" / "TGA-MS").glob("*.txt")
+)
+def test_ms_parse_txt_no_validation(filename):
+    from pydatalab.apps.tga.parsers import parse_mt_mass_spec_txt
+
+    ms = parse_mt_mass_spec_txt(filename)
+    # check that the results exist
+    assert ms
+
+    assert "Performed" in ms["meta"]
+    for header in ms["data"]:
+        assert "t[s]" in ms["data"][header]
+        assert "Value[mg]" in ms["data"][header]
+        assert "Ts[°C]" in ms["data"][header]
+        assert "Tr[°C]" in ms["data"][header]

--- a/pydatalab/tests/apps/test_tga.py
+++ b/pydatalab/tests/apps/test_tga.py
@@ -66,10 +66,10 @@ def test_ms_parse_no_validation(filename):
         assert "Time" not in ms["data"][species]
 
 
-@pytest.mark.parametrize(
-    "filename", (Path(__file__).parent.parent.parent / "example_data" / "TGA-MS").glob("*.txt")
-)
-def test_ms_parse_txt_no_validation(filename):
+def test_ms_parse_txt_with_validation():
+    filename = (
+        Path(__file__).parent.parent.parent / "example_data" / "TGA-MS" / "mp2028_281122_LNO+C.txt"
+    )
     from pydatalab.apps.tga.parsers import parse_mt_mass_spec_txt
 
     ms = parse_mt_mass_spec_txt(filename)
@@ -77,8 +77,20 @@ def test_ms_parse_txt_no_validation(filename):
     assert ms
 
     assert "Performed" in ms["meta"]
-    for header in ms["data"]:
-        assert "t[s]" in ms["data"][header]
-        assert "Value[mg]" in ms["data"][header]
-        assert "Ts[°C]" in ms["data"][header]
-        assert "Tr[°C]" in ms["data"][header]
+    assert "t[s]" in ms["data"]["tga"]
+    assert "Value[mg]" in ms["data"]["tga"]
+    assert "Ts[°C]" in ms["data"]["tga"]
+    assert "Tr[°C]" in ms["data"]["tga"]
+
+    # regression test to check if means and standard deviations remain the same in the future
+    assert pytest.approx(ms["data"]["tga"]["t[s]"].mean(), rel=1e-3) == 2025
+    assert pytest.approx(ms["data"]["tga"]["t[s]"].std(), rel=1e-3) == 1169.57
+
+    assert pytest.approx(ms["data"]["tga"]["Ts[°C]"].mean(), rel=1e-3) == 352.45
+    assert pytest.approx(ms["data"]["tga"]["Ts[°C]"].std(), rel=1e-3) == 196.34
+
+    assert pytest.approx(ms["data"]["tga"]["Tr[°C]"].mean(), rel=1e-3) == 362.45
+    assert pytest.approx(ms["data"]["tga"]["Tr[°C]"].std(), rel=1e-3) == 194.93
+
+    assert pytest.approx(ms["data"]["tga"]["Value[mg]"].mean(), rel=1e-3) == 4.16899
+    assert pytest.approx(ms["data"]["tga"]["Value[mg]"].std(), rel=1e-3) == 0.004453


### PR DESCRIPTION
This PR attempts to solve parsing `mp2028_281122_LNO+C.txt` file.
Done by:
- Creating new TGA parser specifically for the `.txt` file.
- Writing tests for this new parser, that use the example file
- Integrating into the TGA datablock.
  - Allowing multifile selection for this TGA datablock.
  - Allowing partial pressures to be plotted from a `.asc` file with the temperature from the `.txt` file to also be plotted.
    - Current approach assumes that the time points from the respective files start from the same point but might not be the same length (as given in the example files) (see sub issue #1899).
  - Allows the `.txt` DTA file to be plotted solely
- Fixing a bokeh issue where it fails to update the second plot line on a `selectable_axes_plot` graph.

Resolves issue #1897