### PR TITLE
Fix tz-naive datetime for certain routes

### DIFF
--- a/pydatalab/src/pydatalab/utils/__init__.py
+++ b/pydatalab/src/pydatalab/utils/__init__.py
@@ -42,7 +42,17 @@ class CustomJSONEncoder(JSONEncoder):
 
     @staticmethod
     def default(o):
-        if isinstance(o, (datetime.date, datetime.datetime)):
+        if isinstance(o, datetime.datetime):
+            # MongoDB stores datetimes as UTC instants. With PyMongo's default
+            # tz_aware=False, those values are returned as naive datetimes even though
+            # they represent UTC. We attach UTC here so the serialized ISO 8601 string
+            # includes an explicit offset, matching the assumption made in
+            # IsoformatDateTime.validate.
+            if o.tzinfo is None:
+                o = o.replace(tzinfo=datetime.timezone.utc)
+            return o.isoformat()
+
+        elif isinstance(o, datetime.date):
             return o.isoformat()
 
         elif isinstance(o, ObjectId):

--- a/pydatalab/tests/server/test_equipment.py
+++ b/pydatalab/tests/server/test_equipment.py
@@ -106,6 +106,50 @@ def test_save_good_equipment(client, default_equipment_dict):
             assert response.json[key] == updated_equipment[key]
 
 
+def test_get_equipment_summary_naive_datetime_serialized_as_utc(client, database):
+    """Regression test for `CustomJSONEncoder`/`BSONProvider`: MongoDB has no
+    timezone concept (BSON dates are plain UTC instants), so `pymongo.MongoClient`
+    (not configured with `tz_aware=True`) always reads dates back as *naive*
+    Python datetimes -- with no intervening Pydantic validation, e.g. via
+    `get_equipment_summary`'s raw aggregation -- regardless of whether the value
+    was originally written as tz-aware. The encoder must assume UTC for such
+    naive datetimes before calling `.isoformat()`, otherwise the serialized
+    string carries no timezone offset and clients (e.g. JS `Date` parsing)
+    misinterpret it as local time.
+    """
+    aware_date = datetime.datetime(2026, 7, 15, 14, 30, 0, 123000, tzinfo=datetime.timezone.utc)
+
+    database.items.insert_one(
+        {
+            "item_id": "test_naive_datetime_equipment",
+            "type": "equipment",
+            "date": aware_date,
+            "refcode": "test:NAIVEDATETIME",
+            "status": None,
+        }
+    )
+
+    try:
+        # Confirm the premise: pymongo hands back a naive datetime even though
+        # `aware_date` was tz-aware when written.
+        raw_doc = database.items.find_one({"item_id": "test_naive_datetime_equipment"})
+        assert raw_doc["date"].tzinfo is None
+
+        response = client.get("/equipment/")
+        assert response.status_code == 200
+
+        entry = next(
+            item
+            for item in response.json["items"]
+            if item["item_id"] == "test_naive_datetime_equipment"
+        )
+        # The serialized date must carry an explicit UTC offset/designator, matching
+        # the original tz-aware value.
+        assert entry["date"] == aware_date.isoformat()
+    finally:
+        database.items.delete_one({"item_id": "test_naive_datetime_equipment"})
+
+
 @pytest.mark.dependency(depends=["test_new_equipment"])
 def test_delete_equipment(admin_client, default_equipment_dict):
     """For now, only admins can delete equipment."""

--- a/pydatalab/tests/server/test_item_versions.py
+++ b/pydatalab/tests/server/test_item_versions.py
@@ -156,6 +156,40 @@ class TestListVersions:
         assert "action" in version
         assert version["action"] == "manual_save"
 
+    def test_list_versions_timestamp_serialized_as_utc(self, client, sample_with_version):
+        """Regression test for `CustomJSONEncoder`/`BSONProvider`: `list_versions`
+        returns `timestamp` straight from a raw `item_versions` aggregation, with
+        no intervening Pydantic validation. `save_version_snapshot` writes a
+        tz-aware `datetime.now(tz=utc)` for `timestamp`, but MongoDB has no
+        timezone concept -- it stores dates as plain UTC instants -- so pymongo
+        (not configured with `tz_aware=True`) always reads dates back as *naive*
+        Python datetimes, regardless of what tzinfo was set when they were
+        written. The encoder must assume UTC for such naive datetimes before
+        calling `.isoformat()`, otherwise the serialized string carries no
+        timezone offset and clients (e.g. JS `Date` parsing) misinterpret it as
+        local time.
+        """
+        import datetime
+
+        from pydatalab.mongo import flask_mongo
+
+        refcode = sample_with_version.refcode.split(":")[1]
+        client.post(f"/items/{refcode}/save-version/")
+
+        # Confirm the premise: pymongo hands back a naive datetime for a field
+        # that was written as tz-aware, since BSON dates carry no tzinfo.
+        raw_version = flask_mongo.db.item_versions.find_one(
+            {"refcode": sample_with_version.refcode}
+        )
+        assert raw_version["timestamp"].tzinfo is None
+
+        response = client.get(f"/items/{refcode}/versions/")
+        timestamp = response.json["versions"][0]["timestamp"]
+
+        assert (
+            timestamp == raw_version["timestamp"].replace(tzinfo=datetime.timezone.utc).isoformat()
+        )
+
 
 class TestGetVersion:
     """Tests for the get_version endpoint."""


### PR DESCRIPTION
MongoDB stores datetimes as UTC instants, but pymongo doesn't attach that timezone information back onto the datetime objects it returns — they come back naive (tzinfo=None), regardless of whether the value was originally written as timezone-aware.

Most routes have a pydantic model validation stage where naive datetimes have utc reattached if there is no timezone info. Some routes don't have a pydantic model validator and are simply aggregations, so the datetimes are serialised as is. Frontend code that parses this string with new Date(...) then interprets it as local time rather than UTC, showing the wrong time to any user not in UTC.

Routes found affected:
- get_equipment_summary (/equipment/)
- list_versions (/items/<refcode>/versions/, backing the version history modal)

This fix makes CustomJSONEncoder assume UTC for any naive datetime before serializing it, matching what the Pydantic validator already does — so the same fix also protects any other raw/unvalidated route that haven't been specifically identified.

If you want to recreate the bug in the UI, in a timezone that isn't utc save a version, the version history modal then won't say "a few minutes ago" it will be however many hours your timezone is that isn't utc.

Another potential fix: pymongo.MongoClient has a tz_aware=True option, so every datetime read from the db would come back with timezone information attached. Maybe something to discuss as this could affect more code