### PR TITLE
Make block hydration more consistent when using pydantic

### DIFF
--- a/pydatalab/src/pydatalab/blocks/base.py
+++ b/pydatalab/src/pydatalab/blocks/base.py
@@ -190,7 +190,9 @@ class DataBlock:
         """returns a dictionary with the data for this
         block, ready to be input into mongodb"""
 
-        LOGGER.debug("Casting block %s to database object.", self.__class__.__name__)
+        LOGGER.debug(
+            "Casting block %s to database object, data: %s", self.__class__.__name__, self.data
+        )
         exclude_fields: set[str] = {
             f
             for (f, s) in self.block_db_model.schema()["properties"].items()
@@ -238,6 +240,10 @@ class DataBlock:
                                 ]
                             )
 
+        # Opportunistically convert the data to a dict if it is already a pydantic model
+        if not isinstance(self.data, dict):
+            self.data = self.data.dict()
+
         # If the last plotting run did not raise any errors or warnings, remove any old ones
         if block_errors:
             self.data["errors"] = block_errors
@@ -263,6 +269,7 @@ class DataBlock:
                     self, self.__class__
                 )
                 try:
+                    LOGGER.debug("Processing event %s with params %s", event_name, event)
                     bound_method(**event)
                 except Exception as e:
                     LOGGER.error(
@@ -309,28 +316,32 @@ class DataBlock:
         }
 
     @classmethod
-    def from_web(cls, data: dict):
+    def from_web(cls, data: dict, stored_data: dict | None = None):
         """Initialise the block state from data passed via web request
         with a given item and block ID.
 
         Parameters:
             data: The block data to initialiaze the block with.
+            stored_data: The stored database state of the block, if any,
+                used to preserve server-authoritative fields that cannot
+                be set from the web.
 
         """
         block = cls(
             item_id=data.get("item_id"),
             unique_id=data["block_id"],
         )
-        block.update_from_web(data)
+        block.update_from_web(data, stored_data=stored_data)
         return block
 
-    def update_from_web(self, data: dict):
+    def update_from_web(self, data: dict, stored_data: dict | None = None):
         """Update the block with validated data received from a web request.
         Will strip any fields that are "computed" or otherwise not controllable
-        by the user.
+        by the user, restoring their stored database values where available.
 
         Parameters:
             data: A dictionary of data to update the block with.
+            stored_data: The stored database state of the block, if any.
 
         """
         LOGGER.debug(
@@ -344,4 +355,13 @@ class DataBlock:
         }
         [data.pop(f, None) for f in exclude_fields]
         self.data.update(self.block_db_model(**data).dict())
+        # Fields stripped above (e.g., `metadata`, `computed`) are server-authoritative:
+        # writable only via block events or block code, never from the web payload.
+        # Without restoring them from the stored state here, the model defaults
+        # materialised by `.dict()` above would overwrite them in the database on
+        # every subsequent save of the block or its item.
+        if stored_data:
+            for field in exclude_fields:
+                if field in stored_data:
+                    self.data[field] = stored_data[field]
         return self

--- a/pydatalab/src/pydatalab/bokeh_plots.py
+++ b/pydatalab/src/pydatalab/bokeh_plots.py
@@ -393,7 +393,7 @@ def selectable_axes_plot(
             df_temp = df_
 
         if labels:
-            orig = labels[ind]
+            orig = str(labels[ind])
         else:
             if hasattr(df_temp, "attrs") and "original_filename" in df_temp.attrs:
                 orig = df_temp.attrs["original_filename"] if len(df) > 1 else ""
@@ -402,11 +402,13 @@ def selectable_axes_plot(
 
         original_labels_list.append(orig)
 
-    legend_labels = (
-        generate_unique_labels(original_labels_list)
-        if len(df) > 1 and use_unique_labels
-        else original_labels_list
-    )
+    legend_labels = original_labels_list
+    if len(df) > 1 and use_unique_labels:
+        try:
+            legend_labels = generate_unique_labels(original_labels_list)
+        except Exception:
+            legend_labels = original_labels_list
+
     plot_columns = []
 
     for ind, df_ in enumerate(df):

--- a/pydatalab/src/pydatalab/routes/v0_1/blocks.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/blocks.py
@@ -73,7 +73,15 @@ def _process_block_async(
             block_type = block_data["blocktype"]
             add_stage(f"Loading {block_type} block from database")
 
-            block = BLOCK_TYPES[block_type].from_web(block_data)
+            stored_item = flask_mongo.db.items.find_one(
+                {"item_id": block_data["item_id"], **get_default_permissions(user_only=True)},
+                projection={f"blocks_obj.{block_data['block_id']}": 1},
+            )
+            stored_block_data = (
+                (stored_item or {}).get("blocks_obj", {}).get(block_data["block_id"])
+            )
+
+            block = BLOCK_TYPES[block_type].from_web(block_data, stored_data=stored_block_data)
 
             if event_data:
                 add_stage("Processing block events")
@@ -327,12 +335,16 @@ def update_block():
     if not item_id:
         raise BadRequest(f"Invalid or missing item_id: {item_id}")
 
-    if not flask_mongo.db.items.find_one(
-        {"item_id": item_id, **get_default_permissions(user_only=False)}
-    ):
+    item = flask_mongo.db.items.find_one(
+        {"item_id": item_id, **get_default_permissions(user_only=False)},
+        projection={f"blocks_obj.{block_data['block_id']}": 1},
+    )
+    if not item:
         raise NotFound(f"Item with item_id {item_id} not found or not accessible")
 
-    block = BLOCK_TYPES[block_type].from_web(block_data)
+    block = BLOCK_TYPES[block_type].from_web(
+        block_data, stored_data=item.get("blocks_obj", {}).get(block_data["block_id"])
+    )
 
     from pydatalab.config import CONFIG
 

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -1667,13 +1667,6 @@ def save_item():
         if k in updated_data:
             del updated_data[k]
 
-    for block_id, block_data in updated_data.get("blocks_obj", {}).items():
-        blocktype = block_data["blocktype"]
-
-        block = BLOCK_TYPES.get(blocktype, BLOCK_TYPES["notsupported"]).from_web(block_data)
-
-        updated_data["blocks_obj"][block_id] = block.to_db()
-
     # Bit of a hack for now: starting materials and equipment should be editable by anyone,
     # so we adjust the query above to be more permissive when the user is requesting such an item
     # but before returning we need to check that the actual item did indeed have that type
@@ -1715,6 +1708,16 @@ def save_item():
             ),
             404,
         )
+
+    stored_blocks = item.get("blocks_obj", {})
+    for block_id, block_data in updated_data.get("blocks_obj", {}).items():
+        blocktype = block_data["blocktype"]
+
+        block = BLOCK_TYPES.get(blocktype, BLOCK_TYPES["notsupported"]).from_web(
+            block_data, stored_data=stored_blocks.get(block_id)
+        )
+
+        updated_data["blocks_obj"][block_id] = block.to_db()
 
     if "collections" in updated_data:
         requested_collections = updated_data["collections"]

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -169,6 +169,7 @@ def get_items_summary(match: dict | None = None, project: dict | None = None) ->
                 "input": {"$objectToArray": {"$ifNull": ["$blocks_obj", {}]}},
                 "as": "b",
                 "in": {
+                    "block_id": "$$b.k",
                     "blocktype": "$$b.v.blocktype",
                     "title": "$$b.v.title",
                 },

--- a/pydatalab/tests/server/test_async_blocks.py
+++ b/pydatalab/tests/server/test_async_blocks.py
@@ -118,7 +118,7 @@ class TestAsyncUpdateBlock:
             (),
             {
                 "_prefers_async": True,
-                "from_web": classmethod(lambda cls, x: MagicMock()),
+                "from_web": classmethod(lambda cls, x, stored_data=None: MagicMock()),
             },
         )
         with patch.dict(


### PR DESCRIPTION
- Load fields from the database rather than relying on `exclude_unset` as `stored_data`
- Opportunistically convert back from pydantic to dicts
- return block_ids in item summary
- improve bokeh plot labelling

Closes #1977 