### PR TITLE
Remove all item graph caching from the store

### DIFF
--- a/webapp/src/components/CollectionRelationshipVisualization.vue
+++ b/webapp/src/components/CollectionRelationshipVisualization.vue
@@ -42,16 +42,21 @@ export default {
       default: null,
     },
   },
-  computed: {
-    graphData() {
-      return this.$store.state.itemGraphData;
-    },
-    isLoading() {
-      return this.$store.state.itemGraphIsLoading;
-    },
+  data() {
+    return {
+      graphData: null,
+      isLoading: true,
+    };
   },
   mounted() {
-    getItemGraph({ item_id: null, collection_id: this.collection_id });
+    this.isLoading = true;
+    getItemGraph({ item_id: null, collection_id: this.collection_id })
+      .then((graphData) => {
+        this.graphData = graphData;
+      })
+      .finally(() => {
+        this.isLoading = false;
+      });
   },
 };
 </script>

--- a/webapp/src/components/ItemRelationshipVisualization.vue
+++ b/webapp/src/components/ItemRelationshipVisualization.vue
@@ -41,18 +41,25 @@ export default {
   props: {
     item_id: { type: String, required: true },
   },
-  computed: {
-    graphData() {
-      return this.$store.state.itemGraphData;
-    },
-    isLoading() {
-      return this.$store.state.itemGraphIsLoading;
-    },
+  data() {
+    return {
+      graphData: null,
+      isLoading: true,
+    };
   },
   mounted() {
     // Defer the graph fetch (and subsequent layout) until the browser is
     // idle, so it does not compete with the initial item and block loads
-    const load = () => getItemGraph({ item_id: this.item_id });
+    const load = () => {
+      this.isLoading = true;
+      getItemGraph({ item_id: this.item_id })
+        .then((graphData) => {
+          this.graphData = graphData;
+        })
+        .finally(() => {
+          this.isLoading = false;
+        });
+    };
     if (window.requestIdleCallback) {
       this.idleCallbackId = window.requestIdleCallback(load, { timeout: 2000 });
     } else {

--- a/webapp/src/components/SampleGraphExportModal.vue
+++ b/webapp/src/components/SampleGraphExportModal.vue
@@ -217,7 +217,6 @@ export default {
         const graphData = await getItemGraph({
           item_id: this.itemId,
           max_depth: this.graphDepth,
-          updateStore: false,
         });
 
         const previouslySelected = new Set(this.selectedSampleIds);
@@ -343,7 +342,6 @@ export default {
         const response = await getItemGraph({
           item_id: this.itemId,
           max_depth: this.graphDepth,
-          updateStore: false,
         });
         this.graphData = response;
       } catch (error) {

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -1165,20 +1165,14 @@ export async function addRemoteFileToSample(file_entry, item_id) {
 }
 
 /**
- * Fetches an item graph from the API with optional store updates
+ * Fetches an item graph from the API
  * @param {Object} options - Configuration options
  * @param {string|null} options.item_id - The item ID to fetch graph for
  * @param {string|null} options.collection_id - The collection ID to filter by
  * @param {number} options.max_depth - Maximum depth for related items (default: 1)
- * @param {boolean} options.updateStore - Whether to update Vuex store (default: true)
- * @returns {Promise<Object|void>} Returns graph data if updateStore is false, void otherwise
+ * @returns {Promise<Object>} Returns graph data ({ nodes, edges })
  */
-export async function getItemGraph({
-  item_id = null,
-  collection_id = null,
-  max_depth = 1,
-  updateStore = true,
-} = {}) {
+export async function getItemGraph({ item_id = null, collection_id = null, max_depth = 1 } = {}) {
   // Short-circuit and do not send request if user is not logged in
   if (!(await waitForUserAuth())) return;
 
@@ -1201,29 +1195,11 @@ export async function getItemGraph({
   const urlParams = new URLSearchParams(window.location.search);
   const accessToken = urlParams.get("at");
 
-  if (updateStore) {
-    // Clear any previously loaded graph so components do not lay out
-    // stale data from another item/collection while this fetch is in flight
-    store.commit("setItemGraph", null);
-    store.commit("setItemGraphIsLoading", true);
-  }
-
   return fetch_get(url)
     .then(function (response_json) {
-      const graphData = { nodes: response_json.nodes, edges: response_json.edges };
-
-      if (updateStore) {
-        store.commit("setItemGraph", graphData);
-        store.commit("setItemGraphIsLoading", false);
-      }
-
-      return graphData;
+      return { nodes: response_json.nodes, edges: response_json.edges };
     })
     .catch((error) => {
-      if (updateStore) {
-        store.commit("setItemGraphIsLoading", false);
-      }
-
       if (!accessToken) {
         DialogService.error({
           title: "Graph Retrieval Failed",

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -26,8 +26,6 @@ export default createStore({
     updatingDelayed: {},
     remoteDirectoryTree: {},
     remoteDirectoryTreeSecondsSinceLastUpdate: null,
-    itemGraphData: null,
-    itemGraphIsLoading: false,
     remoteDirectoryTreeIsLoading: false,
     fileSelectModalIsOpen: false,
     currentUserDisplayName: null,
@@ -373,14 +371,8 @@ export default createStore({
     setRemoteDirectoryTreeIsLoading(state, isLoading) {
       state.remoteDirectoryTreeIsLoading = isLoading;
     },
-    setItemGraph(state, payload) {
-      state.itemGraphData = payload;
-    },
     setCurrentUserInfoLoading(state, isLoading) {
       state.currentUserInfoLoading = isLoading;
-    },
-    setItemGraphIsLoading(state, isLoading) {
-      state.itemGraphIsLoading = isLoading;
     },
     setBlocksInfos(state, blocksInfos) {
       blocksInfos.forEach((info) => {

--- a/webapp/src/views/ItemGraphPage.vue
+++ b/webapp/src/views/ItemGraphPage.vue
@@ -34,19 +34,19 @@ export default {
   },
   data() {
     return {
-      isLoaded: false,
+      graphData: null,
+      isLoading: true,
     };
   },
-  computed: {
-    graphData() {
-      return this.$store.state.itemGraphData;
-    },
-    isLoading() {
-      return this.$store.state.itemGraphIsLoading;
-    },
-  },
   mounted() {
-    getItemGraph();
+    this.isLoading = true;
+    getItemGraph()
+      .then((graphData) => {
+        this.graphData = graphData;
+      })
+      .finally(() => {
+        this.isLoading = false;
+      });
   },
 };
 </script>


### PR DESCRIPTION
Completes the saga of slow graph loading (e.g., #1933).