### PR TITLE
Fix ephemeral race condition in e2e test of batch sample table

### DIFF
--- a/webapp/cypress/e2e/sampleTablePage.cy.js
+++ b/webapp/cypress/e2e/sampleTablePage.cy.js
@@ -238,6 +238,8 @@ describe("Advanced sample creation features", () => {
   });
 
   it("modifies some data in the second sample", () => {
+    cy.intercept("POST", "**/save-item/").as("saveItem");
+
     cy.findByText("testB").click();
     cy.findByLabelText("Description").type("this is a description of testB.");
     cy.get('[data-testid="add-block-button-top"]').click();
@@ -259,7 +261,12 @@ describe("Advanced sample creation features", () => {
     cy.findByLabelText("Procedure").type("a description of the synthesis here");
 
     cy.get(".fa-save").click();
+    cy.wait("@saveItem").then(({ response }) => {
+      expect(response.statusCode).to.equal(200);
+      expect(response.body).to.have.property("status", "success");
+    });
     cy.findByText("Home").click();
+    cy.location("pathname").should("equal", "/");
   });
 
   it("copies the second sample", () => {


### PR DESCRIPTION
In the cypress test for the sample table page, there might be some race condition between the save of the testB and the copy of testB to testB_COPY.
Not sure if this is the only reason (and if it is the right one...) why we sometimes get random failures.

I've added a wait for the save to actually happen before making a copy.