### PR TITLE
Fix group search + group row unclickable

### DIFF
--- a/pydatalab/src/pydatalab/mongo.py
+++ b/pydatalab/src/pydatalab/mongo.py
@@ -54,6 +54,8 @@ USERS_FTS_FIELDS: set[str] = {"identities.name", "display_name", "contact_email"
 COLLECTIONS_FTS_FIELDS: set[str] = {"collection_id", "title", "description"}
 """Fields to search for collections."""
 
+GROUPS_FTS_FIELDS: set[str] = {"group_id", "display_name", "description"}
+
 
 def generate_heuristic_regex_search(
     query: str, fields: set[str], part_length: int = 4

--- a/pydatalab/src/pydatalab/mongo.py
+++ b/pydatalab/src/pydatalab/mongo.py
@@ -23,6 +23,7 @@ __all__ = (
     "ITEMS_FTS_FIELDS",
     "USERS_FTS_FIELDS",
     "COLLECTIONS_FTS_FIELDS",
+    "GROUPS_FTS_FIELDS",
     "generate_heuristic_regex_search",
     "build_search_pipeline",
 )

--- a/pydatalab/src/pydatalab/mongo.py
+++ b/pydatalab/src/pydatalab/mongo.py
@@ -56,6 +56,7 @@ COLLECTIONS_FTS_FIELDS: set[str] = {"collection_id", "title", "description"}
 """Fields to search for collections."""
 
 GROUPS_FTS_FIELDS: set[str] = {"group_id", "display_name", "description"}
+"""Fields to search for groups."""
 
 
 def generate_heuristic_regex_search(

--- a/pydatalab/src/pydatalab/routes/v0_1/groups.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/groups.py
@@ -3,7 +3,11 @@ import json
 from flask import Blueprint, jsonify, request
 
 from pydatalab.models.people import Group
-from pydatalab.mongo import flask_mongo
+from pydatalab.mongo import (
+    GROUPS_FTS_FIELDS,
+    build_search_pipeline,
+    flask_mongo,
+)
 from pydatalab.permissions import active_users_or_get_only
 
 GROUPS = Blueprint("groups", __name__)
@@ -28,23 +32,15 @@ def search_groups():
 
     query = request.args.get("query", type=str)
     nresults = request.args.get("nresults", default=100, type=int)
-    match_obj = {"$text": {"$search": query}}
 
-    cursor = flask_mongo.db.groups.aggregate(
-        [
-            {"$match": match_obj},
-            {"$sort": {"score": {"$meta": "textScore"}}},
-            {"$limit": nresults},
-            {
-                "$project": {
-                    "_id": 1,
-                    "display_name": 1,
-                    "description": 1,
-                    "group_id": 1,
-                }
-            },
-        ]
-    )
+    if not query:
+        return jsonify({"status": "error", "message": "No query provided"}), 400
+
+    pipeline = build_search_pipeline(query, GROUPS_FTS_FIELDS, permissions=None)
+    pipeline.append({"$limit": nresults})
+    pipeline.append({"$project": {"_id": 1, "display_name": 1, "description": 1, "group_id": 1}})
+    cursor = flask_mongo.db.groups.aggregate(pipeline)
+
     return jsonify(
         {"status": "success", "data": list(json.loads(Group(**d).json()) for d in cursor)}
     ), 200

--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -1278,7 +1278,7 @@ export default {
       });
     },
     goToEditPage(event) {
-      if (this.dataType === "users") {
+      if (this.dataType === "users" || this.dataType === "groups") {
         return;
       }
       const row = event.data;


### PR DESCRIPTION
This PR fixes 
- https://github.com/datalab-org/datalab/issues/1908,  using the same pattern as user search
- https://github.com/datalab-org/datalab/issues/1827, making the group rows unclickable in the admin menu