### PR TITLE
Add mongo image healthcheck and add API startup dependency

### DIFF
--- a/.docker/mongo/Dockerfile
+++ b/.docker/mongo/Dockerfile
@@ -1,2 +1,3 @@
 FROM mongo:8-noble
 EXPOSE 27017
+HEALTHCHECK --interval=30s --timeout=5s --start-interval=1s --start-period=180s --retries=3 CMD mongosh --quiet --eval "db.runCommand('ping').ok" || exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,8 @@ services:
       args:
         SETUPTOOLS_SCM_PRETEND_VERSION: ${SETUPTOOLS_SCM_PRETEND_VERSION}
     depends_on:
-      - database
+      database:
+        condition: service_healthy
     restart: unless-stopped
     volumes:
       - /data/logs:/logs
@@ -82,7 +83,10 @@ services:
       dockerfile: .docker/server/Dockerfile
       target: dev
     depends_on:
-      - database-dev
+      # The dev server has no restart policy, so it must not boot (and
+      # try to create indices) until the database accepts connections
+      database-dev:
+        condition: service_healthy
     volumes:
       - ./pydatalab:/app
       - datalab-dev-files:/app/files


### PR DESCRIPTION
This pull request improves the reliability of service startup in the Docker Compose environment by ensuring that application services only start after the MongoDB service is healthy. The changes add a health check to the MongoDB Dockerfile and update service dependencies in `docker-compose.yml` to wait for MongoDB to be ready before starting dependent services.