### PR TITLE
Add option to disable magic link authentication

### DIFF
--- a/pydatalab/docs/config.md
+++ b/pydatalab/docs/config.md
@@ -62,6 +62,9 @@ Third-party options with a free tier include [resend](https://resend.com/), whic
 
 The email addresses that are allowed to sign up can be restricted by domain/subdomain using the [`EMAIL_DOMAIN_ALLOW_LIST`][pydatalab.config.ServerConfig.EMAIL_DOMAIN_ALLOW_LIST] setting.
 
+If SMTP settings are required for notification emails but email magic-link sign-in should be disabled, set [`DISABLE_MAGIC_LINK_AUTH`][pydatalab.config.ServerConfig.DISABLE_MAGIC_LINK_AUTH] to `true`.
+This hides email authentication from the advertised authentication mechanisms and rejects direct requests to generate or consume magic links.
+
 ### OAuth2
 
 OAuth2 allows users to log in using their existing accounts with third-party providers, without the need for a password.

--- a/pydatalab/src/pydatalab/config.py
+++ b/pydatalab/src/pydatalab/config.py
@@ -232,6 +232,11 @@ class ServerConfig(BaseSettings):
         description="A dictionary containing SMTP settings for sending emails for account registration.",
     )
 
+    DISABLE_MAGIC_LINK_AUTH: bool = Field(
+        False,
+        description="Whether to disable magic-link email authentication while retaining SMTP-backed notification emails.",
+    )
+
     MAX_CONTENT_LENGTH: int = Field(
         10 * 1000**3,
         description=r"""Direct mapping to the equivalent Flask setting. In practice, limits the file size that can be uploaded.

--- a/pydatalab/src/pydatalab/feature_flags.py
+++ b/pydatalab/src/pydatalab/feature_flags.py
@@ -81,7 +81,12 @@ def check_feature_flags(app):
             )
             FEATURE_FLAGS.email_notifications = False
 
-        if (
+        if CONFIG.DISABLE_MAGIC_LINK_AUTH:
+            FEATURE_FLAGS.auth_mechanisms.email = False
+            LOGGER.warning(
+                "`CONFIG.DISABLE_MAGIC_LINK_AUTH` is set; email magic-link authentication will not be enabled."
+            )
+        elif (
             CONFIG.EMAIL_DOMAIN_ALLOW_LIST is None or CONFIG.EMAIL_DOMAIN_ALLOW_LIST
         ) and FEATURE_FLAGS.email_notifications:
             FEATURE_FLAGS.auth_mechanisms.email = True

--- a/pydatalab/src/pydatalab/routes/v0_1/auth.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/auth.py
@@ -630,6 +630,9 @@ def find_create_or_modify_user(
 
 
 def _validate_magic_link_request(email: str, referrer: str) -> None:
+    if CONFIG.DISABLE_MAGIC_LINK_AUTH:
+        raise Forbidden("Magic-link authentication is disabled for this datalab instance.")
+
     if not email:
         raise BadRequest("No email provided")
 
@@ -808,6 +811,9 @@ def email_logged_in():
     - Authenticate the user for this session.
 
     """
+    if CONFIG.DISABLE_MAGIC_LINK_AUTH:
+        raise Forbidden("Magic-link authentication is disabled for this datalab instance.")
+
     args = request.args
     token = args.get("token")
     if not token:

--- a/pydatalab/tests/server/test_auth.py
+++ b/pydatalab/tests/server/test_auth.py
@@ -62,6 +62,34 @@ def test_magic_links_expected_failures(unauthenticated_client, app):
         assert len(outbox) == 0
 
 
+def test_magic_link_auth_can_be_disabled(unauthenticated_client, app, database, monkeypatch):
+    from pydatalab import config
+
+    monkeypatch.setattr(config.CONFIG, "DISABLE_MAGIC_LINK_AUTH", True)
+    database.magic_links.delete_many({})
+
+    with app.extensions["mail"].record_messages() as outbox:
+        response = unauthenticated_client.post(
+            "/login/magic-link",
+            json={"email": "test@ml-evs.science", "referrer": "datalab.example.org"},
+        )
+        assert response.status_code == 403
+        assert (
+            response.json["message"]
+            == "Magic-link authentication is disabled for this datalab instance."
+        )
+        assert len(outbox) == 0
+        assert database.magic_links.count_documents({}) == 0
+
+        response = unauthenticated_client.get("/login/email?token=unused")
+        assert response.status_code == 403
+        assert (
+            response.json["message"]
+            == "Magic-link authentication is disabled for this datalab instance."
+        )
+        assert len(outbox) == 0
+
+
 # ──────────────────────────────────────────────
 # GitHub OAuth tests
 # ──────────────────────────────────────────────

--- a/pydatalab/tests/server/test_info_and_health.py
+++ b/pydatalab/tests/server/test_info_and_health.py
@@ -21,6 +21,16 @@ def test_info_endpoint(client, url_prefix, app):
     assert auth["email"] is bool(app.config.get("MAIL_PASSWORD", None))
 
 
+def test_magic_link_auth_feature_flag_can_be_disabled(app, monkeypatch):
+    from pydatalab import config
+    from pydatalab.feature_flags import FEATURE_FLAGS, check_feature_flags
+
+    monkeypatch.setattr(config.CONFIG, "DISABLE_MAGIC_LINK_AUTH", True)
+    check_feature_flags(app)
+    assert FEATURE_FLAGS.email_notifications is True
+    assert FEATURE_FLAGS.auth_mechanisms.email is False
+
+
 def test_landing_page(unauthenticated_client, client):
     """Check that the rudimentary landing page renders without error for both
     unauthenticated and authenticated users."""


### PR DESCRIPTION
Add option to disable magic link authentication while keeping admin notification email enabled.

Fixes #1916 