### PR TITLE
Fixed editing of roles (UI)

### DIFF
--- a/webapp/src/components/UserRoleCell.vue
+++ b/webapp/src/components/UserRoleCell.vue
@@ -1,3 +1,4 @@
+<!-- This file was edited with the assistance of an AI model and requires human review from the contributor. -->
 <template>
   <div class="role-cell-wrapper">
     <vSelect
@@ -80,7 +81,12 @@ export default {
       }
     },
     async handleRoleChange(newRole) {
-      const originalRole = this.localRole;
+      const originalRole = this.user?.role || "user";
+
+      if (newRole === originalRole) {
+        this.localRole = originalRole;
+        return;
+      }
 
       if (originalRole === "admin" && newRole !== "admin") {
         const confirmed = await DialogService.confirm({

--- a/webapp/src/components/UserRoleCell.vue
+++ b/webapp/src/components/UserRoleCell.vue
@@ -1,4 +1,3 @@
-<!-- This file was edited with the assistance of an AI model and requires human review from the contributor. -->
 <template>
   <div class="role-cell-wrapper">
     <vSelect

--- a/webapp/src/components/UserRoleCell.vue
+++ b/webapp/src/components/UserRoleCell.vue
@@ -87,18 +87,6 @@ export default {
         return;
       }
 
-      if (originalRole === "admin" && newRole !== "admin") {
-        const confirmed = await DialogService.confirm({
-          title: "Change Admin Role",
-          message: `Are you sure you want to remove admin privileges from ${this.user.display_name}?`,
-          type: "warning",
-        });
-        if (!confirmed) {
-          this.localRole = originalRole;
-          return;
-        }
-      }
-
       const confirmed = await DialogService.confirm({
         title: "Change User Role",
         message: `Are you sure you want to change ${this.user.display_name}'s role from "${originalRole}" to "${newRole}"?`,


### PR DESCRIPTION
In the admin menu, when changing the role for a user from one role to another, it says "Are you sure .... from "admin" to "admin". It repeats the "final" role. Also, if we do Cancel, the role seems to be changed in the UI but it's actually not (which is normal, it should not be changed if we do Cancel). When we refresh the page then the correct role is shown (i.e. the one that hasn't changed).

This PR fixes this small UI issue.