### PR TITLE
Promote location to be a item-level field

### DIFF
--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -27,6 +27,10 @@
         "$ref": "#/definitions/Collection"
       }
     },
+    "location": {
+      "title": "Location",
+      "type": "string"
+    },
     "revision": {
       "title": "Revision",
       "default": 1,

--- a/pydatalab/schemas/equipment.json
+++ b/pydatalab/schemas/equipment.json
@@ -27,6 +27,10 @@
         "$ref": "#/definitions/Collection"
       }
     },
+    "location": {
+      "title": "Location",
+      "type": "string"
+    },
     "revision": {
       "title": "Revision",
       "default": 1,
@@ -151,10 +155,6 @@
     },
     "manufacturer": {
       "title": "Manufacturer",
-      "type": "string"
-    },
-    "location": {
-      "title": "Location",
       "type": "string"
     },
     "contact": {

--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -82,6 +82,10 @@
         "$ref": "#/definitions/Collection"
       }
     },
+    "location": {
+      "title": "Location",
+      "type": "string"
+    },
     "revision": {
       "title": "Revision",
       "default": 1,

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -3,6 +3,10 @@
   "description": "A model for representing an experimental sample, based on the connection\nwith cheminventory.net, which mixes container-level and substance-level\ninformation.",
   "type": "object",
   "properties": {
+    "location": {
+      "title": "Location",
+      "type": "string"
+    },
     "chemform": {
       "title": "Chemform",
       "example": [
@@ -227,10 +231,6 @@
     },
     "supplier": {
       "title": "Supplier",
-      "type": "string"
-    },
-    "location": {
-      "title": "Location",
       "type": "string"
     },
     "comment": {

--- a/pydatalab/src/pydatalab/models/equipment.py
+++ b/pydatalab/src/pydatalab/models/equipment.py
@@ -17,9 +17,6 @@ class Equipment(Item):
     manufacturer: str | None
     """The manufacturer of this piece of equipment"""
 
-    location: str | None
-    """Place where the equipment is located"""
-
     contact: str | None
     """Contact information for equipment (e.g., email address or phone number)."""
 

--- a/pydatalab/src/pydatalab/models/items.py
+++ b/pydatalab/src/pydatalab/models/items.py
@@ -6,6 +6,7 @@ from pydatalab.models.entries import Entry
 from pydatalab.models.files import File
 from pydatalab.models.traits import (
     HasBlocks,
+    HasLocation,
     HasOwner,
     HasRevisionControl,
     IsCollectable,
@@ -18,7 +19,7 @@ from pydatalab.models.utils import (
 )
 
 
-class Item(Entry, HasOwner, HasRevisionControl, IsCollectable, HasBlocks, abc.ABC):
+class Item(Entry, HasOwner, HasRevisionControl, HasLocation, IsCollectable, HasBlocks, abc.ABC):
     """The generic model for data types that will be exposed with their own named endpoints."""
 
     refcode: Refcode = None  # type: ignore

--- a/pydatalab/src/pydatalab/models/starting_materials.py
+++ b/pydatalab/src/pydatalab/models/starting_materials.py
@@ -1,11 +1,11 @@
 from pydantic import Field
 
 from pydatalab.models.items import Item
-from pydatalab.models.traits import HasSubstanceInfo, HasSynthesisInfo
+from pydatalab.models.traits import HasLocation, HasSubstanceInfo, HasSynthesisInfo
 from pydatalab.models.utils import IsoformatDateTime, StartingMaterialsStatus
 
 
-class StartingMaterial(Item, HasSynthesisInfo, HasSubstanceInfo):
+class StartingMaterial(Item, HasSynthesisInfo, HasSubstanceInfo, HasLocation):
     """A model for representing an experimental sample, based on the connection
     with cheminventory.net, which mixes container-level and substance-level
     information.
@@ -44,9 +44,6 @@ class StartingMaterial(Item, HasSynthesisInfo, HasSubstanceInfo):
 
     supplier: str | None = Field(alias="Supplier")
     """Supplier or manufacturer of the chemical."""
-
-    location: str | None = Field(alias="Location")
-    """The place where the container is located."""
 
     comment: str | None = Field(alias="Comments")
     """Any additional comments or notes about the container."""

--- a/pydatalab/src/pydatalab/models/traits.py
+++ b/pydatalab/src/pydatalab/models/traits.py
@@ -216,3 +216,8 @@ class HasSubstanceInfo(BaseModel):
                 return None
 
         return v
+
+
+class HasLocation(BaseModel):
+    location: str | None = Field(alias="Location")
+    """The place where the item is located."""


### PR DESCRIPTION
This pull request refactors how the `location` field is handled across several schema and model files. The main change is to centralize the definition of `location` by introducing a new `HasLocation` trait, and to update models to use this trait instead of defining `location` individually.