### PR TITLE
Allow non-creators but those with permission to "read" blocks

### DIFF
--- a/pydatalab/src/pydatalab/routes/v0_1/blocks.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/blocks.py
@@ -294,7 +294,7 @@ def _save_block_to_db(block: DataBlock):
     match = {
         "item_id": block.data["item_id"],
         f"blocks_obj.{block.block_id}": {"$exists": True},
-        **get_default_permissions(user_only=True),
+        **get_default_permissions(user_only=False),
     }
     result = flask_mongo.db.items.update_one(match, update)
 
@@ -328,7 +328,7 @@ def update_block():
         raise BadRequest(f"Invalid or missing item_id: {item_id}")
 
     if not flask_mongo.db.items.find_one(
-        {"item_id": item_id, **get_default_permissions(user_only=True)}
+        {"item_id": item_id, **get_default_permissions(user_only=False)}
     ):
         raise NotFound(f"Item with item_id {item_id} not found or not accessible")
 

--- a/pydatalab/tests/server/test_blocks.py
+++ b/pydatalab/tests/server/test_blocks.py
@@ -121,7 +121,8 @@ def test_add_multiple_blocks_to_sample(admin_client, default_sample_dict):
 
 def test_block_permissions(client, admin_client, unauthenticated_client, default_sample_dict):
     """Test that normal users can add blocks to samples they have access to, but unauthenticated users cannot,
-    and that another user cannot update another user's block if they know the IDs.
+    and that a user with read access to an item (e.g., via a shared group) can update its blocks,
+    even if they are not its creator.
 
     """
     sample_id = "test_sample_user_permissions"
@@ -201,7 +202,11 @@ def test_block_permissions(client, admin_client, unauthenticated_client, default
         },
     )
 
-    bad_response = client.post(
+    # `client` shares a group with `admin_client` (via `default_sample_dict`), so it has read
+    # access to this item and is currently permitted to update its blocks, even though it is
+    # not the creator. This is intentionally relaxed for now (to allow rendering/collaboration)
+    # and should be tightened once block permissions are refactored.
+    read_access_response = client.post(
         "/update-block/",
         json={
             "block_data": {
@@ -213,7 +218,7 @@ def test_block_permissions(client, admin_client, unauthenticated_client, default
         },
     )
 
-    assert bad_response.status_code == 404
+    assert read_access_response.status_code == 200
 
 
 def test_add_block_to_nonexistent_item(admin_client):


### PR DESCRIPTION
Bug where someone with access to a collection, but not a creator couldn't load certain blocks. E.g EIS, Cyclic Voltammetry etc.