### PR TITLE
Add docker development environment and CI coverage

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -31,7 +31,6 @@ RUN apt update \
         xauth \
         xvfb \
     && rm -rf /var/lib/apt/lists/*
-COPY webapp ./
 
 # build target: runs the production webpack bundle. Derives from `base` rather
 # than `dev` so production builds don't pull in the Cypress system libraries.

--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:22.22-bullseye-slim AS build
+FROM node:22.22-bullseye-slim AS base
 SHELL ["/bin/bash", "--login", "-c"]
 
 WORKDIR /app
@@ -13,6 +13,30 @@ COPY webapp/package.json webapp/yarn.lock ./
 # Using a custom node_modules location to avoid mounting it outside of docker
 RUN --mount=type=cache,target=/root/.cache/yarn yarn install --frozen-lockfile --modules-folder /node_modules
 
+# dev target: deps installed, source mounted at runtime — no production build.
+# Also installs the system libraries the Cypress test runner needs (GTK/X11
+# runtime libs plus xvfb for a virtual display), so the webapp test suites can
+# run inside the container.
+FROM base AS dev
+RUN apt update \
+    && apt install -y --no-install-recommends \
+        libgtk2.0-0 \
+        libgtk-3-0 \
+        libgbm-dev \
+        libnotify-dev \
+        libnss3 \
+        libxss1 \
+        libasound2 \
+        libxtst6 \
+        xauth \
+        xvfb \
+    && rm -rf /var/lib/apt/lists/*
+COPY webapp ./
+
+# build target: runs the production webpack bundle. Derives from `base` rather
+# than `dev` so production builds don't pull in the Cypress system libraries.
+FROM base AS build
+COPY webapp ./
 # These get replaced by the entrypoint script for production builds.
 # Set the real values in `.env` files or an external docker-compose.
 ENV NODE_ENV=production
@@ -28,7 +52,6 @@ ARG VUE_APP_AUTOMATICALLY_GENERATE_ID_DEFAULT=magic-generate-id-setting
 ARG VUE_APP_GIT_VERSION=0.0.0+ci
 ENV VUE_APP_GIT_VERSION=${VUE_APP_GIT_VERSION}
 
-COPY webapp ./
 RUN /node_modules/.bin/vue-cli-service build
 
 FROM node:22.22-bullseye-slim AS production

--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -32,6 +32,10 @@ RUN apt update \
         xvfb \
     && rm -rf /var/lib/apt/lists/*
 
+CMD [ "/node_modules/.bin/vue-cli-service", "serve", "--host", "0.0.0.0", "--port", "8081" ]
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 CMD node -e "fetch('http://localhost:8081').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+
 # build target: runs the production webpack bundle. Derives from `base` rather
 # than `dev` so production builds don't pull in the Cypress system libraries.
 FROM base AS build

--- a/.docker/server/Dockerfile
+++ b/.docker/server/Dockerfile
@@ -1,7 +1,7 @@
 ARG UV_VERSION="0.11.8"
 FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_image
 
-FROM python:3.11-slim-trixie AS api
+FROM python:3.11-slim-trixie AS build
 ARG TARGETARCH
 SHELL ["/bin/bash", "--login", "-c"]
 
@@ -67,11 +67,21 @@ RUN git config --global --add safe.directory /
 # a `.git` bind mount, so this layer doesn't invalidate on every commit.
 RUN uv pip install --python /opt/.venv/bin/python --no-deps --editable .
 
+
+FROM build as dev
+# Hot-reloading dev server
+
+ENV PORT=5001
+CMD ["/opt/.venv/bin/invoke", "dev.serve", "--host", "0.0.0.0", "--port", "${PORT}"]
+HEALTHCHECK --interval=30s --timeout=30s --start-interval=15s --start-period=30s --retries=3 CMD curl --fail http://localhost:${PORT}/healthcheck/is_ready || exit 1
+
+FROM build as api
+# Production gunicorn server
+
 # Define some default gunicorn runtime args
 ENV WEB_CONCURRENCY=4
 ENV GUNICORN_CMD_ARGS="--preload --timeout 120 --graceful-timeout 90"
 ENV PORT=5001
 
 CMD ["/bin/bash", "-c", "/opt/.venv/bin/python -m gunicorn -b 0.0.0.0:${PORT} -w ${WEB_CONCURRENCY} ${GUNICORN_CMD_ARGS} 'pydatalab.main:create_app()'"]
-
 HEALTHCHECK --interval=30s --timeout=30s --start-interval=15s --start-period=30s --retries=3 CMD curl --fail http://localhost:${PORT}/healthcheck/is_ready || exit 1

--- a/.docker/server/Dockerfile
+++ b/.docker/server/Dockerfile
@@ -68,14 +68,14 @@ RUN git config --global --add safe.directory /
 RUN uv pip install --python /opt/.venv/bin/python --no-deps --editable .
 
 
-FROM build as dev
+FROM build AS dev
 # Hot-reloading dev server
 
 ENV PORT=5001
-CMD ["/opt/.venv/bin/invoke", "dev.serve", "--host", "0.0.0.0", "--port", "${PORT}"]
+CMD ["/bin/bash", "-c", "/opt/.venv/bin/invoke dev.serve --host 0.0.0.0 --port ${PORT}"]
 HEALTHCHECK --interval=30s --timeout=30s --start-interval=15s --start-period=30s --retries=3 CMD curl --fail http://localhost:${PORT}/healthcheck/is_ready || exit 1
 
-FROM build as api
+FROM build AS api
 # Production gunicorn server
 
 # Define some default gunicorn runtime args

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,63 @@ jobs:
           # Test that plugin block is listed in info endpoint
           curl -s http://localhost:5000/info/blocks | jq '.data | any(.id == "example")'
 
+  docker-dev:
+    name: Test dev Docker builds
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Validate Docker Compose configuration
+        run: docker compose config --quiet
+
+      - name: Build dev Docker images
+        uses: docker/bake-action@v7
+        with:
+          files: docker-compose.yml
+          load: true
+          source: .
+          targets: "app-dev,api-dev,database-dev"
+          set: |
+            app-dev.cache-from=type=gha,scope=${{ github.ref_name }}-build-app-dev
+            app-dev.cache-from=type=gha,scope=main-build-app-dev
+            app-dev.cache-to=type=gha,scope=${{ github.ref_name }}-build-app-dev,mode=max
+            api-dev.cache-from=type=gha,scope=${{ github.ref_name }}-build-api
+            api-dev.cache-from=type=gha,scope=main-build-api
+            database-dev.cache-from=type=gha,scope=${{ github.ref_name }}-build-database
+            database-dev.cache-from=type=gha,scope=main-build-database
+            api-dev.args.SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0+ci
+            app-dev.tags=datalab-app-dev:latest
+            api-dev.tags=datalab-api-dev:latest
+            database-dev.tags=datalab-database-dev:latest
+
+      - name: Start dev services
+        run: |
+          # Boot the hot-reloading dev profile and block on healthchecks
+          # (webpack dev server compiled, API answering /healthcheck/is_ready).
+          docker compose --profile dev up --no-build --force-recreate -d --wait
+
+      - name: Check the dev API and app respond
+        run: |
+          curl --fail http://localhost:5001/healthcheck/is_ready
+          curl --fail --silent --output /dev/null http://localhost:8081
+
+      - name: Show dev service diagnostics
+        if: failure()
+        run: |
+          docker compose --profile dev logs
+          docker compose --profile dev ps
+
+      - name: Stop dev services
+        if: always()
+        run: docker compose --profile dev down --volumes
+
   e2e:
     name: e2e tests
     runs-on: ubuntu-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,82 @@ services:
     networks:
       - backend
 
+  # ---------------------------------------------------------------------------
+  # Development services (`docker compose --profile dev up`).
+  #
+  # These give a hot-reloading, source-mounted environment for local
+  # development.
+  # ---------------------------------------------------------------------------
+  database-dev:
+    profiles: ["dev"]
+    build:
+      context: .
+      dockerfile: .docker/mongo/Dockerfile
+    volumes:
+      - datalab-dev-dbdata:/data/db
+    ports:
+      # Published on host port 27018 to avoid clashing with a
+      # developer's native MongoDB.
+      - "27018:27017"
+    networks:
+      - backend
+
+  api-dev:
+    profiles: ["dev"]
+    build:
+      context: .
+      dockerfile: .docker/server/Dockerfile
+      target: api
+    command: ["/opt/.venv/bin/invoke", "dev.serve", "--host", "0.0.0.0", "--port", "5001"]
+    depends_on:
+      - database-dev
+    volumes:
+      - ./pydatalab:/app
+      - datalab-dev-files:/app/files
+    ports:
+      - "5001:5001"
+    networks:
+      - backend
+    environment:
+      - PYDATALAB_MONGO_URI=mongodb://database-dev:27017/${DATALAB_DB_NAME:-datalabvue}
+      - PYDATALAB_FILE_DIRECTORY=/app/files
+
+  app-dev:
+    profiles: ["dev"]
+    build:
+      context: .
+      dockerfile: .docker/app/Dockerfile
+      target: dev
+    command:
+      ["/node_modules/.bin/vue-cli-service", "serve", "--host", "0.0.0.0", "--port", "8081"]
+    volumes:
+      - ./webapp:/app
+    ports:
+      - "8081:8081"
+    environment:
+      - NODE_ENV=development
+      - VUE_APP_API_URL=${VUE_APP_API_URL:-http://localhost:5001}
+      - CHOKIDAR_USEPOLLING=${CHOKIDAR_USEPOLLING:-true}
+    healthcheck:
+      # The dev image has no HEALTHCHECK (that lives in the production stage);
+      # this lets `docker compose up --wait` (used in CI) block until the
+      # webpack dev server has compiled and is serving.
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://localhost:8081').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))",
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 180s
+
 networks:
   backend:
     driver: bridge
+
+volumes:
+  datalab-dev-dbdata:
+  datalab-dev-files:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@ services:
     environment:
       - NODE_ENV=development
       - VUE_APP_API_URL=${VUE_APP_API_URL:-http://localhost:5001}
-      - CHOKIDAR_USEPOLLING=${CHOKIDAR_USEPOLLING:-true}
+      - CHOKIDAR_USEPOLLING=true
     healthcheck:
       # The dev image has no HEALTHCHECK (that lives in the production stage);
       # this lets `docker compose up --wait` (used in CI) block until the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
     networks:
       - backend
     environment:
-      - PYDATALAB_MONGO_URI=mongodb://database-dev:27017/${DATALAB_DB_NAME:-datalabvue}
+      - PYDATALAB_MONGO_URI=mongodb://database-dev:27017/datalabvue
       - PYDATALAB_FILE_DIRECTORY=/app/files
 
   app-dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,8 +82,7 @@ services:
     build:
       context: .
       dockerfile: .docker/server/Dockerfile
-      target: api
-    command: ["/opt/.venv/bin/invoke", "dev.serve", "--host", "0.0.0.0", "--port", "5001"]
+      target: dev
     depends_on:
       - database-dev
     volumes:
@@ -103,8 +102,6 @@ services:
       context: .
       dockerfile: .docker/app/Dockerfile
       target: dev
-    command:
-      ["/node_modules/.bin/vue-cli-service", "serve", "--host", "0.0.0.0", "--port", "8081"]
     volumes:
       - ./webapp:/app
     ports:
@@ -113,21 +110,6 @@ services:
       - NODE_ENV=development
       - VUE_APP_API_URL=${VUE_APP_API_URL:-http://localhost:5001}
       - CHOKIDAR_USEPOLLING=true
-    healthcheck:
-      # The dev image has no HEALTHCHECK (that lives in the production stage);
-      # this lets `docker compose up --wait` (used in CI) block until the
-      # webpack dev server has compiled and is serving.
-      test:
-        [
-          "CMD",
-          "node",
-          "-e",
-          "fetch('http://localhost:8081').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))",
-        ]
-      interval: 15s
-      timeout: 5s
-      retries: 3
-      start_period: 180s
 
 networks:
   backend:

--- a/pydatalab/docs/INSTALL.md
+++ b/pydatalab/docs/INSTALL.md
@@ -30,6 +30,29 @@ If you are not familiar with `git` or GitHub, you can do worse than reading thro
 
 Your local development *datalab* can be configured with all the options as a real *datalab*; these are expected in the same places as described in [Server configuration](https://docs.datalab-org.io/en/latest/config/), and can be set with environment variables or a config file, with additional config and secrets provided in `.env` files in the `pydatalab/`  and `webapp/` directories for development purposes.
 
+### Docker development environment
+
+The complete development stack can be run with Docker Compose:
+
+```shell
+docker compose --profile dev up --build
+```
+
+This starts the web app at [http://localhost:8081](http://localhost:8081), the API at
+[http://localhost:5001](http://localhost:5001), and MongoDB at
+`mongodb://localhost:27018`. Changes under `pydatalab/` and `webapp/` are
+bind-mounted into the containers and trigger the respective development servers to reload.
+
+The development database and uploaded files are stored in separate Docker volumes. To use
+a different database name, set `DATALAB_DB_NAME` when starting the stack, for example:
+
+```shell
+DATALAB_DB_NAME=my-project docker compose --profile dev up
+```
+
+Stop the stack with `docker compose --profile dev down`. Add `--volumes` to also remove its
+development database and uploaded files.
+
 ### `pydatalab` server installation
 
 The instructions in this section will leave you with a running *datalab* server on your host machine, as implemented in the `pydatalab` Python package.

--- a/pydatalab/docs/INSTALL.md
+++ b/pydatalab/docs/INSTALL.md
@@ -43,17 +43,10 @@ This starts the web app at [http://localhost:8081](http://localhost:8081), the A
 `mongodb://localhost:27018`. Changes under `pydatalab/` and `webapp/` are
 bind-mounted into the containers and trigger the respective development servers to reload.
 
-After connection, you can make yourself admin with the command
+After registration, you can make yourself admin with the command
 ```shell
 docker compose exec api-dev /opt/.venv/bin/invoke admin.change-user-role \
   --display-name "Your Name" --role admin
-```
-
-The development database and uploaded files are stored in separate Docker volumes. To use
-a different database name, set `DATALAB_DB_NAME` when starting the stack, for example:
-
-```shell
-DATALAB_DB_NAME=my-project docker compose --profile dev up
 ```
 
 Stop the stack with `docker compose --profile dev down`. Add `--volumes` to also remove its

--- a/pydatalab/docs/INSTALL.md
+++ b/pydatalab/docs/INSTALL.md
@@ -43,6 +43,12 @@ This starts the web app at [http://localhost:8081](http://localhost:8081), the A
 `mongodb://localhost:27018`. Changes under `pydatalab/` and `webapp/` are
 bind-mounted into the containers and trigger the respective development servers to reload.
 
+After connection, you can make yourself admin with the command
+```shell
+docker compose exec api-dev /opt/.venv/bin/invoke admin.change-user-role \
+  --display-name "Your Name" --role admin
+```
+
 The development database and uploaded files are stored in separate Docker volumes. To use
 a different database name, set `DATALAB_DB_NAME` when starting the stack, for example:
 

--- a/pydatalab/docs/INSTALL.md
+++ b/pydatalab/docs/INSTALL.md
@@ -30,6 +30,11 @@ If you are not familiar with `git` or GitHub, you can do worse than reading thro
 
 Your local development *datalab* can be configured with all the options as a real *datalab*; these are expected in the same places as described in [Server configuration](https://docs.datalab-org.io/en/latest/config/), and can be set with environment variables or a config file, with additional config and secrets provided in `.env` files in the `pydatalab/`  and `webapp/` directories for development purposes.
 
+There are two main options for creating a local installation:
+
+1) Natively on your host machine, with a Python virtual environment for the server and Node.js for the web app.
+2) Using Docker, which is the recommended approach for development and testing.
+
 ### Docker development environment
 
 The complete development stack can be run with Docker Compose:
@@ -52,11 +57,13 @@ docker compose exec api-dev /opt/.venv/bin/invoke admin.change-user-role \
 Stop the stack with `docker compose --profile dev down`. Add `--volumes` to also remove its
 development database and uploaded files.
 
-### `pydatalab` server installation
+### Native installation
+
+#### `pydatalab` server installation
 
 The instructions in this section will leave you with a running *datalab* server on your host machine, as implemented in the `pydatalab` Python package.
 
-#### Database installation
+##### Database installation
 
 *datalab* uses MongoDB as its database backend.
 This requires a MongoDB server to be running on your desired host machine.
@@ -67,13 +74,13 @@ This requires a MongoDB server to be running on your desired host machine.
     * You will need to ensure that MongoDB is running (rather than just installed) -- either run manually each time you run the `pydatalab` server set up MongoDB to run as a service on your computer.
     * If you wish to view the database directly, MongoDB has several GUIs, e.g. [MongoDB Compass](https://www.mongodb.com/products/compass) or [Studio 3T](https://robomongo.org/).
 
-#### Python setup
+##### Python setup
 
 The next step is to set up a Python environment that contains all of the required dependencies with the correct versions.
 The currently supported versions are 3.10 and 3.11; you can find the full list of supported versions in the `pyproject.toml` file.
 We strongly recommend using a tool to manage Python versions on your machine, to avoid breakages based on your OS's Python versioning (e.g., [`uv`](https://github.com/astral-sh/uv)).
 
-##### Installation with `uv` or `venv`
+###### Installation with `uv` or `venv`
 
 We recommend using [`uv`](https://github.com/astral-sh/uv) (see the linked repository or the [uv documentation](https://docs.astral.sh/uv) for installation instructions) for managing your *datalab* installation.
 
@@ -102,7 +109,7 @@ You could also use the standard library `venv` module, but this will not allow y
     pip install -e '.[all]'
     ```
 
-##### Installing with plugins
+###### Installing with plugins
 
 If you would like to install *datalab* together with one or more plugins (e.g., custom data blocks from a third-party repository or a local checkout), create a `plugins.toml` file at the root of the repository (alongside `pydatalab/` and `webapp/`) declaring the plugin packages and their sources, then run:
 
@@ -115,7 +122,7 @@ This merges `plugins.toml` into a working copy of `pyproject.toml` under `./buil
 
 See the [plugins documentation](plugins.md) for the `plugins.toml` format and a full description of the install procedure.
 
-#### Running the development server
+###### Running the development server
 
 1. Run the server from the `pydatalab` folder with either:
 
@@ -152,13 +159,13 @@ Should you wish to contribute to/modify the Python code, you may wish to perform
     - The hooks that run on each commit can be found in the top-level `.pre-commit-config.yml` file.
 1. From an activated virtual environment, the tests on the Python code can be run by executing `pytest` from the `pydatalab/` folder (or `uv run pytest`).
 
-#### Additional notes
+##### Additional notes
 
 - If the Flask server is running when the source code is changed, it will generally hot-reload without needing to manually restart the server.
 This can be controlled with the `--reload` flag to the `flask run` command.
 - You may have to set `MONGO_URI` in your config file or environment variables (`PYDATALAB_MONGO_URI`) depending on your MongoDB setup, to e.g., `PYDATALAB_MONGO_URI=mongodb://localhost:27017/datalabvue`.
 
-### Web app
+#### Web app
 
 1. If you do not already have it, install `node.js` and the Node Package Manager (`npm`).
 It is recommended not to install node using the official installer, since it is difficult to manage multiple versions or uninstall, and permissions issues may arise.
@@ -170,7 +177,7 @@ From this point on, the `npm` command is not needed - all package and script man
 3. Navigate to the `webapp/` directory in your local copy of this repository and run `yarn install` (requires ~400 MB of disk space).
 4. Run the webapp from a development server with `yarn serve`.
 
-#### Additional notes
+##### Additional notes
 
 Similar to the Flask development server, these steps will provide a development environment that serves the web app at [http://localhost:8081](http://localhost:8081) (by default) and automatically reloads it as changes are made to the source code.
 

--- a/pydatalab/mkdocs.yml
+++ b/pydatalab/mkdocs.yml
@@ -70,7 +70,7 @@ markdown_extensions:
       normalize_issue_symbols: true
   - toc:
       permalink: true
-      toc_depth: 2
+      toc_depth: 3
 
 extra_css:
   - css/reference.css


### PR DESCRIPTION
This PR extracts the Docker development environment and CI coverage from https://github.com/datalab-org/datalab/pull/1845 so they can be reviewed independently from environment-variable handling and seed snapshots.