### PR TITLE
Converted jsonify errors to werkzeug exceptions.

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/admin.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/admin.py
@@ -4,7 +4,14 @@ import pymongo.errors
 from bson import ObjectId
 from flask import Blueprint, jsonify, request
 from flask_login import current_user
-from werkzeug.exceptions import BadRequest, NotFound
+from werkzeug.exceptions import (
+    BadRequest,
+    Conflict,
+    Forbidden,
+    InternalServerError,
+    NotFound,
+    Unauthorized,
+)
 
 from pydatalab.config import CONFIG
 from pydatalab.models.people import Group, Person
@@ -136,24 +143,21 @@ def save_role(user_id):
         user_role = request_json
 
     if not current_user.is_authenticated and not CONFIG.TESTING:
-        return (jsonify({"status": "error", "message": "No user authenticated."}), 401)
+        raise Unauthorized("No user authenticated.")
 
     if not CONFIG.TESTING and current_user.role != "admin":
-        return (
-            jsonify({"status": "error", "message": "User not allowed to edit this profile."}),
-            403,
-        )
+        raise Forbidden("User not allowed to edit this profile.")
 
     existing_user = flask_mongo.db.users.find_one({"_id": ObjectId(user_id)})
 
     if not existing_user:
-        return (jsonify({"status": "error", "message": "User not found."}), 404)
+        raise NotFound("User not found.")
 
     existing_role = flask_mongo.db.roles.find_one({"_id": ObjectId(user_id)})
 
     if not existing_role:
         if not user_role:
-            return (jsonify({"status": "error", "message": "Role not provided for new user."}), 400)
+            raise BadRequest("Role not provided for new user.")
 
         new_user_role = {"_id": ObjectId(user_id), **user_role}
         flask_mongo.db.roles.insert_one(new_user_role)
@@ -163,7 +167,7 @@ def save_role(user_id):
     update_result = flask_mongo.db.roles.update_one({"_id": ObjectId(user_id)}, {"$set": user_role})
 
     if update_result.matched_count != 1:
-        return (jsonify({"status": "error", "message": "Unable to update user."}), 400)
+        raise BadRequest("Unable to update user.")
 
     if update_result.modified_count != 1:
         return (
@@ -186,16 +190,16 @@ def update_user_managers(user_id):
     request_json = request.get_json()
 
     if request_json is None or "managers" not in request_json:
-        return jsonify({"status": "error", "message": "Managers list not provided"}), 400
+        raise BadRequest("Managers list not provided")
 
     managers = request_json["managers"]
 
     if not isinstance(managers, list):
-        return jsonify({"status": "error", "message": "Managers must be a list"}), 400
+        raise BadRequest("Managers must be a list")
 
     existing_user = flask_mongo.db.users.find_one({"_id": ObjectId(user_id)})
     if not existing_user:
-        return jsonify({"status": "error", "message": "User not found"}), 404
+        raise NotFound("User not found")
 
     manager_object_ids = []
     for manager_id in managers:
@@ -203,22 +207,15 @@ def update_user_managers(user_id):
             try:
                 manager_oid = ObjectId(manager_id)
             except Exception:
-                return jsonify(
-                    {"status": "error", "message": f"Invalid manager ID format: {manager_id}"}
-                ), 400
+                raise BadRequest(f"Invalid manager ID format: {manager_id}") from None
 
             if not flask_mongo.db.users.find_one({"_id": manager_oid}):
-                return jsonify(
-                    {"status": "error", "message": f"Manager with ID {manager_id} not found"}
-                ), 404
+                raise NotFound(f"Manager with ID {manager_id} not found")
 
             if check_manager_cycle(user_id, manager_id):
-                return jsonify(
-                    {
-                        "status": "error",
-                        "message": "Cannot assign manager: would create a circular management hierarchy",
-                    }
-                ), 400
+                raise BadRequest(
+                    "Cannot assign manager: would create a circular management hierarchy"
+                )
 
             manager_object_ids.append(manager_oid)
 
@@ -227,7 +224,7 @@ def update_user_managers(user_id):
     )
 
     if update_result.matched_count != 1:
-        return jsonify({"status": "error", "message": "Unable to update user managers"}), 400
+        raise BadRequest("Unable to update user managers")
 
     return jsonify({"status": "success"}), 200
 
@@ -395,14 +392,12 @@ def create_group():
             group.dict(exclude_unset=True)
         ).inserted_id
     except pymongo.errors.DuplicateKeyError:
-        return jsonify(
-            {"status": "error", "message": f"Group ID {group.group_id} already exists."}
-        ), 400
+        raise Conflict(f"Group ID {group.group_id} already exists.") from None
 
     if group_immutable_id:
         return jsonify({"status": "success", "group_immutable_id": str(group_immutable_id)}), 200
 
-    return jsonify({"status": "error", "message": "Unable to create group."}), 400
+    raise InternalServerError("Unable to create group.")
 
 
 @ADMIN.route("/groups/<group_immutable_id>", methods=["DELETE"])
@@ -413,7 +408,7 @@ def delete_group(group_immutable_id: str):
         if result.deleted_count == 1:
             return jsonify({"status": "success"}), 200
 
-    return jsonify({"status": "error", "message": "Unable to delete group."}), 400
+    raise NotFound("Unable to delete group.")
 
 
 @ADMIN.route("/groups/<group_immutable_id>", methods=["PATCH"])
@@ -422,7 +417,7 @@ def update_group(group_immutable_id: str):
 
     existing_group = flask_mongo.db.groups.find_one({"_id": ObjectId(group_immutable_id)})
     if not existing_group:
-        return jsonify({"status": "error", "message": "Group not found."}), 404
+        raise NotFound("Group not found.")
 
     update_data = {}
 
@@ -450,23 +445,22 @@ def update_group(group_immutable_id: str):
         temp_group_data.pop("_id", None)
         Group(**temp_group_data)
     except Exception as e:
-        return jsonify({"status": "error", "message": f"Invalid group data: {str(e)}"}), 400
+        raise BadRequest(f"Invalid group data: {str(e)}") from e
 
     try:
         result = flask_mongo.db.groups.update_one(
             {"_id": ObjectId(group_immutable_id)}, {"$set": update_data}
         )
+    except pymongo.errors.PyMongoError as e:
+        raise InternalServerError(f"Failed to update group: {str(e)}") from e
 
-        if result.matched_count == 0:
-            return jsonify({"status": "error", "message": "Group not found."}), 404
+    if result.matched_count == 0:
+        raise NotFound("Group not found.")
 
-        if result.modified_count == 0:
-            return jsonify({"status": "success", "message": "No changes were made."}), 200
+    if result.modified_count == 0:
+        return jsonify({"status": "success", "message": "No changes were made."}), 200
 
-        return jsonify({"status": "success", "message": "Group updated successfully."}), 200
-
-    except Exception as e:
-        return jsonify({"status": "error", "message": f"Failed to update group: {str(e)}"}), 500
+    return jsonify({"status": "success", "message": "Group updated successfully."}), 200
 
 
 @ADMIN.route("/groups/<group_immutable_id>", methods=["PUT"])

--- a/pydatalab/src/pydatalab/routes/v0_1/admin.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/admin.py
@@ -249,8 +249,8 @@ def invalidate_access_token(refcode: str):
 
     if response.modified_count == 1:
         return jsonify({"status": "success"}), 200
-    else:
-        return jsonify({"status": "error", "detail": "Token not found or already invalidated"}), 404
+
+    raise NotFound("Token not found or already invalidated.")
 
 
 @ADMIN.route("/access-tokens", methods=["GET"])

--- a/pydatalab/src/pydatalab/routes/v0_1/auth.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/auth.py
@@ -18,7 +18,7 @@ from flask import Blueprint, g, jsonify, redirect, request
 from flask_dance.consumer import OAuth2ConsumerBlueprint, oauth_authorized
 from flask_login import current_user, login_user
 from flask_login.utils import LocalProxy
-from werkzeug.exceptions import BadRequest, Forbidden
+from werkzeug.exceptions import BadRequest, Forbidden, Unauthorized
 
 from pydatalab.config import CONFIG
 from pydatalab.errors import UserRegistrationForbidden
@@ -1059,8 +1059,8 @@ def get_authenticated_user_info():
         current_user_response = json.loads(current_user.person.json())
         current_user_response["role"] = current_user.role.value
         return jsonify(current_user_response), 200
-    else:
-        return jsonify({"status": "failure", "message": "User must be authenticated."}), 401
+
+    raise Unauthorized("User must be authenticated.")
 
 
 @AUTH.route("/get-api-key/", methods=["GET"])
@@ -1074,16 +1074,8 @@ def generate_user_api_key():
             upsert=True,
         )
         return jsonify({"key": new_key}), 200
-    else:
-        return (
-            jsonify(
-                {
-                    "status": "failure",
-                    "message": "User must be an authenticated admin to request an API key.",
-                }
-            ),
-            401,
-        )
+
+    raise Unauthorized("User must be an authenticated admin to request an API key.")
 
 
 @AUTH.route("/testing/create-magic-link", methods=["POST"])
@@ -1095,9 +1087,7 @@ def create_test_magic_link():
     and returns the token.
     """
     if not CONFIG.TESTING:
-        return jsonify(
-            {"status": "error", "detail": "This endpoint is only available in testing mode."}
-        ), 403
+        raise Forbidden("This endpoint is only available in testing mode.")
 
     request_json = request.get_json()
     email = request_json.get("email")

--- a/pydatalab/src/pydatalab/routes/v0_1/auth.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/auth.py
@@ -17,11 +17,7 @@ from flask import Blueprint, Response, g, jsonify, redirect, request
 from flask_dance.consumer import OAuth2ConsumerBlueprint, oauth_authorized
 from flask_login import current_user, login_user
 from flask_login.utils import LocalProxy
-<<<<<<< HEAD
-from werkzeug.exceptions import BadRequest, Forbidden, NotFound
-=======
-from werkzeug.exceptions import BadRequest, Forbidden, Unauthorized
->>>>>>> a8f2b330 (More clean up of errors in routes.)
+from werkzeug.exceptions import BadRequest, Forbidden, NotFound, Unauthorized
 
 from pydatalab.config import CONFIG
 from pydatalab.errors import UserRegistrationForbidden

--- a/pydatalab/src/pydatalab/routes/v0_1/auth.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/auth.py
@@ -17,7 +17,11 @@ from flask import Blueprint, Response, g, jsonify, redirect, request
 from flask_dance.consumer import OAuth2ConsumerBlueprint, oauth_authorized
 from flask_login import current_user, login_user
 from flask_login.utils import LocalProxy
+<<<<<<< HEAD
 from werkzeug.exceptions import BadRequest, Forbidden, NotFound
+=======
+from werkzeug.exceptions import BadRequest, Forbidden, Unauthorized
+>>>>>>> a8f2b330 (More clean up of errors in routes.)
 
 from pydatalab.config import CONFIG
 from pydatalab.errors import UserRegistrationForbidden
@@ -1060,8 +1064,8 @@ def get_authenticated_user_info():
         current_user_response = json.loads(current_user.person.json())
         current_user_response["role"] = current_user.role.value
         return jsonify(current_user_response), 200
-    else:
-        return jsonify({"status": "failure", "message": "User must be authenticated."}), 401
+
+    raise Unauthorized("User must be authenticated.")
 
 
 @AUTH.route("/api-keys", methods=["POST"])
@@ -1140,10 +1144,13 @@ def delete_api_key(api_id):
     if not doc:
         raise NotFound(description="API key not found.")
     result = flask_mongo.db.api_keys.delete_one({"_id": ObjectId(api_id)})
+
     if result.deleted_count == 1:
         return Response("", status=204)
     else:
         raise BadRequest(description="Problem deleting the key")
+
+    raise Unauthorized("User must be an authenticated admin to request an API key.")
 
 
 @AUTH.route("/testing/create-magic-link", methods=["POST"])
@@ -1155,9 +1162,7 @@ def create_test_magic_link():
     and returns the token.
     """
     if not CONFIG.TESTING:
-        return jsonify(
-            {"status": "error", "detail": "This endpoint is only available in testing mode."}
-        ), 403
+        raise Forbidden("This endpoint is only available in testing mode.")
 
     request_json = request.get_json()
     email = request_json.get("email")

--- a/pydatalab/src/pydatalab/routes/v0_1/blocks.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/blocks.py
@@ -257,13 +257,7 @@ def add_data_block():
     )
 
     if result.modified_count < 1:
-        return (
-            jsonify(
-                status="error",
-                message=f"Update failed. {item_id=} is probably incorrect.",
-            ),
-            400,
-        )
+        raise BadRequest(f"Update failed. {item_id=} is probably incorrect.")
 
     # get the new display_order:
     display_order_result = flask_mongo.db.items.find_one(
@@ -430,15 +424,7 @@ def delete_block():
     )
 
     if result.modified_count < 1:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "message": f"Update failed. The item_id probably incorrect: {item_id}",
-                }
-            ),
-            400,
-        )
+        raise BadRequest(f"Update failed. The item_id probably incorrect: {item_id}")
     return (
         jsonify({"status": "success"}),
         200,
@@ -450,7 +436,7 @@ def get_block_task_status(task_id: str):
     task = flask_mongo.db.tasks.find_one({"task_id": task_id, "type": TaskType.BLOCK_PROCESSING})
 
     if not task:
-        return jsonify({"status": "error", "message": "Task not found"}), 404
+        raise NotFound("Task not found")
 
     response = {
         "status": task["status"],

--- a/pydatalab/src/pydatalab/routes/v0_1/blocks.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/blocks.py
@@ -265,13 +265,7 @@ def add_data_block():
     )
 
     if result.modified_count < 1:
-        return (
-            jsonify(
-                status="error",
-                message=f"Update failed. {item_id=} is probably incorrect.",
-            ),
-            400,
-        )
+        raise BadRequest(f"Update failed. {item_id=} is probably incorrect.")
 
     # get the new display_order:
     display_order_result = flask_mongo.db.items.find_one(
@@ -442,15 +436,7 @@ def delete_block():
     )
 
     if result.modified_count < 1:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "message": f"Update failed. The item_id probably incorrect: {item_id}",
-                }
-            ),
-            400,
-        )
+        raise BadRequest(f"Update failed. The item_id probably incorrect: {item_id}")
     return (
         jsonify({"status": "success"}),
         200,
@@ -462,7 +448,7 @@ def get_block_task_status(task_id: str):
     task = flask_mongo.db.tasks.find_one({"task_id": task_id, "type": TaskType.BLOCK_PROCESSING})
 
     if not task:
-        return jsonify({"status": "error", "message": "Task not found"}), 404
+        raise NotFound("Task not found")
 
     response = {
         "status": task["status"],

--- a/pydatalab/src/pydatalab/routes/v0_1/collections.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/collections.py
@@ -6,6 +6,7 @@ from flask import Blueprint, jsonify, request
 from flask_login import current_user
 from pydantic import ValidationError
 from pymongo.results import InsertOneResult, UpdateResult
+from werkzeug.exceptions import BadRequest, NotFound
 
 from pydatalab.config import CONFIG
 from pydatalab.logger import LOGGER, logged_route
@@ -59,15 +60,7 @@ def get_collection(collection_id):
         doc = None
 
     if not doc or (not current_user.is_authenticated and not CONFIG.TESTING):
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "message": f"No matching collection {collection_id=} with current authorization.",
-                }
-            ),
-            404,
-        )
+        raise NotFound(f"No matching collection {collection_id=} with current authorization.")
 
     collection = Collection(**doc)
 
@@ -267,13 +260,7 @@ def save_collection(collection_id):
     )
 
     if not collection:
-        return (
-            jsonify(
-                status="error",
-                message=f"Unable to find item with appropriate permissions and {collection_id=}.",
-            ),
-            400,
-        )
+        raise NotFound(f"Unable to find item with appropriate permissions and {collection_id=}.")
 
     collection.update(updated_data)
 
@@ -320,15 +307,7 @@ def update_collection_permissions(collection_id: str):
     )  # type: ignore
 
     if not current_collection:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "message": f"No valid collection found with the given {collection_id=}.",
-                }
-            ),
-            401,
-        )
+        raise NotFound(f"No valid collection found with the given {collection_id=}.")
 
     current_creator_ids = current_collection["creator_ids"]
 
@@ -360,45 +339,21 @@ def update_collection_permissions(collection_id: str):
         ]
 
     if not groups_requested and not creators_requested:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "message": "No valid creator or group IDs found in the request.",
-                }
-            ),
-            400,
-        )
+        raise BadRequest("No valid creator or group IDs found in the request.")
 
     if creator_ids:
         found_creator_ids = [
             d for d in flask_mongo.db.users.find({"_id": {"$in": creator_ids}}, {"_id": 1})
         ]  # type: ignore
         if len(found_creator_ids) != len(creator_ids):
-            return (
-                jsonify(
-                    {
-                        "status": "error",
-                        "message": "One or more creator IDs not found in the database.",
-                    }
-                ),
-                400,
-            )
+            raise BadRequest("One or more creator IDs not found in the database.")
 
     if group_ids:
         found_group_ids = [
             d for d in flask_mongo.db.groups.find({"_id": {"$in": group_ids}}, {"_id": 1})
         ]  # type: ignore
         if len(found_group_ids) != len(group_ids):
-            return (
-                jsonify(
-                    {
-                        "status": "error",
-                        "message": "One or more group IDs not found in the database.",
-                    }
-                ),
-                400,
-            )
+            raise BadRequest("One or more group IDs not found in the database.")
 
     if creator_ids and creators_requested:
         current_user_id = current_user.person.immutable_id
@@ -437,12 +392,9 @@ def update_collection_permissions(collection_id: str):
     )
 
     if result.matched_count != 1:
-        return jsonify(
-            {
-                "status": "error",
-                "message": "Failed to update permissions: collection not found or insufficient permissions.",
-            }
-        ), 400
+        raise NotFound(
+            "Failed to update permissions: collection not found or insufficient permissions."
+        )
 
     return jsonify({"status": "success"}), 200
 
@@ -462,14 +414,8 @@ def delete_collection(collection_id: str):
                 }
             )
             if result.deleted_count != 1:
-                return (
-                    jsonify(
-                        {
-                            "status": "error",
-                            "message": f"Authorization required to attempt to delete collection with {collection_id=} from the database.",
-                        }
-                    ),
-                    401,
+                raise NotFound(
+                    f"No valid collection found with {collection_id=} and current authorization."
                 )
 
             # If successful, remove collection from all matching items relationships
@@ -518,7 +464,7 @@ def search_collections():
     nresults = request.args.get("nresults", default=100, type=int)
 
     if not query:
-        return jsonify({"status": "error", "message": "No query provided."}), 400
+        raise BadRequest("No query provided.")
 
     permissions = get_default_permissions(user_only=False)
     pipeline = build_search_pipeline(query, COLLECTIONS_FTS_FIELDS, permissions)
@@ -580,7 +526,7 @@ def add_items_to_collection(collection_id):
     )
 
     if update_result.matched_count == 0:
-        return (jsonify({"status": "error", "message": "Unable to add to collection."}), 400)
+        raise BadRequest("Unable to add to collection.")
 
     if update_result.modified_count == 0:
         return (
@@ -624,7 +570,7 @@ def remove_items_from_collection(collection_id):
     )
 
     if update_result.matched_count == 0:
-        return jsonify({"status": "error", "message": "No matching items found."}), 404
+        raise NotFound("No matching items found.")
 
     elif update_result.matched_count != len(refcodes):
         return jsonify(

--- a/pydatalab/src/pydatalab/routes/v0_1/collections.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/collections.py
@@ -6,7 +6,7 @@ from flask import Blueprint, jsonify, request
 from flask_login import current_user
 from pydantic import ValidationError
 from pymongo.results import InsertOneResult, UpdateResult
-from werkzeug.exceptions import BadRequest, NotFound
+from werkzeug.exceptions import BadRequest, Conflict, NotFound, Unauthorized
 
 from pydatalab.config import CONFIG
 from pydatalab.logger import LOGGER, logged_route
@@ -94,14 +94,7 @@ def create_collection():
     starting_members = data.get("starting_members", [])
 
     if not current_user.is_authenticated and not CONFIG.TESTING:
-        return (
-            dict(
-                status="error",
-                message="Unable to create new collection without user authentication.",
-                collection_id=data.get("collection_id"),
-            ),
-            401,
-        )
+        raise Unauthorized("Unable to create new collection without user authentication.")
 
     if copy_from_id:
         raise NotImplementedError("Copying collections is not yet implemented.")
@@ -133,13 +126,8 @@ def create_collection():
 
     # check to make sure that item_id isn't taken already
     if flask_mongo.db.collections.find_one({"collection_id": data["collection_id"]}):
-        return (
-            dict(
-                status="error",
-                message=f"collection_id_validation_error: {data['collection_id']!r} already exists in database.",
-                collection_id=data["collection_id"],
-            ),
-            409,  # 409: Conflict
+        raise Conflict(
+            f"collection_id_validation_error: {data['collection_id']!r} already exists in database."
         )
 
     data["last_modified"] = data.get(
@@ -497,17 +485,17 @@ def add_items_to_collection(collection_id):
     )
 
     if not collection:
-        return jsonify({"error": "Collection not found"}), 404
+        raise NotFound("Collection not found")
 
     if not refcodes:
-        return jsonify({"error": "No item provided"}), 400
+        raise BadRequest("No item provided")
 
     item_count = flask_mongo.db.items.count_documents(
         {"refcode": {"$in": refcodes}, **get_default_permissions()}
     )
 
     if item_count == 0:
-        return jsonify({"error": "No matching items found"}), 404
+        raise NotFound("No matching items found")
 
     update_result = flask_mongo.db.items.update_many(
         {"refcode": {"$in": refcodes}, **get_default_permissions()},
@@ -552,10 +540,10 @@ def remove_items_from_collection(collection_id):
     )
 
     if not collection:
-        return jsonify({"error": "Collection not found"}), 404
+        raise NotFound("Collection not found")
 
     if not refcodes:
-        return jsonify({"error": "No refcodes provided"}), 400
+        raise BadRequest("No refcodes provided")
 
     update_result = flask_mongo.db.items.update_many(
         {"refcode": {"$in": refcodes}, **get_default_permissions()},

--- a/pydatalab/src/pydatalab/routes/v0_1/export.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/export.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from flask import Blueprint, jsonify, make_response, request, send_file
 from flask_login import current_user
+from werkzeug.exceptions import BadRequest, Conflict, NotFound
 
 from pydatalab.config import CONFIG
 from pydatalab.export import create_eln_file
@@ -201,7 +202,7 @@ def start_collection_export(collection_id: str):
         {"collection_id": collection_id, **get_default_permissions(user_only=False)}
     )
     if not collection_with_perms:
-        return jsonify({"status": "error", "message": "Collection not found"}), 404
+        raise NotFound("Collection not found")
 
     task_id = str(uuid.uuid4())
 
@@ -245,7 +246,7 @@ def get_export_status(task_id: str):
     )
 
     if not task:
-        return jsonify({"status": "error", "message": "Export task not found"}), 404
+        raise NotFound("Export task not found")
 
     response = {
         "status": task["status"],
@@ -326,12 +327,10 @@ def download_export(task_id: str):
         task = flask_mongo.db.tasks.find_one({"task_id": task_id, "type": TaskType.EXPORT})
 
     if not task:
-        return jsonify({"status": "error", "message": "Export task not found"}), 404
+        raise NotFound("Export task not found")
 
     if task["status"] != TaskStatus.READY:
-        return jsonify(
-            {"status": "error", "message": f"Export is not ready. Current status: {task['status']}"}
-        ), 400
+        raise Conflict(f"Export is not ready. Current status: {task['status']}")
 
     spec = task.get("spec", {})
     file_path = spec.get("file_path")
@@ -340,7 +339,7 @@ def download_export(task_id: str):
         or not _is_export_path_safe(file_path, task_id)
         or not os.path.exists(file_path)
     ):
-        return jsonify({"status": "error", "message": "Export file not found"}), 404
+        raise NotFound("Export file not found")
 
     filename = f"{spec.get('collection_id') or spec.get('item_id')}.eln"
 
@@ -355,7 +354,7 @@ def start_item_export(item_id: str):
         {"item_id": item_id, **get_default_permissions(user_only=False)}
     )
     if not item_data:
-        return jsonify({"status": "error", "message": "Item not found"}), 404
+        raise NotFound("Item not found")
 
     task_id = str(uuid.uuid4())
 
@@ -371,12 +370,7 @@ def start_item_export(item_id: str):
     if request_data.get("include_related"):
         related_item_ids = request_data.get("related_item_ids", [])
         if not related_item_ids:
-            return jsonify(
-                {
-                    "status": "error",
-                    "message": "related_item_ids required when include_related is true",
-                }
-            ), 400
+            raise BadRequest("related_item_ids required when include_related is true")
         export_type = "graph"
 
     export_task = Task(

--- a/pydatalab/src/pydatalab/routes/v0_1/export.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/export.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from flask import Blueprint, jsonify, make_response, request, send_file
 from flask_login import current_user
+from werkzeug.exceptions import BadRequest, Conflict, NotFound
 
 from pydatalab.config import CONFIG
 from pydatalab.export import create_eln_file
@@ -201,7 +202,7 @@ def start_collection_export(collection_id: str):
         {"collection_id": collection_id, **get_default_permissions(user_only=False)}
     )
     if not collection_with_perms:
-        return jsonify({"status": "error", "message": "Collection not found"}), 404
+        raise NotFound("Collection not found")
 
     task_id = str(uuid.uuid4())
 
@@ -245,7 +246,7 @@ def get_export_status(task_id: str):
     )
 
     if not task:
-        return jsonify({"status": "error", "message": "Export task not found"}), 404
+        raise NotFound("Export task not found")
 
     response = {
         "status": task["status"],
@@ -326,12 +327,10 @@ def download_export(task_id: str):
         task = flask_mongo.db.tasks.find_one({"task_id": task_id, "type": TaskType.EXPORT})
 
     if not task:
-        return jsonify({"status": "error", "message": "Export task not found"}), 404
+        raise NotFound("Export task not found")
 
     if task["status"] != TaskStatus.READY:
-        return jsonify(
-            {"status": "error", "message": f"Export is not ready. Current status: {task['status']}"}
-        ), 400
+        raise Conflict(f"Export is not ready. Current status: {task['status']}")
 
     spec = task.get("spec", {})
     file_path = spec.get("file_path")
@@ -340,7 +339,7 @@ def download_export(task_id: str):
         or not _is_export_path_safe(file_path, task_id)
         or not os.path.exists(file_path)
     ):
-        return jsonify({"status": "error", "message": "Export file not found"}), 404
+        raise NotFound("Export file not found")
 
     filename = f"{spec.get('collection_id') or spec.get('item_id')}.eln.zip"
 
@@ -355,7 +354,7 @@ def start_item_export(item_id: str):
         {"item_id": item_id, **get_default_permissions(user_only=False)}
     )
     if not item_data:
-        return jsonify({"status": "error", "message": "Item not found"}), 404
+        raise NotFound("Item not found")
 
     task_id = str(uuid.uuid4())
 
@@ -371,12 +370,7 @@ def start_item_export(item_id: str):
     if request_data.get("include_related"):
         related_item_ids = request_data.get("related_item_ids", [])
         if not related_item_ids:
-            return jsonify(
-                {
-                    "status": "error",
-                    "message": "related_item_ids required when include_related is true",
-                }
-            ), 400
+            raise BadRequest("related_item_ids required when include_related is true")
         export_type = "graph"
 
     export_task = Task(

--- a/pydatalab/src/pydatalab/routes/v0_1/files.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/files.py
@@ -5,7 +5,7 @@ from bson.errors import InvalidId
 from flask import Blueprint, jsonify, request, send_from_directory
 from flask_login import current_user
 from pymongo import ReturnDocument
-from werkzeug.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest, Forbidden, Unauthorized
 from werkzeug.utils import secure_filename
 
 import pydatalab.mongo
@@ -40,16 +40,7 @@ def get_file(file_id: str, filename: str):
     if not pydatalab.mongo.flask_mongo.db.items.find_one(
         {"file_ObjectIds": {"$in": [_file_id]}, **get_default_permissions(user_only=False)}
     ):
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "title": "Not Authorized",
-                    "detail": "Authorization required to access file",
-                }
-            ),
-            401,
-        )
+        raise Forbidden("Authorization required to access file")
 
     path = os.path.join(CONFIG.FILE_DIRECTORY, secure_filename(file_id))
     return send_from_directory(path, filename)
@@ -71,21 +62,12 @@ def upload():
     """
 
     if not current_user.is_authenticated and not CONFIG.TESTING:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "title": "Not Authorized",
-                    "detail": "File upload requires login.",
-                }
-            ),
-            401,
-        )
+        raise Unauthorized("File upload requires login.")
 
     if len(request.files) == 0:
-        return jsonify(error="No file in request"), 400
+        raise BadRequest("No file in request")
     if "item_id" not in request.form:
-        return jsonify(error="No item id provided in form"), 400
+        raise BadRequest("No item id provided in form")
     item_id = request.form["item_id"]
     replace_file_id = request.form["replace_file"]
 
@@ -132,16 +114,7 @@ def upload():
 @FILES.route("/add-remote-file-to-sample/", methods=["POST"])
 def add_remote_file_to_sample():
     if not current_user.is_authenticated and not CONFIG.TESTING:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "title": "Not Authorized",
-                    "detail": "Adding a file to a sample requires login.",
-                }
-            ),
-            401,
-        )
+        raise Unauthorized("Adding a file to a sample requires login.")
 
     request_json = request.get_json()
     item_id = request_json["item_id"]
@@ -173,16 +146,7 @@ def delete_file_from_sample():
     """Remove a file from a sample, but don't delete the actual file (for now)"""
 
     if not current_user.is_authenticated and not CONFIG.TESTING:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "title": "Not Authorized",
-                    "detail": "Adding a file to a sample requires login.",
-                }
-            ),
-            401,
-        )
+        raise Unauthorized("Adding a file to a sample requires login.")
 
     request_json = request.get_json()
 
@@ -228,16 +192,7 @@ def delete_file():
     """delete a data file from the uploads/item_id folder"""
 
     if not current_user.is_authenticated and not CONFIG.TESTING:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "title": "Not Authorized",
-                    "detail": "Adding a file to a sample requires login.",
-                }
-            ),
-            401,
-        )
+        raise Unauthorized("Adding a file to a sample requires login.")
 
     request_json = request.get_json()
 

--- a/pydatalab/src/pydatalab/routes/v0_1/files.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/files.py
@@ -5,6 +5,7 @@ from bson.errors import InvalidId
 from flask import Blueprint, jsonify, request, send_from_directory
 from flask_login import current_user
 from pymongo import ReturnDocument
+from werkzeug.exceptions import BadRequest
 from werkzeug.utils import secure_filename
 
 import pydatalab.mongo
@@ -207,12 +208,8 @@ def delete_file_from_sample():
     )
 
     if not updated_file_entry:
-        return (
-            jsonify(
-                status="error",
-                message=f"{item_id} {file_id} delete failed. Something went wrong with the db call to remove sample from file",
-            ),
-            400,
+        raise BadRequest(
+            f"{item_id} {file_id} delete failed. Something went wrong with the db call to remove sample from file"
         )
 
     return (
@@ -253,13 +250,7 @@ def delete_file():
     path = os.path.join(CONFIG.FILE_DIRECTORY, secure_item_id, secure_fname)
 
     if not os.path.isfile(path):
-        return (
-            jsonify(
-                status="error",
-                message=f"Delete failed. file not found: {path}",
-            ),
-            400,
-        )
+        raise BadRequest(f"Delete failed. file not found: {path}")
 
     result = pydatalab.mongo.flask_mongo.db.items.update_one(
         {"item_id": item_id, **get_default_permissions(user_only=True)},

--- a/pydatalab/src/pydatalab/routes/v0_1/graphs.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/graphs.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, jsonify, request
+from werkzeug.exceptions import NotFound
 
 from pydatalab.mongo import flask_mongo
 from pydatalab.permissions import active_users_or_get_only, get_default_permissions
@@ -32,12 +33,7 @@ def get_graph_cy_format(
                 projection={"_id": 1},
             )
             if not collection_immutable_id:
-                return (
-                    jsonify(
-                        status="error", message=f"No collection found with ID {collection_id!r}"
-                    ),
-                    404,
-                )
+                raise NotFound(f"No collection found with ID {collection_id!r}")
             collection_immutable_id = collection_immutable_id["_id"]
             query = {
                 "$and": [
@@ -64,10 +60,7 @@ def get_graph_cy_format(
         )
 
         if not main_item:
-            return (
-                jsonify(status="error", message=f"Item {item_id} not found or no permission"),
-                404,
-            )
+            raise NotFound(f"Item {item_id} not found or no permission")
 
         node_ids = {item_id}
         all_documents = [main_item]

--- a/pydatalab/src/pydatalab/routes/v0_1/groups.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/groups.py
@@ -1,6 +1,7 @@
 import json
 
 from flask import Blueprint, jsonify, request
+from werkzeug.exceptions import BadRequest
 
 from pydatalab.models.people import Group
 from pydatalab.mongo import (
@@ -34,7 +35,7 @@ def search_groups():
     nresults = request.args.get("nresults", default=100, type=int)
 
     if not query:
-        return jsonify({"status": "error", "message": "No query provided"}), 400
+        raise BadRequest("No query provided")
 
     pipeline = build_search_pipeline(query, GROUPS_FTS_FIELDS, permissions=None)
     pipeline.append({"$limit": nresults})

--- a/pydatalab/src/pydatalab/routes/v0_1/healthcheck.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/healthcheck.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, jsonify
+from werkzeug.exceptions import BadGateway
 
 HEALTHCHECK = Blueprint("healthcheck", __name__)
 
@@ -10,10 +11,7 @@ def is_ready():
     try:
         check_mongo_connection()
     except RuntimeError:
-        return (
-            jsonify(status="error", message="Unable to connect to MongoDB at specified URI."),
-            502,
-        )
+        raise BadGateway("Unable to connect to MongoDB at specified URI.") from None
     return (jsonify(status="success", message="Server and database are ready"), 200)
 
 

--- a/pydatalab/src/pydatalab/routes/v0_1/info.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/info.py
@@ -8,6 +8,7 @@ from functools import lru_cache
 
 from flask import Blueprint, jsonify, request
 from pydantic import AnyUrl, BaseModel, Field, validator
+from werkzeug.exceptions import NotFound
 
 from pydatalab import __version__
 from pydatalab.apps import BLOCK_TYPES
@@ -202,9 +203,7 @@ def list_supported_types():
 def get_schema_type(item_type):
     """Returns the schema of the given type."""
     if item_type not in SCHEMAS:
-        return jsonify(
-            {"status": "error", "detail": f"Item type {item_type} not found for this deployment"}
-        ), 404
+        raise NotFound(f"Item type {item_type} not found for this deployment")
 
     return jsonify(
         json.loads(

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -11,7 +11,7 @@ from flask import Blueprint, jsonify, redirect, request
 from flask_login import current_user
 from pydantic import ValidationError
 from pymongo.errors import DuplicateKeyError
-from werkzeug.exceptions import BadRequest, Conflict, NotFound
+from werkzeug.exceptions import BadRequest, Conflict, InternalServerError, NotFound, Unauthorized
 
 from pydatalab.apps import BLOCK_TYPES
 from pydatalab.config import CONFIG
@@ -515,7 +515,7 @@ def search_items():
         types = types.split(",")
 
     if not query:
-        return jsonify({"status": "error", "message": "No query provided."}), 400
+        raise BadRequest("No query provided.")
 
     permissions = get_default_permissions(user_only=False)
     pipeline = build_search_pipeline(query, ITEMS_FTS_FIELDS, permissions)
@@ -786,12 +786,9 @@ def create_samples():
     sample_jsons = request_json["new_sample_datas"]
 
     if len(sample_jsons) > CONFIG.MAX_BATCH_CREATE_SIZE:
-        return jsonify(
-            {
-                "status": "error",
-                "message": f"Batch size limit exceeded. Maximum allowed: {CONFIG.MAX_BATCH_CREATE_SIZE}, requested: {len(sample_jsons)}",
-            }
-        ), 400
+        raise BadRequest(
+            f"Batch size limit exceeded. Maximum allowed: {CONFIG.MAX_BATCH_CREATE_SIZE}, requested: {len(sample_jsons)}"
+        )
 
     copy_from_item_ids = request_json.get("copy_from_item_ids")
     generate_ids_automatically = request_json.get("generate_ids_automatically")
@@ -1018,12 +1015,7 @@ def issue_physical_token(refcode: str):
     )
 
     if not current_item:
-        return jsonify(
-            {
-                "status": "error",
-                "message": f"No valid item found with the given {refcode=}.",
-            }
-        ), 404
+        raise NotFound(f"No valid item found with the given {refcode=}.")
 
     token = secrets.token_urlsafe(16)
     access_document = {
@@ -1039,15 +1031,11 @@ def issue_physical_token(refcode: str):
 
     try:
         result = flask_mongo.db.api_keys.insert_one(access_document)
-        if not result.inserted_id:
-            return jsonify(
-                {"status": "error", "message": "Unknown error generating token for item."}
-            ), 500
     except Exception as e:
         LOGGER.error("Error inserting access token: %s", e)
-        return jsonify(
-            {"status": "error", "message": "Database error generating token for item."}
-        ), 500
+        raise InternalServerError("Database error generating token for item.") from e
+    if not result.inserted_id:
+        raise InternalServerError("Unknown error generating token for item.")
 
     return jsonify({"status": "success", "token": token}), 201
 
@@ -1063,30 +1051,14 @@ def delete_sample():
     )
 
     if not item:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "message": f"Authorization required to attempt to delete sample with {item_id=} from the database.",
-                }
-            ),
-            401,
-        )
+        raise NotFound(f"No valid item found with {item_id=} and current authorization.")
 
     result = flask_mongo.db.items.delete_one(
         {"item_id": item_id, **get_default_permissions(user_only=True, deleting=True)}
     )
 
     if result.deleted_count != 1:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "message": f"Failed to delete item with {item_id=}.",
-                }
-            ),
-            400,
-        )
+        raise BadRequest(f"Failed to delete item with {item_id=}.")
 
     flask_mongo.db.api_keys.delete_many({"refcode": item["refcode"], "type": "access_token"})
 
@@ -1154,15 +1126,7 @@ def get_item_data(
         doc = None
 
     if not doc:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "message": f"No matching items for {match=} with current authorization.",
-                }
-            ),
-            404,
-        )
+        raise NotFound(f"No matching items for {match=} with current authorization.")
 
     # determine the item type and validate according to the appropriate schema
     try:
@@ -1186,15 +1150,9 @@ def get_item_data(
             doc["type"],
             error,
         )
-        return (
-            jsonify(
-                status="error",
-                message=(
-                    f"Item {item_id=} is stored in a state that does not validate "
-                    f"against the expected schema for its type {doc['type']}: {error}"
-                ),
-            ),
-            500,
+        raise InternalServerError(
+            f"Item {item_id=} is stored in a state that does not validate "
+            f"against the expected schema for its type {doc['type']}: {error}"
         )
 
     # find any documents with relationships that mention this document
@@ -1276,9 +1234,7 @@ def list_versions(refcode):
     # Check if user has access to the item (read access)
     has_access, _ = check_version_access(refcode, user_only=False)
     if not has_access:
-        return jsonify(
-            {"status": "error", "message": "Item not found or insufficient permissions"}
-        ), 404
+        raise NotFound("Item not found or insufficient permissions")
 
     if len(refcode.split(":")) != 2:
         refcode = f"{CONFIG.IDENTIFIER_PREFIX}:{refcode}"
@@ -1330,9 +1286,7 @@ def get_version(refcode, version_id):
     # Check if user has access to the item (read access)
     has_access, _ = check_version_access(refcode, user_only=False)
     if not has_access:
-        return jsonify(
-            {"status": "error", "message": "Item not found or insufficient permissions"}
-        ), 404
+        raise NotFound("Item not found or insufficient permissions")
 
     if len(refcode.split(":")) != 2:
         refcode = f"{CONFIG.IDENTIFIER_PREFIX}:{refcode}"
@@ -1340,7 +1294,7 @@ def get_version(refcode, version_id):
     try:
         version_object_id = ObjectId(version_id)
     except (InvalidId, TypeError):
-        return jsonify({"status": "error", "message": f"Invalid version_id: {version_id}"}), 400
+        raise BadRequest(f"Invalid version_id: {version_id}") from None
 
     version = list(
         flask_mongo.db.item_versions.aggregate(
@@ -1367,7 +1321,7 @@ def get_version(refcode, version_id):
         version = version[0]
 
     if not version:
-        return jsonify({"status": "error", "message": "Version not found"}), 404
+        raise NotFound("Version not found")
 
     return jsonify({"status": "success", "version": version}), 200
 
@@ -1381,9 +1335,7 @@ def compare_versions(refcode):
     # Check if user has access to the item (read access)
     has_access, _ = check_version_access(refcode, user_only=False)
     if not has_access:
-        return jsonify(
-            {"status": "error", "message": "Item not found or insufficient permissions"}
-        ), 404
+        raise NotFound("Item not found or insufficient permissions")
 
     if len(refcode.split(":")) != 2:
         refcode = f"{CONFIG.IDENTIFIER_PREFIX}:{refcode}"
@@ -1402,12 +1354,12 @@ def compare_versions(refcode):
         v1_object_id = ObjectId(query_params.v1)
         v2_object_id = ObjectId(query_params.v2)
     except (InvalidId, TypeError) as e:
-        return jsonify({"status": "error", "message": f"Invalid version ID format: {str(e)}"}), 400
+        raise BadRequest(f"Invalid version ID format: {str(e)}") from e
 
     v1 = flask_mongo.db.item_versions.find_one({"_id": v1_object_id, "refcode": refcode})
     v2 = flask_mongo.db.item_versions.find_one({"_id": v2_object_id, "refcode": refcode})
     if not v1 or not v2:
-        return jsonify({"status": "error", "message": "One or both versions not found"}), 404
+        raise NotFound("One or both versions not found")
 
     # Use DeepDiff for proper nested structure comparison
     # This handles nested dicts, lists, type changes, and provides detailed change information
@@ -1459,22 +1411,18 @@ def restore_version(refcode):
     try:
         version_object_id = ObjectId(restore_request.version_id)
     except (InvalidId, TypeError):
-        return jsonify(
-            {"status": "error", "message": f"Invalid version_id: {restore_request.version_id}"}
-        ), 400
+        raise BadRequest(f"Invalid version_id: {restore_request.version_id}") from None
 
     # Check permissions - user must have write access
     current_item = flask_mongo.db.items.find_one(
         {"refcode": refcode, **get_default_permissions(user_only=True)}
     )
     if not current_item:
-        return jsonify(
-            {"status": "error", "message": "Item not found or insufficient permissions"}
-        ), 404
+        raise NotFound("Item not found or insufficient permissions")
 
     version = flask_mongo.db.item_versions.find_one({"_id": version_object_id, "refcode": refcode})
     if not version:
-        return jsonify({"status": "error", "message": "Version not found"}), 404
+        raise NotFound("Version not found")
 
     restored_data = version["data"].copy()
 
@@ -1483,12 +1431,9 @@ def restore_version(refcode):
 
     # Ensure type consistency
     if restored_data.get("type") != current_item.get("type"):
-        return jsonify(
-            {
-                "status": "error",
-                "message": f"Cannot restore version with different type. Current: {current_item.get('type')}, Version: {restored_data.get('type')}",
-            }
-        ), 400
+        raise BadRequest(
+            f"Cannot restore version with different type. Current: {current_item.get('type')}, Version: {restored_data.get('type')}"
+        )
 
     # Atomically get the next version number (used for both version in item_versions and item.version)
     next_version_number = get_next_version_number(refcode)
@@ -1500,7 +1445,7 @@ def restore_version(refcode):
     # Validate restored data against the item model
     item_type = current_item["type"]
     if item_type not in ITEM_MODELS:
-        return jsonify({"status": "error", "message": f"Invalid item type: {item_type}"}), 400
+        raise BadRequest(f"Invalid item type: {item_type}")
 
     try:
         # Validate using the appropriate model
@@ -1580,9 +1525,7 @@ def delete_version(refcode, version_id):
     # Check if user has write access to the item (write access required)
     has_access, _ = check_version_access(refcode, user_only=True)
     if not has_access:
-        return jsonify(
-            {"status": "error", "message": "Item not found or insufficient permissions"}
-        ), 404
+        raise NotFound("Item not found or insufficient permissions")
 
     if len(refcode.split(":")) != 2:
         refcode = f"{CONFIG.IDENTIFIER_PREFIX}:{refcode}"
@@ -1590,13 +1533,13 @@ def delete_version(refcode, version_id):
     try:
         version_object_id = ObjectId(version_id)
     except (InvalidId, TypeError):
-        return jsonify({"status": "error", "message": f"Invalid version_id: {version_id}"}), 400
+        raise BadRequest(f"Invalid version_id: {version_id}") from None
 
     result = flask_mongo.db.item_versions.delete_one({"_id": version_object_id, "refcode": refcode})
     if result.deleted_count == 1:
         return jsonify({"status": "success"}), 200
     else:
-        return jsonify({"status": "error", "message": "Version not found"}), 404
+        raise NotFound("Version not found")
 
 
 @ITEMS.route("/items/<refcode>/save-version/", methods=["POST"])
@@ -1668,24 +1611,12 @@ def save_item():
     )
 
     if not item:
-        return (
-            jsonify(
-                status="error",
-                message=f"Unable to find item with appropriate permissions and {item_id=}.",
-            ),
-            404,
-        )
+        raise NotFound(f"Unable to find item with appropriate permissions and {item_id=}.")
 
     # Store refcode for version saving after successful update
     refcode = item.get("refcode")
     if not refcode:
-        return (
-            jsonify(
-                status="error",
-                message=f"Item {item_id} does not have a refcode.",
-            ),
-            400,
-        )
+        raise BadRequest(f"Item {item_id} does not have a refcode.")
 
     user_only = item["type"] not in ("starting_materials", "equipment")
 
@@ -1694,13 +1625,7 @@ def save_item():
     )
 
     if not item:
-        return (
-            jsonify(
-                status="error",
-                message=f"Unable to find item with appropriate permissions and {item_id=}.",
-            ),
-            404,
-        )
+        raise NotFound(f"Unable to find item with appropriate permissions and {item_id=}.")
 
     if "collections" in updated_data:
         requested_collections = updated_data["collections"]
@@ -1828,7 +1753,7 @@ def get_access_token_info(refcode: str):
     if access_token and check_access_token(refcode, access_token):
         pass
     elif not (current_user.is_authenticated):
-        return jsonify({"status": "error", "message": "Authentication required."}), 401
+        raise Unauthorized("Authentication required.")
 
     if len(refcode.split(":")) != 2:
         refcode = f"{CONFIG.IDENTIFIER_PREFIX}:{refcode}"
@@ -1839,12 +1764,7 @@ def get_access_token_info(refcode: str):
     )
 
     if not current_item:
-        return jsonify(
-            {
-                "status": "error",
-                "message": f"No valid item found with the given {refcode=}.",
-            }
-        ), 404
+        raise NotFound(f"No valid item found with the given {refcode=}.")
 
     existing_token = flask_mongo.db.api_keys.find_one(
         {"refcode": refcode, "active": True, "type": "access_token"},

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -11,7 +11,7 @@ from flask import Blueprint, jsonify, redirect, request
 from flask_login import current_user
 from pydantic import ValidationError
 from pymongo.errors import DuplicateKeyError
-from werkzeug.exceptions import BadRequest, Conflict, NotFound
+from werkzeug.exceptions import BadRequest, Conflict, InternalServerError, NotFound, Unauthorized
 
 from pydatalab.apps import BLOCK_TYPES
 from pydatalab.config import CONFIG
@@ -525,7 +525,7 @@ def search_items():
         types = types.split(",")
 
     if not query:
-        return jsonify({"status": "error", "message": "No query provided."}), 400
+        raise BadRequest("No query provided.")
 
     permissions = get_default_permissions(user_only=False)
     pipeline = build_search_pipeline(query, ITEMS_FTS_FIELDS, permissions)
@@ -799,12 +799,9 @@ def create_samples():
     sample_jsons = request_json["new_sample_datas"]
 
     if len(sample_jsons) > CONFIG.MAX_BATCH_CREATE_SIZE:
-        return jsonify(
-            {
-                "status": "error",
-                "message": f"Batch size limit exceeded. Maximum allowed: {CONFIG.MAX_BATCH_CREATE_SIZE}, requested: {len(sample_jsons)}",
-            }
-        ), 400
+        raise BadRequest(
+            f"Batch size limit exceeded. Maximum allowed: {CONFIG.MAX_BATCH_CREATE_SIZE}, requested: {len(sample_jsons)}"
+        )
 
     copy_from_item_ids = request_json.get("copy_from_item_ids")
     generate_ids_automatically = request_json.get("generate_ids_automatically")
@@ -852,13 +849,7 @@ def _process_item_permissions(
     )
 
     if not current_item:
-        return (
-            {
-                "status": "error",
-                "message": f"No valid item found with the given {refcode=}.",
-            },
-            401,
-        )
+        raise NotFound(f"No valid item found with the given {refcode=}.")
 
     current_creator_ids = current_item.get("creator_ids", [])
     current_group_ids = current_item.get("group_ids", [])
@@ -891,13 +882,7 @@ def _process_item_permissions(
         ]
 
     if not groups_requested and not creators_requested:
-        return (
-            {
-                "status": "error",
-                "message": "No valid creator or group IDs found in the request.",
-            },
-            400,
-        )
+        raise BadRequest("No valid creator or group IDs found in the request.")
 
     # Validate all creator IDs are present in the database
     if creator_ids:
@@ -905,13 +890,7 @@ def _process_item_permissions(
             d for d in flask_mongo.db.users.find({"_id": {"$in": creator_ids}}, {"_id": 1})
         ]
         if len(found_creator_ids) != len(creator_ids):
-            return (
-                {
-                    "status": "error",
-                    "message": "One or more creator IDs not found in the database.",
-                },
-                400,
-            )
+            raise BadRequest("One or more creator IDs not found in the database.")
 
     if group_ids:
         # Validate all group IDs are present in the database
@@ -919,13 +898,7 @@ def _process_item_permissions(
             d for d in flask_mongo.db.groups.find({"_id": {"$in": group_ids}}, {"_id": 1})
         ]
         if len(found_group_ids) != len(group_ids):
-            return (
-                {
-                    "status": "error",
-                    "message": "One or more group IDs not found in the database.",
-                },
-                400,
-            )
+            raise BadRequest("One or more group IDs not found in the database.")
 
     if append_mode:
         if creators_requested:
@@ -987,12 +960,8 @@ def _process_item_permissions(
     )
 
     if result.modified_count != 1:
-        return (
-            {
-                "status": "error",
-                "message": "Failed to update permissions: you cannot remove yourself or the base owner as a creator.",
-            },
-            400,
+        raise BadRequest(
+            "Failed to update permissions: you cannot remove yourself or the base owner as a creator."
         )
 
     return {"status": "success"}, 200
@@ -1031,12 +1000,7 @@ def issue_physical_token(refcode: str):
     )
 
     if not current_item:
-        return jsonify(
-            {
-                "status": "error",
-                "message": f"No valid item found with the given {refcode=}.",
-            }
-        ), 404
+        raise NotFound(f"No valid item found with the given {refcode=}.")
 
     token = secrets.token_urlsafe(16)
     access_document = AccessToken(
@@ -1051,15 +1015,13 @@ def issue_physical_token(refcode: str):
 
     try:
         result = flask_mongo.db.api_keys.insert_one(access_document.dict())
-        if not result.inserted_id:
-            return jsonify(
-                {"status": "error", "message": "Unknown error generating token for item."}
-            ), 500
+
     except Exception as e:
         LOGGER.error("Error inserting access token: %s", e)
-        return jsonify(
-            {"status": "error", "message": "Database error generating token for item."}
-        ), 500
+        raise InternalServerError("Database error generating token for item.") from e
+
+    if not result.inserted_id:
+        raise InternalServerError("Unknown error generating token for item.")
 
     return jsonify({"status": "success", "token": token}), 201
 
@@ -1075,30 +1037,14 @@ def delete_sample():
     )
 
     if not item:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "message": f"Authorization required to attempt to delete sample with {item_id=} from the database.",
-                }
-            ),
-            401,
-        )
+        raise NotFound(f"No valid item found with {item_id=} and current authorization.")
 
     result = flask_mongo.db.items.delete_one(
         {"item_id": item_id, **get_default_permissions(user_only=True, deleting=True)}
     )
 
     if result.deleted_count != 1:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "message": f"Failed to delete item with {item_id=}.",
-                }
-            ),
-            400,
-        )
+        raise BadRequest(f"Failed to delete item with {item_id=}.")
 
     flask_mongo.db.api_keys.delete_many({"refcode": item["refcode"], "type": "access_token"})
 
@@ -1166,15 +1112,7 @@ def get_item_data(
         doc = None
 
     if not doc:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "message": f"No matching items for {match=} with current authorization.",
-                }
-            ),
-            404,
-        )
+        raise NotFound(f"No matching items for {match=} with current authorization.")
 
     # See LAST_MODIFIED_PROJECTION: same backfill, applied outside an aggregation
     if not doc.get("last_modified") and isinstance(doc.get("_id"), ObjectId):
@@ -1202,15 +1140,9 @@ def get_item_data(
             doc["type"],
             error,
         )
-        return (
-            jsonify(
-                status="error",
-                message=(
-                    f"Item {item_id=} is stored in a state that does not validate "
-                    f"against the expected schema for its type {doc['type']}: {error}"
-                ),
-            ),
-            500,
+        raise InternalServerError(
+            f"Item {item_id=} is stored in a state that does not validate "
+            f"against the expected schema for its type {doc['type']}: {error}"
         )
 
     # find any documents with relationships that mention this document
@@ -1292,9 +1224,7 @@ def list_versions(refcode):
     # Check if user has access to the item (read access)
     has_access, _ = check_version_access(refcode, user_only=False)
     if not has_access:
-        return jsonify(
-            {"status": "error", "message": "Item not found or insufficient permissions"}
-        ), 404
+        raise NotFound("Item not found or insufficient permissions")
 
     if len(refcode.split(":")) != 2:
         refcode = f"{CONFIG.IDENTIFIER_PREFIX}:{refcode}"
@@ -1346,9 +1276,7 @@ def get_version(refcode, version_id):
     # Check if user has access to the item (read access)
     has_access, _ = check_version_access(refcode, user_only=False)
     if not has_access:
-        return jsonify(
-            {"status": "error", "message": "Item not found or insufficient permissions"}
-        ), 404
+        raise NotFound("Item not found or insufficient permissions")
 
     if len(refcode.split(":")) != 2:
         refcode = f"{CONFIG.IDENTIFIER_PREFIX}:{refcode}"
@@ -1356,7 +1284,7 @@ def get_version(refcode, version_id):
     try:
         version_object_id = ObjectId(version_id)
     except (InvalidId, TypeError):
-        return jsonify({"status": "error", "message": f"Invalid version_id: {version_id}"}), 400
+        raise BadRequest(f"Invalid version_id: {version_id}") from None
 
     version = list(
         flask_mongo.db.item_versions.aggregate(
@@ -1383,7 +1311,7 @@ def get_version(refcode, version_id):
         version = version[0]
 
     if not version:
-        return jsonify({"status": "error", "message": "Version not found"}), 404
+        raise NotFound("Version not found")
 
     return jsonify({"status": "success", "version": version}), 200
 
@@ -1397,9 +1325,7 @@ def compare_versions(refcode):
     # Check if user has access to the item (read access)
     has_access, _ = check_version_access(refcode, user_only=False)
     if not has_access:
-        return jsonify(
-            {"status": "error", "message": "Item not found or insufficient permissions"}
-        ), 404
+        raise NotFound("Item not found or insufficient permissions")
 
     if len(refcode.split(":")) != 2:
         refcode = f"{CONFIG.IDENTIFIER_PREFIX}:{refcode}"
@@ -1410,20 +1336,18 @@ def compare_versions(refcode):
             v1=request.args.get("v1", ""), v2=request.args.get("v2", "")
         )
     except ValidationError as exc:
-        return jsonify(
-            {"status": "error", "message": "Invalid query parameters", "errors": exc.errors()}
-        ), 400
+        raise BadRequest(f"Invalid query parameters: {exc.errors()}") from exc
 
     try:
         v1_object_id = ObjectId(query_params.v1)
         v2_object_id = ObjectId(query_params.v2)
     except (InvalidId, TypeError) as e:
-        return jsonify({"status": "error", "message": f"Invalid version ID format: {str(e)}"}), 400
+        raise BadRequest(f"Invalid version ID format: {str(e)}") from e
 
     v1 = flask_mongo.db.item_versions.find_one({"_id": v1_object_id, "refcode": refcode})
     v2 = flask_mongo.db.item_versions.find_one({"_id": v2_object_id, "refcode": refcode})
     if not v1 or not v2:
-        return jsonify({"status": "error", "message": "One or both versions not found"}), 404
+        raise NotFound("One or both versions not found")
 
     # Use DeepDiff for proper nested structure comparison
     # This handles nested dicts, lists, type changes, and provides detailed change information
@@ -1467,30 +1391,24 @@ def restore_version(refcode):
     # Validate request body using Pydantic model
     try:
         restore_request = RestoreVersionRequest(**request.get_json())
-    except ValidationError as exc:
-        return jsonify(
-            {"status": "error", "message": "Invalid request body", "errors": exc.errors()}
-        ), 400
+    except ValidationError:
+        return BadRequest("Invalid request body")
 
     try:
         version_object_id = ObjectId(restore_request.version_id)
     except (InvalidId, TypeError):
-        return jsonify(
-            {"status": "error", "message": f"Invalid version_id: {restore_request.version_id}"}
-        ), 400
+        raise BadRequest(f"Invalid version_id: {restore_request.version_id}") from None
 
     # Check permissions - user must have write access
     current_item = flask_mongo.db.items.find_one(
         {"refcode": refcode, **get_default_permissions(user_only=True)}
     )
     if not current_item:
-        return jsonify(
-            {"status": "error", "message": "Item not found or insufficient permissions"}
-        ), 404
+        raise NotFound("Item not found or insufficient permissions")
 
     version = flask_mongo.db.item_versions.find_one({"_id": version_object_id, "refcode": refcode})
     if not version:
-        return jsonify({"status": "error", "message": "Version not found"}), 404
+        raise NotFound("Version not found")
 
     restored_data = version["data"].copy()
 
@@ -1499,12 +1417,9 @@ def restore_version(refcode):
 
     # Ensure type consistency
     if restored_data.get("type") != current_item.get("type"):
-        return jsonify(
-            {
-                "status": "error",
-                "message": f"Cannot restore version with different type. Current: {current_item.get('type')}, Version: {restored_data.get('type')}",
-            }
-        ), 400
+        raise BadRequest(
+            f"Cannot restore version with different type. Current: {current_item.get('type')}, Version: {restored_data.get('type')}"
+        )
 
     # Atomically get the next version number (used for both version in item_versions and item.version)
     next_version_number = get_next_version_number(refcode)
@@ -1516,19 +1431,13 @@ def restore_version(refcode):
     # Validate restored data against the item model
     item_type = current_item["type"]
     if item_type not in ITEM_MODELS:
-        return jsonify({"status": "error", "message": f"Invalid item type: {item_type}"}), 400
+        raise BadRequest(f"Invalid item type: {item_type}")
 
     try:
         # Validate using the appropriate model
         ITEM_MODELS[item_type](**restored_data)
-    except ValidationError as exc:
-        return jsonify(
-            {
-                "status": "error",
-                "message": f"Restored data failed validation: {str(exc)}",
-                "output": str(exc),
-            }
-        ), 400
+    except ValidationError:
+        raise BadRequest("Restored data failed validation")
 
     # Perform the restore first
     flask_mongo.db.items.update_one({"refcode": refcode}, {"$set": restored_data})
@@ -1559,19 +1468,8 @@ def restore_version(refcode):
     # Validate with Pydantic before inserting
     try:
         validated_restored_version = ItemVersion(**restored_version_entry)
-    except ValidationError as exc:
-        LOGGER.error(
-            "Restored version validation failed for item %s: %s",
-            refcode,
-            str(exc),
-        )
-        return jsonify(
-            {
-                "status": "error",
-                "message": f"Restored version data validation failed: {str(exc)}",
-                "output": str(exc),
-            }
-        ), 400
+    except ValidationError:
+        raise InternalServerError("Restored version data validation failed")
 
     # Insert validated data
     flask_mongo.db.item_versions.insert_one(
@@ -1596,9 +1494,7 @@ def delete_version(refcode, version_id):
     # Check if user has write access to the item (write access required)
     has_access, _ = check_version_access(refcode, user_only=True)
     if not has_access:
-        return jsonify(
-            {"status": "error", "message": "Item not found or insufficient permissions"}
-        ), 404
+        raise NotFound("Item not found or insufficient permissions")
 
     if len(refcode.split(":")) != 2:
         refcode = f"{CONFIG.IDENTIFIER_PREFIX}:{refcode}"
@@ -1606,13 +1502,13 @@ def delete_version(refcode, version_id):
     try:
         version_object_id = ObjectId(version_id)
     except (InvalidId, TypeError):
-        return jsonify({"status": "error", "message": f"Invalid version_id: {version_id}"}), 400
+        raise BadRequest(f"Invalid version_id: {version_id}") from None
 
     result = flask_mongo.db.item_versions.delete_one({"_id": version_object_id, "refcode": refcode})
     if result.deleted_count == 1:
         return jsonify({"status": "success"}), 200
     else:
-        return jsonify({"status": "error", "message": "Version not found"}), 404
+        raise NotFound("Version not found")
 
 
 @ITEMS.route("/items/<refcode>/save-version/", methods=["POST"])
@@ -1676,24 +1572,12 @@ def save_item():
     )
 
     if not item:
-        return (
-            jsonify(
-                status="error",
-                message=f"Unable to find item with appropriate permissions and {item_id=}.",
-            ),
-            404,
-        )
+        raise NotFound(f"Unable to find item with appropriate permissions and {item_id=}.")
 
     # Store refcode for version saving after successful update
     refcode = item.get("refcode")
     if not refcode:
-        return (
-            jsonify(
-                status="error",
-                message=f"Item {item_id} does not have a refcode.",
-            ),
-            400,
-        )
+        raise BadRequest(f"Item {item_id} does not have a refcode.")
 
     user_only = item["type"] not in ("starting_materials", "equipment")
 
@@ -1702,13 +1586,7 @@ def save_item():
     )
 
     if not item:
-        return (
-            jsonify(
-                status="error",
-                message=f"Unable to find item with appropriate permissions and {item_id=}.",
-            ),
-            404,
-        )
+        raise NotFound(f"Unable to find item with appropriate permissions and {item_id=}.")
 
     stored_blocks = item.get("blocks_obj", {})
     for block_id, block_data in updated_data.get("blocks_obj", {}).items():
@@ -1775,14 +1653,9 @@ def save_item():
     try:
         item = entry_reference_lookup(item)
         item = ITEM_MODELS[item_type](**item).dict()
-    except ValidationError as exc:
-        return (
-            jsonify(
-                status="error",
-                message=f"Unable to update item {item_id=} ({item_type=}) with new data {updated_data}",
-                output=str(exc),
-            ),
-            400,
+    except ValidationError:
+        raise BadRequest(
+            f"Unable to update item {item_id=} ({item_type=}) with new data {updated_data}"
         )
 
     if preserve_relationships and original_relationships is not None:
@@ -1805,14 +1678,7 @@ def save_item():
     )
 
     if result.matched_count != 1:
-        return (
-            jsonify(
-                status="error",
-                message=f"{item_id} item update failed. no subdocument matched",
-                output=result.raw_result,
-            ),
-            400,
-        )
+        raise BadRequest(f"{item_id} item update failed. no subdocument matched")
 
     # Now save a version AFTER successful item update.
     # Only increment item.version and bump last_modified when content actually changed
@@ -1858,7 +1724,7 @@ def get_access_token_info(refcode: str):
     if access_token and check_access_token(refcode, access_token):
         pass
     elif not (current_user.is_authenticated):
-        return jsonify({"status": "error", "message": "Authentication required."}), 401
+        raise Unauthorized("Authentication required.")
 
     if len(refcode.split(":")) != 2:
         refcode = f"{CONFIG.IDENTIFIER_PREFIX}:{refcode}"
@@ -1869,12 +1735,7 @@ def get_access_token_info(refcode: str):
     )
 
     if not current_item:
-        return jsonify(
-            {
-                "status": "error",
-                "message": f"No valid item found with the given {refcode=}.",
-            }
-        ), 404
+        raise NotFound(f"No valid item found with the given {refcode=}.")
 
     existing_token = flask_mongo.db.api_keys.find_one(
         {"refcode": refcode, "active": True, "type": "access_token"},

--- a/pydatalab/src/pydatalab/routes/v0_1/remotes.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/remotes.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from flask import Blueprint, jsonify, request
 from flask_login import current_user
-from werkzeug.exceptions import BadRequest
+from werkzeug.exceptions import BadRequest, NotFound, Unauthorized
 
 from pydatalab.config import CONFIG
 from pydatalab.permissions import active_users_or_get_only
@@ -45,30 +45,9 @@ def list_remote_directories():
         not (current_user.is_authenticated and current_user.account_status == "active")
         and not CONFIG.TESTING
     ):
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "title": "Not Authorized",
-                    "detail": "Listing remote directories requires authentication.",
-                }
-            ),
-            401,
-        )
+        raise Unauthorized("Listing remote directories requires authentication.")
 
-    try:
-        invalidate_cache = _check_invalidate_cache(request.args)
-    except RuntimeError as e:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "title": "Invalid Argument",
-                    "detail": str(e),
-                }
-            ),
-            400,
-        )
+    invalidate_cache = _check_invalidate_cache(request.args)
 
     all_directory_structures = get_directory_structures(
         CONFIG.REMOTE_FILESYSTEMS, invalidate_cache=invalidate_cache
@@ -94,46 +73,16 @@ def get_remote_directory(remote_id: str):
 
     """
     if not current_user.is_authenticated and not CONFIG.TESTING:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "title": "Not Authorized",
-                    "detail": "Listing remote directories requires authentication.",
-                }
-            ),
-            401,
-        )
+        raise Unauthorized("Listing remote directories requires authentication.")
 
-    try:
-        invalidate_cache = _check_invalidate_cache(request.args)
-    except RuntimeError as e:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "title": "Invalid Argument",
-                    "detail": str(e),
-                }
-            ),
-            400,
-        )
+    invalidate_cache = _check_invalidate_cache(request.args)
 
     for d in CONFIG.REMOTE_FILESYSTEMS:
         if remote_id == d.name:
             remote_obj = d
             break
     else:
-        return (
-            jsonify(
-                {
-                    "status": "error",
-                    "title": "Not Found",
-                    "detail": f"No remote found with name {remote_id!r}",
-                }
-            ),
-            404,
-        )
+        raise NotFound(f"No remote found with name {remote_id!r}")
 
     directory_structure = get_directory_structure(remote_obj, invalidate_cache=invalidate_cache)
 

--- a/pydatalab/src/pydatalab/routes/v0_1/users.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/users.py
@@ -159,7 +159,7 @@ def get_user_activity(user_id):
     """Get activity data for a specific user (creation dates)."""
 
     if str(current_user.person.immutable_id) != user_id and current_user.role != "admin":
-        return jsonify({"status": "error", "message": "Unauthorized"}), 403
+        raise Forbidden("User not allowed to view this activity.")
 
     months = int(request.args.get("months", 12))
 
@@ -207,7 +207,7 @@ def search_users():
     nresults = request.args.get("nresults", default=100, type=int)
 
     if not query:
-        return jsonify({"status": "error", "message": "No query provided."}), 400
+        raise BadRequest("No query provided.")
 
     pipeline = build_search_pipeline(query, USERS_FTS_FIELDS, permissions=None)
     pipeline.append({"$limit": nresults})

--- a/pydatalab/tests/server/test_export.py
+++ b/pydatalab/tests/server/test_export.py
@@ -226,7 +226,7 @@ def test_download_export_not_ready(client, user_id, database):
     database.tasks.insert_one(task.dict())
 
     response = client.get(f"/exports/{task_id}/download")
-    assert response.status_code == 400
+    assert response.status_code == 409
 
     data = json.loads(response.data)
     assert "not ready" in data["message"].lower()

--- a/pydatalab/tests/server/test_files.py
+++ b/pydatalab/tests/server/test_files.py
@@ -216,7 +216,7 @@ def test_file_permissions(
 
     # Test that a random user cannot access the file directly
     response = another_client.get(f"/files/{file_id}/{filename}")
-    assert response.status_code == 401
+    assert response.status_code == 403
     assert response.json["status"] == "error"
 
     # Give the user access to the item, then check again
@@ -275,7 +275,7 @@ def test_file_download_sudo_mode(
 
     # Admin without ?sudo=1 cannot access the file
     response = admin_client.get(f"/files/{file_id}/{filename}")
-    assert response.status_code == 401
+    assert response.status_code == 403
 
     # Admin with ?sudo=1 can access the file
     response = admin_client.get(f"/files/{file_id}/{filename}?sudo=1")

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -860,7 +860,7 @@ def test_add_items_to_collection_not_found(client):
 
     response = client.post(f"/collections/{collection_id}", json={"data": {"refcodes": []}})
     assert response.status_code == 404
-    assert response.json["error"] == "Collection not found"
+    assert response.json["message"] == "Collection not found"
 
 
 @pytest.mark.dependency(depends=["test_add_items_to_collection_not_found"])
@@ -870,7 +870,7 @@ def test_add_items_to_collection_no_items(client, default_collection):
     )
 
     assert response.status_code == 400
-    assert response.json["error"] == "No item provided"
+    assert response.json["message"] == "No item provided"
 
 
 @pytest.mark.dependency(depends=["test_add_items_to_collection_no_items"])
@@ -881,7 +881,7 @@ def test_add_items_to_collection_no_matching_items(client, default_collection):
         f"/collections/{default_collection.collection_id}", json={"data": {"refcodes": refcodes}}
     )
     assert response.status_code == 404
-    assert response.json["error"] == "No matching items found"
+    assert response.json["message"] == "No matching items found"
 
 
 @pytest.mark.dependency(depends=["test_add_items_to_collection_no_matching_items"])
@@ -990,7 +990,7 @@ def test_remove_items_from_collection_not_found(client):
 
     assert response.status_code == 404
     data = response.get_json()
-    assert data["error"] == "Collection not found"
+    assert data["message"] == "Collection not found"
 
 
 @pytest.mark.dependency()
@@ -1006,7 +1006,7 @@ def test_remove_items_from_collection_no_items_provided(client, default_collecti
 
     assert response.status_code == 400
     data = response.get_json()
-    assert data["error"] == "No refcodes provided"
+    assert data["message"] == "No refcodes provided"
 
 
 @pytest.mark.dependency()

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -776,7 +776,7 @@ def test_add_items_to_collection_not_found(client):
 
     response = client.post(f"/collections/{collection_id}", json={"data": {"refcodes": []}})
     assert response.status_code == 404
-    assert response.json["error"] == "Collection not found"
+    assert response.json["message"] == "Collection not found"
 
 
 @pytest.mark.dependency(depends=["test_add_items_to_collection_not_found"])
@@ -786,7 +786,7 @@ def test_add_items_to_collection_no_items(client, default_collection):
     )
 
     assert response.status_code == 400
-    assert response.json["error"] == "No item provided"
+    assert response.json["message"] == "No item provided"
 
 
 @pytest.mark.dependency(depends=["test_add_items_to_collection_no_items"])
@@ -797,7 +797,7 @@ def test_add_items_to_collection_no_matching_items(client, default_collection):
         f"/collections/{default_collection.collection_id}", json={"data": {"refcodes": refcodes}}
     )
     assert response.status_code == 404
-    assert response.json["error"] == "No matching items found"
+    assert response.json["message"] == "No matching items found"
 
 
 @pytest.mark.dependency(depends=["test_add_items_to_collection_no_matching_items"])
@@ -906,7 +906,7 @@ def test_remove_items_from_collection_not_found(client):
 
     assert response.status_code == 404
     data = response.get_json()
-    assert data["error"] == "Collection not found"
+    assert data["message"] == "Collection not found"
 
 
 @pytest.mark.dependency()
@@ -922,7 +922,7 @@ def test_remove_items_from_collection_no_items_provided(client, default_collecti
 
     assert response.status_code == 400
     data = response.get_json()
-    assert data["error"] == "No refcodes provided"
+    assert data["message"] == "No refcodes provided"
 
 
 @pytest.mark.dependency()

--- a/pydatalab/tests/server/test_starting_materials.py
+++ b/pydatalab/tests/server/test_starting_materials.py
@@ -235,7 +235,7 @@ def test_starting_material_permissions(
         json={"item_id": default_starting_material_dict["item_id"]},
     )
 
-    assert response.status_code == 401
+    assert response.status_code == 404
 
     # Check that the admin can delete a starting material that has no user
     response = admin_client.post(

--- a/pydatalab/tests/server/test_users.py
+++ b/pydatalab/tests/server/test_users.py
@@ -178,7 +178,7 @@ def test_groups(
 
     # Group ID must be unique
     resp = admin_client.put("/groups", json=good_group)
-    assert resp.status_code == 400
+    assert resp.status_code == 409
 
     # Request must come from admin
     # Make ID unique so that this would otherwise pass


### PR DESCRIPTION
As discussed in #1944, converted jsonify errors to werkzeug exceptions.

A few error code changes when clearly not correct.

This is done only on the jsonify errors that were very clear (only status, message and error code). More "complex" jsonify errors are left as is.

Just as a showcase for #1944.

Done with AI but reviewed.

Went from ~115 jsonify errors to ~40 (some of which are probably still very easy to convert)

@OMWalmsley 