### PR TITLE
Remove unnecessary log volume mounts from docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     build:
       context: .
       dockerfile: .docker/app/Dockerfile
-    volumes:
-      - ./logs:/logs
     restart: unless-stopped
     environment:
       - VUE_APP_GIT_VERSION
@@ -31,7 +29,7 @@ services:
       - database
     restart: unless-stopped
     volumes:
-      - ./logs:/logs
+      - /data/logs:/logs
       - /data/files:/app/files
       - /tmp/eln-exports:/tmp/eln-exports
       - /data/backups:/tmp/datalab-backups
@@ -51,7 +49,7 @@ services:
       context: .
       dockerfile: .docker/mongo/Dockerfile
     volumes:
-      - ./logs:/var/logs/mongod
+      - /data/logs:/var/logs/mongod
       - /data/db:/data/db
     restart: unless-stopped
     networks:


### PR DESCRIPTION
Not used anymore, and caused issues in a rootless Docker setup.