### PR TITLE
Extend GSAS-II vendored .raw reader to be able to read incomplete files

### DIFF
--- a/pydatalab/src/pydatalab/apps/xrd/utils.py
+++ b/pydatalab/src/pydatalab/apps/xrd/utils.py
@@ -1,5 +1,6 @@
 import os
 import re
+import struct
 import tempfile
 import warnings
 import zipfile
@@ -238,7 +239,11 @@ def parse_bruker_raw(filename: str) -> tuple[pd.DataFrame, dict]:
 
     class raw_ReaderClass:
         """This class is essentially vendored from GSAS-II, with only interface
-        and cosmetic changes:
+        and cosmetic changes.
+
+        06/08/2026 - Method was also updated to allow for incremental reading of partial v4 files,
+        by essentially wrapping all byte block reads into a try/except that will return whatever
+        could be read and emit a warning if the read was partial.
 
         - Permalink: https://github.com/AdvancedPhotonSource/GSAS-II/blob/b87f554c5ca767601cf6f24187645c36947f9a35/GSASII/imports/G2pwd_BrukerRAW.py
         - Copyright: 2010, UChicago Argonne, LLC, Operator of Argonne National Laboratory. All rights reserved.
@@ -544,12 +549,18 @@ def parse_bruker_raw(filename: str) -> tuple[pd.DataFrame, dict]:
                                     pass
                                 fp.read(12)
                                 x = np.array([startAngle + i * stepSize for i in range(Nsteps)])
-                                y = np.array(
-                                    [
-                                        max(1.0, st.unpack("<f", fp.read(4))[0])
-                                        for i in range(Nsteps)
-                                    ]
-                                )
+                                y = np.zeros_like(x)
+                                y *= np.nan
+                                # datalab-specific edit: accumulate y's until we run out and leave the rest padded with NaN
+                                for i in range(Nsteps):
+                                    try:
+                                        y[i] = max(1.0, st.unpack("<f", fp.read(4))[0])
+                                    except struct.error:
+                                        warnings.warn(
+                                            f"Bruker RAW file {filename} appears to be truncated or incomplete, could only read {i} of {Nsteps} expected steps."
+                                        )
+                                        break
+
                                 w = 1.0 / y
                                 if nBank == blockNum - 1:
                                     self.powderdata = [

--- a/pydatalab/tests/apps/test_xrd_block.py
+++ b/pydatalab/tests/apps/test_xrd_block.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from pydatalab.apps.xrd.blocks import XRDBlock
+from pydatalab.apps.xrd.utils import parse_bruker_raw
 
 XRD_DATA_FILES = list((Path(__file__).parent.parent.parent / "example_data" / "XRD").glob("*"))
 
@@ -32,3 +33,27 @@ def test_single_plots(f):
         block = XRDBlock(item_id="test")
         block.generate_xrd_plot(f)
         assert block.data["bokeh_plot_data"]
+
+
+@pytest.mark.parametrize("missing_steps", [1, 25, 250, 1000])
+def test_truncated_bruker_raw(tmp_path, missing_steps):
+    """An incomplete .raw file (e.g., mid-measurement) should still parse,
+    padding the missing intensities with NaN and warning about the partial read."""
+    raw_file = next(f for f in XRD_DATA_FILES if f.suffix == ".raw")
+    full_df, full_metadata = parse_bruker_raw(raw_file)
+    nsteps = int(full_metadata["Nsteps"])
+
+    truncated_file = tmp_path / raw_file.name
+    truncated_file.write_bytes(raw_file.read_bytes()[: -4 * missing_steps])
+
+    read_steps = nsteps - missing_steps
+    with pytest.warns(
+        UserWarning, match=f"could only read {read_steps} of {nsteps} expected steps"
+    ):
+        df, metadata = parse_bruker_raw(truncated_file)
+
+    assert int(metadata["Nsteps"]) == nsteps
+    assert len(df) == nsteps
+    assert df["twotheta"].equals(full_df["twotheta"])
+    assert df["intensity"].iloc[:read_steps].equals(full_df["intensity"].iloc[:read_steps])
+    assert df["intensity"].iloc[read_steps:].isna().all()


### PR DESCRIPTION
Closes #1969 

This PR updates the vendored GSAS-II file with a try/except that catches incomplete data, so that you can read .raw files as they are created. Not sure if we want to extend this to work with versions pre-v4 of the Bruker raw format.