### PR TITLE
Lower erroneously open permissions of block updates if IDs are known

### DIFF
--- a/pydatalab/docs/blocks/index.md
+++ b/pydatalab/docs/blocks/index.md
@@ -30,10 +30,8 @@ Data blocks are modular components that:
 The block system exposes several API endpoints:
 
 - `/add-data-block/`: Create and add a new block to an item
-- `/add-collection-data-block/`: Create and add a new block to a collection
 - `/update-block/`: Update an existing block's state
 - `/delete-block/`: Remove a block from an item
-- `/delete-collection-block/`: Remove a block from a collection
 
 ## Creating a new block
 

--- a/pydatalab/src/pydatalab/apps/chat/blocks.py
+++ b/pydatalab/src/pydatalab/apps/chat/blocks.py
@@ -56,8 +56,6 @@ class ChatBlock(DataBlock):
     name = "Whinchat assistant"
     accepted_file_extensions = None
 
-    __supports_collections = True
-
     defaults: dict = {
         "system_prompt": """You are whinchat (lowercase w), a virtual data managment assistant that helps materials chemists manage their experimental data and plan experiments. You are deployed in the group of Professor Clare Grey in the Department of Chemistry at the University of Cambridge.
 You are embedded within the program datalab, where you have access to JSON describing an ‘item’, or a collection of items, with connections to other items. These items may include experimental samples, starting materials, and devices (e.g. battery cells made out of experimental samples and starting materials).

--- a/pydatalab/src/pydatalab/blocks/base.py
+++ b/pydatalab/src/pydatalab/blocks/base.py
@@ -130,9 +130,6 @@ class DataBlock:
     plot_functions: Sequence[Callable[[], None]] | None = None
     """A list of methods that will generate plots for this block."""
 
-    _supports_collections: bool = False
-    """Whether this datablock can operate on collection data, or just individual items"""
-
     multi_file: bool = False
     """Whether this block can accept multiple files as input."""
 
@@ -142,15 +139,13 @@ class DataBlock:
     def __init__(
         self,
         item_id: str | None = None,
-        collection_id: str | None = None,
         init_data: dict | None = None,
         unique_id: str | None = None,
     ):
-        """Create a data block object for the given `item_id` or `collection_id`.
+        """Create a data block object for the given `item_id`.
 
         Parameters:
-            item_id: The item to which the block is attached, or
-            collection_id: The collection to which the block is attached.
+            item_id: The item to which the block is attached.
             init_data: A dictionary of data to initialise the block with.
             unique_id: A unique id for the block, used in the DOM and database.
 
@@ -158,16 +153,8 @@ class DataBlock:
         if init_data is None:
             init_data = {}
 
-        if item_id is None and not self._supports_collections:
+        if item_id is None:
             raise RuntimeError(f"Must supply `item_id` to make {self.__class__.__name__}.")
-
-        if collection_id is not None and not self._supports_collections:
-            raise RuntimeError(
-                f"This block ({self.__class__.__name__}) does not support collections."
-            )
-
-        if item_id is not None and collection_id is not None:
-            raise RuntimeError("Must provide only one of `item_id` and `collection_id`.")
 
         LOGGER.debug(
             "Creating new block '%s' associated with item_id '%s'",
@@ -179,7 +166,6 @@ class DataBlock:
         )  # this is supposed to be a unique id for use in html and the database.
         self.data = {
             "item_id": item_id,
-            "collection_id": collection_id,
             "blocktype": self.blocktype,
             "block_id": self.block_id,
             **self.defaults,
@@ -195,10 +181,9 @@ class DataBlock:
             init_data
         )  # this could overwrite blocktype and block_id. I think that's reasonable... maybe
         LOGGER.debug(
-            "Initialised block %s for item ID %s or collection ID %s.",
+            "Initialised block %s for item ID %s",
             self.__class__.__name__,
             item_id,
-            collection_id,
         )
 
     def to_db(self) -> dict:
@@ -326,7 +311,7 @@ class DataBlock:
     @classmethod
     def from_web(cls, data: dict):
         """Initialise the block state from data passed via web request
-        with a given item, collection and block ID.
+        with a given item and block ID.
 
         Parameters:
             data: The block data to initialiaze the block with.
@@ -334,7 +319,6 @@ class DataBlock:
         """
         block = cls(
             item_id=data.get("item_id"),
-            collection_id=data.get("collection_id"),
             unique_id=data["block_id"],
         )
         block.update_from_web(data)

--- a/pydatalab/src/pydatalab/routes/v0_1/blocks.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/blocks.py
@@ -280,69 +280,6 @@ def add_data_block():
     )
 
 
-@BLOCKS.route("/add-collection-data-block/", methods=["POST"])
-def add_collection_data_block():
-    """Call with AJAX to add a block to the collection."""
-
-    request_json = request.get_json()
-
-    # pull out required arguments from json
-    block_type = request_json["block_type"]
-    collection_id = request_json["collection_id"]
-    insert_index = request_json["index"]
-
-    if block_type not in BLOCK_TYPES:
-        raise NotImplemented(  # noqa
-            f"Invalid block type {block_type!r}, must be one of {BLOCK_TYPES.keys()}"
-        )
-
-    block = BLOCK_TYPES[block_type](collection_id=collection_id)
-
-    data = block.to_db()
-
-    # currently, adding to both blocks and blocks_obj to mantain compatibility with
-    # the old site. The new site only uses blocks_obj
-    if insert_index:
-        display_order_update = {
-            "$each": [block.block_id],
-            "$position": insert_index,
-        }
-    else:
-        display_order_update = block.block_id
-
-    result = flask_mongo.db.collections.update_one(
-        {"collection_id": collection_id, **get_default_permissions(user_only=True)},
-        {
-            "$push": {"blocks": data, "display_order": display_order_update},
-            "$set": {f"blocks_obj.{block.block_id}": data},
-        },
-    )
-
-    if result.modified_count < 1:
-        return (
-            jsonify(
-                status="error",
-                message=f"Update failed. {collection_id=} is probably incorrect.",
-            ),
-            400,
-        )
-
-    # get the new display_order:
-    display_order_result = flask_mongo.db.collections.find_one(
-        {"collection_id": collection_id, **get_default_permissions(user_only=True)},
-        {"display_order": 1},
-    )
-
-    return jsonify(
-        status="success",
-        new_block_obj=block.to_web(),
-        new_block_insert_index=insert_index
-        if insert_index is None
-        else len(display_order_result["display_order"]) - 1,
-        new_display_order=display_order_result["display_order"],
-    )
-
-
 def _save_block_to_db(block: DataBlock):
     """Save data for a single block within an item to the database,
     overwriting previous data saved there.
@@ -354,22 +291,16 @@ def _save_block_to_db(block: DataBlock):
     updated_block = block.to_db()
     update = {"$set": {f"blocks_obj.{block.block_id}": updated_block}}
 
-    if block.data.get("collection_id"):
-        match = {
-            "collection_id": block.data["collection_id"],
-            f"blocks_obj.{block.block_id}": {"$exists": True},
-        }
-        result = flask_mongo.db.collections.update_one(match, update)
-    else:
-        match = {
-            "item_id": block.data["item_id"],
-            f"blocks_obj.{block.block_id}": {"$exists": True},
-        }
-        result = flask_mongo.db.items.update_one(match, update)
+    match = {
+        "item_id": block.data["item_id"],
+        f"blocks_obj.{block.block_id}": {"$exists": True},
+        **get_default_permissions(user_only=True),
+    }
+    result = flask_mongo.db.items.update_one(match, update)
 
     if result.matched_count != 1:
         raise BadRequest(
-            f"Failed to save block, likely because item_id ({block.data.get('item_id')}), collection_id ({block.data.get('collection_id')}) and/or block_id ({block.block_id}) wasn't found"
+            f"Failed to save block, likely because item_id ({block.data.get('item_id')}), and/or block_id ({block.block_id}) wasn't found"
         )
 
 
@@ -512,44 +443,6 @@ def delete_block():
         jsonify({"status": "success"}),
         200,
     )  # could try to switch to http 204 is "No Content" success with no json
-
-
-@BLOCKS.route("/delete-collection-block/", methods=["POST"])
-def delete_collection_block():
-    """Completely delete a data block from the database that is currently
-    attached to a collection.
-
-    In the future, we may consider preserving data by moving it to a different array,
-    or simply making it invisible"""
-    request_json = request.get_json()
-    collection_id = request_json["collection_id"]
-    block_id = request_json["block_id"]
-
-    result = flask_mongo.db.collections.update_one(
-        {"collection_id": collection_id, **get_default_permissions(user_only=True)},
-        {
-            "$pull": {
-                "blocks": {"block_id": block_id},
-                "display_order": block_id,
-            },
-            "$unset": {f"blocks_obj.{block_id}": ""},
-        },
-    )
-
-    if result.modified_count < 1:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "message": f"Update failed. The collection_id probably incorrect: {collection_id}",
-                }
-            ),
-            400,
-        )
-    return (
-        jsonify({"status": "success"}),
-        200,
-    )
 
 
 @BLOCKS.route("/blocks/<string:task_id>/status", methods=["GET"])

--- a/pydatalab/src/pydatalab/routes/v0_1/blocks.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/blocks.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 import gridfs
 from flask import Blueprint, jsonify, request
 from flask_login import current_user, login_user
-from werkzeug.exceptions import BadRequest, NotImplemented
+from werkzeug.exceptions import BadRequest, NotFound, NotImplemented
 
 from pydatalab.apps import BLOCK_TYPES
 from pydatalab.blocks.base import DataBlock
@@ -391,6 +391,15 @@ def update_block():
         raise NotImplemented(  # noqa: F901
             f"Invalid block type {block_type!r}, must be one of {BLOCK_TYPES.keys()}"
         )
+
+    item_id = block_data.get("item_id")
+    if not item_id:
+        raise BadRequest(f"Invalid or missing item_id: {item_id}")
+
+    if not flask_mongo.db.items.find_one(
+        {"item_id": item_id, **get_default_permissions(user_only=True)}
+    ):
+        raise NotFound(f"Item with item_id {item_id} not found or not accessible")
 
     block = BLOCK_TYPES[block_type].from_web(block_data)
 

--- a/pydatalab/tests/server/test_blocks.py
+++ b/pydatalab/tests/server/test_blocks.py
@@ -120,7 +120,10 @@ def test_add_multiple_blocks_to_sample(admin_client, default_sample_dict):
 
 
 def test_block_permissions(client, admin_client, unauthenticated_client, default_sample_dict):
-    """Test that normal users can add blocks to samples they have access to, but unauthenticated users cannot."""
+    """Test that normal users can add blocks to samples they have access to, but unauthenticated users cannot,
+    and that another user cannot update another user's block if they know the IDs.
+
+    """
     sample_id = "test_sample_user_permissions"
     sample_data = default_sample_dict.copy()
     sample_data["item_id"] = sample_id
@@ -163,6 +166,54 @@ def test_block_permissions(client, admin_client, unauthenticated_client, default
         },
     )
     assert response.status_code == 401
+
+    sample_id = "test_sample_admin_permissions"
+    sample_data = default_sample_dict.copy()
+    sample_data["item_id"] = sample_id
+
+    # Create sample with normal user
+    response = admin_client.post("/new-sample/", json=sample_data)
+    assert response.status_code == 201
+
+    block_type = list(BLOCK_TYPES.keys())[0]
+
+    response = admin_client.post(
+        "/add-data-block/",
+        json={
+            "block_type": block_type,
+            "item_id": sample_id,
+            "index": 0,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json["status"] == "success"
+    block_id = response.json["new_block_obj"]["block_id"]
+
+    response = admin_client.post(
+        "/update-block/",
+        json={
+            "block_data": {
+                "block_id": block_id,
+                "item_id": sample_id,
+                "blocktype": block_type,
+                "freeform_comment": "Admin updated comment",
+            }
+        },
+    )
+
+    bad_response = client.post(
+        "/update-block/",
+        json={
+            "block_data": {
+                "block_id": block_id,
+                "item_id": sample_id,
+                "blocktype": block_type,
+                "freeform_comment": "User updated comment",
+            }
+        },
+    )
+
+    assert bad_response.status_code == 404
 
 
 def test_add_block_to_nonexistent_item(admin_client):


### PR DESCRIPTION
Closes #1912
Closes #1919

The proper fix is #48 and related changes but we need this in now. Likely we should add a test that also does this for an async task block, though the guard is added at the start of the route. I've also removed the leftover code for creating blocks that pertain to collections, as this has the same issue, but is harder to fix, and no block was even using this code properly.