### PR TITLE
Add human-readable `last_modified` as a data table column

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -1831,9 +1831,12 @@ def save_item():
             str(e),
         )
 
-    # Return the freshly-minted timestamp when content changed, otherwise fall back to the
-    # item's existing value (None for an item that has never been modified).
-    return jsonify(status="success", last_modified=new_last_modified or existing_last_modified), 200
+    # Report the freshly-minted timestamp when content changed. If no version was minted
+    # the item was unchanged, so flag it as a no-op and echo back the existing timestamp
+    if new_last_modified:
+        return jsonify(status="success", last_modified=new_last_modified), 200
+
+    return jsonify(status="success", unchanged=True, last_modified=existing_last_modified), 200
 
 
 @ITEMS.route("/items/<refcode>/access-token-info", methods=["GET"])

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -1803,32 +1803,25 @@ def save_item():
     # (i.e., a snapshot was minted). If this fails, we log but don't fail the request
     # since the item was already saved.
     new_last_modified = None
-    try:
-        save_version_resp_dict, save_version_status = save_version_snapshot(
-            refcode,
-        )
-        if save_version_status != 200:
-            LOGGER.error(
-                "Failed to save version for item %s after successful update: %s",
-                item_id,
-                save_version_resp_dict,
-            )
-        elif "version" in save_version_resp_dict:
-            new_last_modified = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
-            flask_mongo.db.items.update_one(
-                {"item_id": item_id},
-                {
-                    "$set": {
-                        "version": save_version_resp_dict["version"],
-                        "last_modified": new_last_modified,
-                    }
-                },
-            )
-    except Exception as e:
+
+    save_version_resp_dict, save_version_status = save_version_snapshot(refcode)
+
+    if save_version_status != 200:
         LOGGER.error(
-            "Exception while saving version for item %s after successful update: %s",
+            "Failed to save version for item %s after successful update: %s",
             item_id,
-            str(e),
+            save_version_resp_dict,
+        )
+    elif "version" in save_version_resp_dict:
+        new_last_modified = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+        flask_mongo.db.items.update_one(
+            {"item_id": item_id},
+            {
+                "$set": {
+                    "version": save_version_resp_dict["version"],
+                    "last_modified": new_last_modified,
+                }
+            },
         )
 
     # Report the freshly-minted timestamp when content changed. If no version was minted

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -45,6 +45,10 @@ ITEMS = Blueprint("items", __name__)
 # item types that should be accessed by anyone with an account
 ACCESSIBLE_TYPES = ("equipment", "starting_materials")
 
+# Legacy items predate `last_modified` being set on creation, so fall back to the
+# creation time embedded in their ObjectId.
+LAST_MODIFIED_PROJECTION = {"$ifNull": ["$last_modified", {"$toDate": "$_id"}]}
+
 
 @ITEMS.before_request
 @active_users_or_get_only
@@ -59,6 +63,7 @@ def get_equipment_summary():
         "name": 1,
         "type": 1,
         "date": 1,
+        "last_modified": LAST_MODIFIED_PROJECTION,
         "refcode": 1,
         "location": 1,
         "status": 1,
@@ -113,7 +118,7 @@ def get_starting_materials():
                         "nblocks": {"$size": "$display_order"},
                         "nfiles": {"$size": "$file_ObjectIds"},
                         "date": 1,
-                        "last_modified": 1,
+                        "last_modified": LAST_MODIFIED_PROJECTION,
                         "chemform": 1,
                         "smiles": 1,
                         "inchi_key": 1,
@@ -193,7 +198,7 @@ def get_items_summary(match: dict | None = None, project: dict | None = None) ->
         "characteristic_chemical_formula": 1,
         "type": 1,
         "date": 1,
-        "last_modified": 1,
+        "last_modified": LAST_MODIFIED_PROJECTION,
         "refcode": 1,
         "status": 1,
     }
@@ -270,7 +275,7 @@ def get_samples_summary(match: dict | None = None, project: dict | None = None) 
         "characteristic_chemical_formula": 1,
         "type": 1,
         "date": 1,
-        "last_modified": 1,
+        "last_modified": LAST_MODIFIED_PROJECTION,
         "refcode": 1,
         "status": 1,
     }
@@ -703,6 +708,9 @@ def _create_sample(
 
     # Set creation timestamp to now if not provided
     new_sample["date"] = new_sample.get("date", datetime.datetime.now(tz=datetime.timezone.utc))
+
+    # Always stamp the real creation time; `date` may be backdated or copied
+    new_sample["last_modified"] = datetime.datetime.now(tz=datetime.timezone.utc)
 
     # Try to deserialize the item data into the appropriate model
     try:
@@ -1166,6 +1174,10 @@ def get_item_data(
             ),
             404,
         )
+
+    # See LAST_MODIFIED_PROJECTION: same backfill, applied outside an aggregation
+    if not doc.get("last_modified") and isinstance(doc.get("_id"), ObjectId):
+        doc["last_modified"] = doc["_id"].generation_time
 
     # determine the item type and validate according to the appropriate schema
     try:

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -113,6 +113,7 @@ def get_starting_materials():
                         "nblocks": {"$size": "$display_order"},
                         "nfiles": {"$size": "$file_ObjectIds"},
                         "date": 1,
+                        "last_modified": 1,
                         "chemform": 1,
                         "smiles": 1,
                         "inchi_key": 1,
@@ -192,6 +193,7 @@ def get_items_summary(match: dict | None = None, project: dict | None = None) ->
         "characteristic_chemical_formula": 1,
         "type": 1,
         "date": 1,
+        "last_modified": 1,
         "refcode": 1,
         "status": 1,
     }
@@ -268,6 +270,7 @@ def get_samples_summary(match: dict | None = None, project: dict | None = None) 
         "characteristic_chemical_formula": 1,
         "type": 1,
         "date": 1,
+        "last_modified": 1,
         "refcode": 1,
         "status": 1,
     }
@@ -1647,11 +1650,10 @@ def save_item():
         "group_ids",
         "item_id",
         "relationships",
+        "last_modified",
     ):
         if k in updated_data:
             del updated_data[k]
-
-    updated_data["last_modified"] = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
 
     for block_id, block_data in updated_data.get("blocks_obj", {}).items():
         blocktype = block_data["blocktype"]
@@ -1774,6 +1776,12 @@ def save_item():
     item.pop("collections")
     item.pop("creators")
 
+    # `last_modified` is controlled by the versioning branch below: only bump it when a
+    # snapshot is actually saved, so re-submitting identical data leaves it untouched.
+    existing_last_modified = item.pop("last_modified", None)
+    if isinstance(existing_last_modified, datetime.datetime):
+        existing_last_modified = existing_last_modified.isoformat()
+
     # Update the item FIRST (transaction safety: item update before version save)
     result = flask_mongo.db.items.update_one(
         {"item_id": item_id, **get_default_permissions(user_only=True)},
@@ -1791,8 +1799,10 @@ def save_item():
         )
 
     # Now save a version AFTER successful item update.
-    # Only increment item.version when content actually changed (i.e., a snapshot was minted).
-    # If this fails, we log but don't fail the request since item was already saved.
+    # Only increment item.version and bump last_modified when content actually changed
+    # (i.e., a snapshot was minted). If this fails, we log but don't fail the request
+    # since the item was already saved.
+    new_last_modified = None
     try:
         save_version_resp_dict, save_version_status = save_version_snapshot(
             refcode,
@@ -1804,9 +1814,15 @@ def save_item():
                 save_version_resp_dict,
             )
         elif "version" in save_version_resp_dict:
+            new_last_modified = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
             flask_mongo.db.items.update_one(
                 {"item_id": item_id},
-                {"$set": {"version": save_version_resp_dict["version"]}},
+                {
+                    "$set": {
+                        "version": save_version_resp_dict["version"],
+                        "last_modified": new_last_modified,
+                    }
+                },
             )
     except Exception as e:
         LOGGER.error(
@@ -1815,7 +1831,9 @@ def save_item():
             str(e),
         )
 
-    return jsonify(status="success", last_modified=updated_data["last_modified"]), 200
+    # Return the freshly-minted timestamp when content changed, otherwise fall back to the
+    # item's existing value (None for an item that has never been modified).
+    return jsonify(status="success", last_modified=new_last_modified or existing_last_modified), 200
 
 
 @ITEMS.route("/items/<refcode>/access-token-info", methods=["GET"])

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -146,15 +146,19 @@ def test_save_item_last_modified(client, default_sample_dict):
     assert response.status_code == 200, response.json
     first_last_modified = response.json["last_modified"]
     assert first_last_modified is not None
+    # A genuine change is not flagged as a no-op
+    assert not response.json.get("unchanged")
 
     after_change = get_item()
     assert after_change["last_modified"] == first_last_modified
     assert after_change["last_modified"] != before.get("last_modified")
     assert after_change.get("version") != version_before
 
-    # 2. Re-submitting identical data is a no-op: no version, no `last_modified` bump
+    # 2. Re-submitting identical data is a no-op: flagged `unchanged`, no version, no bump
     response = client.post("/save-item/", json={"item_id": item_id, "data": changed})
     assert response.status_code == 200, response.json
+    assert response.json["status"] == "success"
+    assert response.json["unchanged"] is True
     assert response.json["last_modified"] == first_last_modified
 
     after_noop = get_item()

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -116,6 +116,53 @@ def test_save_good_sample(client, default_sample_dict):
 
 
 @pytest.mark.dependency(depends=["test_new_sample"])
+def test_save_item_last_modified(client, default_sample_dict):
+    """`last_modified` should only be bumped when a save actually changes the
+    item's content (i.e., a new version is minted), and left untouched when
+    identical data is re-submitted.
+    """
+    # Use a dedicated item so this test doesn't interfere with the shared sample
+    sample = copy.deepcopy(default_sample_dict)
+    sample["item_id"] = "last_modified_test"
+    item_id = sample["item_id"]
+
+    response = client.put("/new-sample/", json=sample)
+    assert response.status_code == 201, response.json
+
+    def get_item():
+        resp = client.get(f"/get-item-data/{item_id}")
+        assert resp.status_code == 200, resp.json
+        return resp.json["item_data"]
+
+    before = get_item()
+    # A freshly created item has never been modified
+    assert before.get("last_modified") is None
+    version_before = before.get("version")
+
+    # 1. A genuine metadata change bumps `last_modified` and mints a new version
+    changed = copy.deepcopy(sample)
+    changed["description"] = "A genuinely new description."
+    response = client.post("/save-item/", json={"item_id": item_id, "data": changed})
+    assert response.status_code == 200, response.json
+    first_last_modified = response.json["last_modified"]
+    assert first_last_modified is not None
+
+    after_change = get_item()
+    assert after_change["last_modified"] == first_last_modified
+    assert after_change["last_modified"] != before.get("last_modified")
+    assert after_change.get("version") != version_before
+
+    # 2. Re-submitting identical data is a no-op: no version, no `last_modified` bump
+    response = client.post("/save-item/", json={"item_id": item_id, "data": changed})
+    assert response.status_code == 200, response.json
+    assert response.json["last_modified"] == first_last_modified
+
+    after_noop = get_item()
+    assert after_noop["last_modified"] == first_last_modified
+    assert after_noop.get("version") == after_change.get("version")
+
+
+@pytest.mark.dependency(depends=["test_new_sample"])
 def test_save_bad_sample(client, default_sample_dict):
     updated_sample = default_sample_dict.copy()
     updated_sample.update({"unknown_key": "This should not be allowed in."})

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -135,8 +135,9 @@ def test_save_item_last_modified(client, default_sample_dict):
         return resp.json["item_data"]
 
     before = get_item()
-    # A freshly created item has never been modified
-    assert before.get("last_modified") is None
+    # Creation stamps `last_modified`, independently of the (backdated) `date` field
+    assert before.get("last_modified") is not None
+    assert before["last_modified"] != before["date"]
     version_before = before.get("version")
 
     # 1. A genuine metadata change bumps `last_modified` and mints a new version
@@ -164,6 +165,38 @@ def test_save_item_last_modified(client, default_sample_dict):
     after_noop = get_item()
     assert after_noop["last_modified"] == first_last_modified
     assert after_noop.get("version") == after_change.get("version")
+
+
+@pytest.mark.dependency(depends=["test_new_sample"])
+def test_last_modified_backfilled_from_object_id(client, database, default_sample_dict):
+    """Legacy items stored without a `last_modified` should have it derived from the
+    creation timestamp embedded in their MongoDB ObjectId.
+    """
+    sample = copy.deepcopy(default_sample_dict)
+    sample["item_id"] = "last_modified_backfill_test"
+    item_id = sample["item_id"]
+
+    response = client.put("/new-sample/", json=sample)
+    assert response.status_code == 201, response.json
+
+    # Simulate a legacy document that predates `last_modified` being set on creation
+    result = database.items.update_one({"item_id": item_id}, {"$unset": {"last_modified": ""}})
+    assert result.modified_count == 1
+
+    stored = database.items.find_one({"item_id": item_id}, {"_id": 1})
+    expected = stored["_id"].generation_time
+
+    response = client.get(f"/get-item-data/{item_id}")
+    assert response.status_code == 200, response.json
+    last_modified = response.json["item_data"]["last_modified"]
+    assert last_modified is not None
+    assert datetime.datetime.fromisoformat(last_modified) == expected
+
+    # The summary endpoint backing the item tables should backfill it too
+    response = client.get("/samples/")
+    assert response.status_code == 200, response.json
+    summary = next(d for d in response.json["samples"] if d["item_id"] == item_id)
+    assert summary["last_modified"] is not None
 
 
 @pytest.mark.dependency(depends=["test_new_sample"])

--- a/pydatalab/tests/server/test_users.py
+++ b/pydatalab/tests/server/test_users.py
@@ -197,6 +197,11 @@ def test_groups(
     assert resp.status_code == 200
     assert len(resp.json["data"]) == 1
 
+    # Check a user can search groups, and check that it doesn't need to be a full match
+    resp = client.get("/search/groups?query=Grou")
+    assert resp.status_code == 200
+    assert len(resp.json["data"]) == 2
+
     # Check that a user can be added to the group by an admin
     resp = admin_client.put(f"/groups/{group_immutable_id}", json={"user_id": another_user_id})
     assert resp.status_code == 200

--- a/webapp/cypress/component/SampleTableTest.cy.jsx
+++ b/webapp/cypress/component/SampleTableTest.cy.jsx
@@ -168,6 +168,7 @@ describe("SampleTable Component Tests", () => {
       "Creators",
       "", // nblocks
       "", // nfiles
+      "", // last_modified
     ];
 
     cy.get(".p-datatable-column-header-content").should("have.length", headers.length);

--- a/webapp/cypress/component/StartingMaterialTableTest.cy.jsx
+++ b/webapp/cypress/component/StartingMaterialTableTest.cy.jsx
@@ -89,6 +89,7 @@ describe("StartingMaterialTable Component Tests", () => {
       "Location",
       "", // nblocks
       "", //nfiles
+      "", // last_modified
     ];
 
     cy.get(".p-datatable-column-header-content").should("have.length", headers.length);

--- a/webapp/src/components/CollectionInformation.vue
+++ b/webapp/src/components/CollectionInformation.vue
@@ -58,6 +58,7 @@
         'blocks',
         'chemform',
         'characteristic_chemical_formula',
+        'creatorsList',
       ]"
       :show-buttons="true"
       :collection-id="collection_id"
@@ -105,11 +106,11 @@ export default {
         },
         { field: "type", header: "Type", filter: true, label: "Type" },
         { field: "status", header: "Status", body: "FormattedItemStatus", filter: true },
-        { field: "name", header: "Sample name", label: "Sample Name" },
+        { field: "name", header: "Name", label: "Sample name" },
         { field: "chemform", header: "Formula", body: "ChemicalFormula", label: "Formula" },
         { field: "date", header: "Date", label: "Date", filter: true },
         {
-          field: "creators",
+          field: "creatorsAndGroups",
           header: "Creators",
           body: "Creators",
           label: "Creators",
@@ -130,6 +131,7 @@ export default {
           icon: ["fa", "file"],
           label: "Files",
         },
+        { field: "last_modified", header: "", label: "Last modified", icon: ["fa", "clock"] },
       ],
     };
   },
@@ -141,7 +143,18 @@ export default {
     CollectionCreators: createComputedSetterForCollectionField("creators"),
     CollectionGroups: createComputedSetterForCollectionField("groups"),
     children() {
-      return this.$store.state.all_collection_children[this.collection_id] || [];
+      const children = this.$store.state.all_collection_children[this.collection_id];
+      if (!children) {
+        return [];
+      }
+      return children.map((child) => ({
+        ...child,
+        creatorsAndGroups: [
+          ...(child.creators || []).map((c) => ({ ...c, type: "creator" })),
+          ...(child.groups || []).map((g) => ({ ...g, type: "group" })),
+        ],
+        creatorsList: (child.creators || []).map((creator) => creator.display_name).join(", "),
+      }));
     },
     collectionRefcode() {
       const collection = this.$store.state.all_collection_data[this.collection_id];

--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -121,6 +121,11 @@
             @group-deleted="$emit('group-deleted')"
           />
         </template>
+        <template v-else-if="column.field === 'last_modified'" #body="slotProps">
+          <span class="last-modified-cell">{{
+            formatRelativeDate(slotProps.data[column.field])
+          }}</span>
+        </template>
         <template
           v-else-if="column.field === 'date' || column.field === 'created_at'"
           #body="slotProps"
@@ -607,6 +612,8 @@ import GroupIdCell from "@/components/GroupIdCell.vue";
 import GroupMembersCell from "@/components/GroupMembersCell.vue";
 import GroupActionsCell from "@/components/GroupActionsCell.vue";
 
+import { formatDistanceToNow } from "date-fns";
+import { parseUTCDate } from "@/field_utils.js";
 import { FilterMatchMode, FilterOperator, FilterService } from "@primevue/core/api";
 import DataTable from "primevue/datatable";
 import MultiSelect from "primevue/multiselect";
@@ -1227,6 +1234,14 @@ export default {
     });
   },
   methods: {
+    formatRelativeDate(isodatetime) {
+      if (!isodatetime) {
+        return isodatetime;
+      }
+      // Timestamps are stored server-side in UTC; parse them as such so the relative
+      // age is correct regardless of the viewer's local timezone.
+      return formatDistanceToNow(parseUTCDate(isodatetime), { addSuffix: true });
+    },
     getColumnMinWidth(column) {
       const COLUMN_BASE_PADDING = 2.5;
       const CHAR_WIDTH_ESTIMATE = 0.75;
@@ -1622,3 +1637,10 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.last-modified-cell {
+  font-size: 0.85em;
+  font-style: italic;
+}
+</style>

--- a/webapp/src/components/DynamicDataTable.vue
+++ b/webapp/src/components/DynamicDataTable.vue
@@ -1563,6 +1563,9 @@ export default {
       const customState = {
         columnWidths: state.columnWidths,
         visibleColumns: this.selectedColumns.map((col) => col.field),
+        // Record every column that existed when this selection was saved, so that on
+        // restore we can tell a genuinely new column apart from one the user deselected.
+        knownColumns: this.availableColumns.map((col) => col.field),
         first: state.first,
         rows: state.rows,
       };
@@ -1588,9 +1591,31 @@ export default {
           }
 
           if (customState.visibleColumns && Array.isArray(customState.visibleColumns)) {
-            this.selectedColumns = this.availableColumns.filter((col) =>
-              customState.visibleColumns.includes(col.field),
-            );
+            const savedVisible = customState.visibleColumns;
+            const knownColumns = Array.isArray(customState.knownColumns)
+              ? customState.knownColumns
+              : null;
+
+            // Whether the user previously had every *other* selectable column selected,
+            // i.e. they had "select all". Legacy states (saved before knownColumns was
+            // tracked) have no knownColumns, so we fall back to this check alone.
+            const hadAllOthersSelected = (field) =>
+              this.availableColumns
+                .filter((col) => col.field !== field && !col.hidden)
+                .every((col) => savedVisible.includes(col.field));
+
+            this.selectedColumns = this.availableColumns.filter((col) => {
+              // Keep whatever the user previously had selected.
+              if (savedVisible.includes(col.field)) return true;
+              // Never auto-show columns that are hidden by default.
+              if (col.hidden) return false;
+              // Otherwise the column wasn't in the saved selection: default it to visible
+              // only if it is new since the selection was saved AND the user had selected
+              // all other columns, so existing "select all" users keep seeing every column
+              // while users who curated their columns keep their choices.
+              const isNewColumn = knownColumns ? !knownColumns.includes(col.field) : true;
+              return isNewColumn && hadAllOthersSelected(col.field);
+            });
 
             if (this.selectedColumns.length === 0) {
               this.selectedColumns = this.availableColumns.filter((col) => !col.hidden);

--- a/webapp/src/components/FileSelectModal.vue
+++ b/webapp/src/components/FileSelectModal.vue
@@ -48,6 +48,7 @@ import Modal from "@/components/Modal";
 import SelectableFileTree from "@/components/SelectableFileTree";
 
 import { fetchRemoteTree, addRemoteFileToSample } from "@/server_fetch_utils";
+import { parseUTCDate } from "@/field_utils.js";
 
 export default {
   components: {
@@ -105,7 +106,7 @@ export default {
       var seconds_since_oldest_update = null;
       if ("meta" in response_json) {
         if ("oldest_cache_update" in response_json.meta) {
-          oldest_cache_update = new Date(response_json.meta.oldest_cache_update + "Z");
+          oldest_cache_update = parseUTCDate(response_json.meta.oldest_cache_update);
           seconds_since_oldest_update = (new Date() - oldest_cache_update) / 1000;
           console.log(
             `loadCachedTree received, oldest dir update was ${seconds_since_oldest_update} s ago`,

--- a/webapp/src/components/SampleTable.vue
+++ b/webapp/src/components/SampleTable.vue
@@ -70,6 +70,7 @@ export default {
           icon: ["fa", "file"],
           label: "Files",
         },
+        { field: "last_modified", header: "", label: "Last modified", icon: ["fa", "clock"] },
       ],
     };
   },

--- a/webapp/src/components/StartingMaterialTable.vue
+++ b/webapp/src/components/StartingMaterialTable.vue
@@ -72,6 +72,7 @@ export default {
           icon: ["fa", "file"],
           label: "Files",
         },
+        { field: "last_modified", header: "", label: "Last modified", icon: ["fa", "clock"] },
       ],
     };
   },

--- a/webapp/src/field_utils.js
+++ b/webapp/src/field_utils.js
@@ -2,6 +2,29 @@ import store from "@/store/index.js";
 import { DATETIME_FIELDS } from "@/resources.js";
 
 /**
+ * Parses a server-provided timestamp as UTC.
+ *
+ * Timestamps are stored server-side in UTC. If an ISO string carries no timezone
+ * designator (e.g. legacy data), `new Date(...)` would interpret it in the viewer's
+ * local timezone; this appends a "Z" in that case so it is read as UTC. Strings that
+ * already have an offset (e.g. "+00:00"/"Z") or non-ISO forms (e.g. RFC 1123 "...GMT")
+ * are passed through untouched.
+ *
+ * @param {string} value - A server timestamp string.
+ * @returns {Date} A Date parsed as UTC.
+ */
+export function parseUTCDate(value) {
+  if (
+    typeof value === "string" &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(value) &&
+    !/(Z|[+-]\d{2}:?\d{2})$/.test(value)
+  ) {
+    value += "Z";
+  }
+  return new Date(value);
+}
+
+/**
  * Converts a datetime-local input value to an ISO format string with timezone offset.
  *
  * @param {string} value - The datetime value from a datetime-local input

--- a/webapp/src/main.js
+++ b/webapp/src/main.js
@@ -76,6 +76,7 @@ import {
   faUserFriends,
   faCaretDown,
   faLock,
+  faClock,
 } from "@fortawesome/free-solid-svg-icons";
 import { faPlusSquare } from "@fortawesome/free-regular-svg-icons";
 import { faGithub, faOrcid, faGoogle, faMicrosoft } from "@fortawesome/free-brands-svg-icons";
@@ -152,6 +153,7 @@ library.add(
   faUserFriends,
   faCaretDown,
   faLock,
+  faClock,
 );
 
 // import "@uppy/vue"


### PR DESCRIPTION
Closes #1782
Closes #1758 
Closes #969 

(the latter two by testing it properly).

This PR adds a column to the data tables for last_modified -- it renders it as a human-readable date using `date-fns`, e.g., "2 months ago".

It prevents the last_modified from updating if `save-item` endpoint doens't actually make any change when requested, controlled by whether a new version is minted.

It also saves which columns users could have selected in a table when they choose columns, and if a new column has been added, it shows them by default (rather than hiding it by default).