### PR TITLE
Add nominal capacity to cell

### DIFF
--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -196,6 +196,30 @@
       "title": "Active Ion Charge",
       "default": 1,
       "type": "number"
+    },
+    "theoretical_capacity": {
+      "title": "Theoretical Capacity",
+      "type": "number"
+    },
+    "theoretical_capacity_unit": {
+      "title": "Theoretical Capacity Unit",
+      "default": "mAh/g",
+      "pattern": "^(mAh/g|mAh/kg)$",
+      "type": "string"
+    },
+    "nominal_capacity_unit": {
+      "title": "Nominal Capacity Unit",
+      "default": "mAh",
+      "pattern": "^(mAh|Ah)$",
+      "type": "string"
+    },
+    "nominal_capacity": {
+      "title": "Nominal Capacity",
+      "type": "number"
+    },
+    "nominal_capacity_mah": {
+      "title": "Nominal Capacity Mah",
+      "type": "number"
     }
   },
   "required": [

--- a/pydatalab/src/pydatalab/models/cells.py
+++ b/pydatalab/src/pydatalab/models/cells.py
@@ -9,6 +9,14 @@ from pydatalab.models.utils import CellStatus, Constituent
 # from pydatalab.logger import LOGGER
 
 
+# Conversion factor to the base unit of each quantity (mAh/g and mAh respectively).
+# Single source of truth: used both by the `set_nominal_capacity` validator and by
+# `Cell.nominal_capacity_mah`, so any downstream consumer normalizes consistently
+# regardless of which unit is currently selected on a given item.
+THEORETICAL_CAPACITY_TO_MAH_PER_G = {"mAh/g": 1, "mAh/kg": 1e-3}
+NOMINAL_CAPACITY_TO_MAH = {"mAh": 1, "Ah": 1e3}
+
+
 class CellComponent(Constituent): ...
 
 
@@ -57,6 +65,26 @@ class Cell(Item):
     status: CellStatus = Field(default=CellStatus.ACTIVE)
     """The status of the cells, indicating its current state."""
 
+    theoretical_capacity: float | None
+    """The theoretical specific capacity of the active material."""
+
+    theoretical_capacity_unit: str = Field("mAh/g", pattern="^(mAh/g|mAh/kg)$")
+    """The unit that `theoretical_capacity` is given in."""
+
+    nominal_capacity_unit: str = Field("mAh", pattern="^(mAh|Ah)$")
+    """The unit that `nominal_capacity` is given in."""
+
+    nominal_capacity: float | None
+    """The nominal capacity of the cell, computed as
+    `theoretical_capacity * characteristic_mass`. See `set_nominal_capacity`."""
+
+    nominal_capacity_mah: float | None
+    """`nominal_capacity` normalized to mAh, regardless of the unit currently selected
+    on this item (`nominal_capacity_unit`). Read-only/derived: always recomputed on
+    save (see `set_nominal_capacity_mah`). Prefer this field over `nominal_capacity`
+    whenever comparing or aggregating across cells, since `nominal_capacity_unit` can
+    differ from item to item."""
+
     @validator("characteristic_molar_mass", always=True, pre=True)
     def set_molar_mass(cls, v, values):
         from periodictable import formula
@@ -71,6 +99,33 @@ class Cell(Item):
                     return None
 
         return v
+
+    @validator("nominal_capacity", always=True, pre=True)
+    def set_nominal_capacity(cls, v, values):
+        theoretical_capacity = values.get("theoretical_capacity")
+        characteristic_mass = values.get("characteristic_mass")
+
+        if theoretical_capacity is None or characteristic_mass is None:
+            return v
+
+        theoretical_capacity_unit = values.get("theoretical_capacity_unit") or "mAh/g"
+        nominal_capacity_unit = values.get("nominal_capacity_unit") or "mAh"
+
+        theoretical_capacity_mah_per_g = (
+            theoretical_capacity * THEORETICAL_CAPACITY_TO_MAH_PER_G[theoretical_capacity_unit]
+        )
+        # characteristic_mass is in mg; divide by 1000 to get grams.
+        nominal_capacity_mah = theoretical_capacity_mah_per_g * characteristic_mass / 1000
+        return nominal_capacity_mah / NOMINAL_CAPACITY_TO_MAH[nominal_capacity_unit]
+
+    @validator("nominal_capacity_mah", always=True, pre=True)
+    def set_nominal_capacity_mah(cls, v, values):
+        nominal_capacity = values.get("nominal_capacity")
+        if nominal_capacity is None:
+            return None
+
+        nominal_capacity_unit = values.get("nominal_capacity_unit") or "mAh"
+        return nominal_capacity * NOMINAL_CAPACITY_TO_MAH[nominal_capacity_unit]
 
     @root_validator
     def add_missing_electrode_relationships(cls, values):

--- a/webapp/src/components/CellInformation.vue
+++ b/webapp/src/components/CellInformation.vue
@@ -93,6 +93,45 @@
             />
           </div>
         </div>
+        <div class="form-row py-4">
+          <div class="form-group col-lg-4 col-md-4 pr-3">
+            <label for="cell-theoretical-capacity">Theoretical capacity</label>
+            <div class="input-group">
+              <input
+                id="cell-theoretical-capacity"
+                v-model="TheoreticalCapacity"
+                class="form-control"
+                type="text"
+                :class="{ 'red-border': isNaN(TheoreticalCapacity) }"
+              />
+              <div class="input-group-append">
+                <select v-model="TheoreticalCapacityUnit" class="form-control">
+                  <option value="mAh/g">mAh/g</option>
+                  <option value="mAh/kg">mAh/kg</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="form-group col-lg-4 col-md-4">
+            <label
+              for="cell-nominal-capacity"
+              title="Computed live as theoretical capacity × active mass."
+            >
+              Nominal capacity
+            </label>
+            <div class="input-group">
+              <div id="cell-nominal-capacity" class="form-control">
+                {{ NominalCapacityDisplay }}
+              </div>
+              <div class="input-group-append">
+                <select v-model="NominalCapacityUnit" class="form-control">
+                  <option value="mAh">mAh</option>
+                  <option value="Ah">Ah</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        </div>
         <div class="row">
           <div class="col">
             <label id="cell-description-label">Description</label>
@@ -175,11 +214,48 @@ export default {
     CharacteristicMass: createComputedSetterForItemField("characteristic_mass"),
     Collections: createComputedSetterForItemField("collections"),
     Status: createComputedSetterForItemField("status"),
+    TheoreticalCapacity: createComputedSetterForItemField("theoretical_capacity"),
+    TheoreticalCapacityUnit: createComputedSetterForItemField("theoretical_capacity_unit"),
+    NominalCapacityUnit: createComputedSetterForItemField("nominal_capacity_unit"),
     schema() {
       return this.$store.state.schemas[this.item?.type];
     },
     possibleItemStatuses() {
       return this.schema?.attributes?.schema?.definitions?.CellStatus?.enum;
+    },
+    // Recomputed live from the store on every render — no save round-trip needed.
+    NominalCapacity() {
+      const theoreticalCapacityToMahPerG = { "mAh/g": 1, "mAh/kg": 1e-3 };
+      const nominalCapacityToMah = { mAh: 1, Ah: 1e3 };
+
+      const theoreticalCapacity = Number(this.TheoreticalCapacity);
+      const characteristicMass = Number(this.CharacteristicMass);
+      if (!Number.isFinite(theoreticalCapacity) || !Number.isFinite(characteristicMass)) {
+        return null;
+      }
+
+      const theoreticalCapacityUnit = this.TheoreticalCapacityUnit || "mAh/g";
+      const nominalCapacityUnit = this.NominalCapacityUnit || "mAh";
+
+      const mAhPerG = theoreticalCapacity * theoreticalCapacityToMahPerG[theoreticalCapacityUnit];
+      // characteristic_mass is stored in mg; divide by 1000 to get grams.
+      const mAh = (mAhPerG * characteristicMass) / 1000;
+      return mAh / nominalCapacityToMah[nominalCapacityUnit];
+    },
+    NominalCapacityDisplay() {
+      return this.NominalCapacity === null ? "—" : this.NominalCapacity.toFixed(4);
+    },
+  },
+  watch: {
+    // Persist the live-computed value too, so it's saved without relying on a
+    // server round-trip (the backend validator recomputes it again on save).
+    NominalCapacity(value) {
+      if (value !== null && value !== this.item?.nominal_capacity) {
+        this.$store.commit("updateItemData", {
+          item_id: this.item_id,
+          item_data: { nominal_capacity: value },
+        });
+      }
     },
   },
 };


### PR DESCRIPTION
Adds theoretical capacity to the front end, which combined with active mass gives a nominal cell capacity.

Unit conversions handled by pydantic model.

nominal_capacity_mah stored in db for future use through API or apps.