### PR TITLE
Add location to all items and `/locations` endpoint, configure pre-defined locations

### DIFF
--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -1216,6 +1216,19 @@
       "title": "File Objectids",
       "type": "array"
     },
+    "location": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The place where the item is located.",
+      "title": "Location"
+    },
     "blocks_obj": {
       "additionalProperties": {
         "$ref": "#/$defs/DataBlockResponse"

--- a/pydatalab/schemas/equipment.json
+++ b/pydatalab/schemas/equipment.json
@@ -1052,6 +1052,19 @@
       "title": "File Objectids",
       "type": "array"
     },
+    "location": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The place where the item is located.",
+      "title": "Location"
+    },
     "blocks_obj": {
       "additionalProperties": {
         "$ref": "#/$defs/DataBlockResponse"
@@ -1293,19 +1306,6 @@
       "default": null,
       "description": "The manufacturer of this piece of equipment",
       "title": "Manufacturer"
-    },
-    "location": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Place where the equipment is located",
-      "title": "Location"
     },
     "contact": {
       "anyOf": [

--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -1325,6 +1325,19 @@
       "title": "File Objectids",
       "type": "array"
     },
+    "location": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The place where the item is located.",
+      "title": "Location"
+    },
     "blocks_obj": {
       "additionalProperties": {
         "$ref": "#/$defs/DataBlockResponse"

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -1326,6 +1326,19 @@
       "title": "File Objectids",
       "type": "array"
     },
+    "location": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The place where the item is located.",
+      "title": "Location"
+    },
     "blocks_obj": {
       "additionalProperties": {
         "$ref": "#/$defs/DataBlockResponse"
@@ -1633,19 +1646,6 @@
       "default": null,
       "description": "Supplier or manufacturer of the chemical.",
       "title": "Supplier"
-    },
-    "location": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "The place where the container is located.",
-      "title": "Location"
     },
     "comment": {
       "anyOf": [

--- a/pydatalab/src/pydatalab/config.py
+++ b/pydatalab/src/pydatalab/config.py
@@ -263,6 +263,12 @@ its importance when deploying a datalab instance.""",
         description="A list of dotted import paths ('package.module:ClassName') to custom `Item` subclasses to register as additional item types served through the generic item endpoints, e.g. ['mypackage.models:MySample']. Each model must declare its own unique `type` literal.",
     )
 
+    PREDEFINED_LOCATIONS: set[str] = Field(
+        default_factory=set,
+        description="A list of additional lab locations to populate in the /locations endpoint that will be suggested globally for autocompletion. Use '>' to indicate location hierarchy",
+        examples=[["Lab A > Cupboard B > Shelf C"]],
+    )
+
     BACKUP_STRATEGIES: dict[str, BackupStrategy] | None = Field(
         {
             "daily-snapshots": BackupStrategy(

--- a/pydatalab/src/pydatalab/config.py
+++ b/pydatalab/src/pydatalab/config.py
@@ -375,6 +375,15 @@ its importance when deploying a datalab instance.""",
                 strategy.active = False
         return self
 
+    @field_validator("PREDEFINED_LOCATIONS", mode="before")
+    @classmethod
+    def check_predefined_locations(cls, v):
+        """Checks that predefined locations can be parsed hierarchically."""
+        from pydatalab.models.utils import construct_location_hierarchy
+
+        construct_location_hierarchy(v)
+        return v
+
     @field_validator("LOG_FILE", mode="before")
     @classmethod
     def make_missing_log_directory(cls, v):

--- a/pydatalab/src/pydatalab/models/equipment.py
+++ b/pydatalab/src/pydatalab/models/equipment.py
@@ -23,9 +23,6 @@ class Equipment(Item):
     manufacturer: str | None = None
     """The manufacturer of this piece of equipment"""
 
-    location: str | None = None
-    """Place where the equipment is located"""
-
     contact: str | None = None
     """Contact information for equipment (e.g., email address or phone number)."""
 

--- a/pydatalab/src/pydatalab/models/items.py
+++ b/pydatalab/src/pydatalab/models/items.py
@@ -6,6 +6,7 @@ from pydatalab.models.entries import Entry
 from pydatalab.models.files import HasFiles
 from pydatalab.models.traits import (
     HasBlocks,
+    HasLocation,
     HasOwner,
     HasRevisionControl,
     IsCollectable,
@@ -17,7 +18,9 @@ from pydatalab.models.utils import (
 )
 
 
-class Item(Entry, HasOwner, HasRevisionControl, IsCollectable, HasBlocks, HasFiles, abc.ABC):
+class Item(
+    Entry, HasOwner, HasRevisionControl, IsCollectable, HasBlocks, HasLocation, HasFiles, abc.ABC
+):
     """The generic model for data types that will be exposed with their own named endpoints.
 
     `Item` is the abstract base shared by every physical item type: samples, cells,

--- a/pydatalab/src/pydatalab/models/starting_materials.py
+++ b/pydatalab/src/pydatalab/models/starting_materials.py
@@ -44,9 +44,6 @@ class StartingMaterial(Item, HasSynthesisInfo, HasSubstanceInfo):
     supplier: str | None = Field(None, alias="Supplier")
     """Supplier or manufacturer of the chemical."""
 
-    location: str | None = Field(None, alias="Location")
-    """The place where the container is located."""
-
     comment: str | None = Field(None, alias="Comments")
     """Any additional comments or notes about the container."""
 

--- a/pydatalab/src/pydatalab/models/traits.py
+++ b/pydatalab/src/pydatalab/models/traits.py
@@ -245,5 +245,5 @@ class HasSubstanceInfo(BaseModel):
 
 
 class HasLocation(BaseModel):
-    location: str | None = Field(alias="Location")
+    location: str | None = Field(None)
     """The place where the item is located."""

--- a/pydatalab/src/pydatalab/models/traits.py
+++ b/pydatalab/src/pydatalab/models/traits.py
@@ -16,6 +16,7 @@ __all__ = (
     "IsCollectable",
     "HasSynthesisInfo",
     "HasSubstanceInfo",
+    "HasLocation",
 )
 
 
@@ -241,3 +242,8 @@ class HasSubstanceInfo(BaseModel):
                 return None
 
         return v
+
+
+class HasLocation(BaseModel):
+    location: str | None = Field(alias="Location")
+    """The place where the item is located."""

--- a/pydatalab/src/pydatalab/models/utils.py
+++ b/pydatalab/src/pydatalab/models/utils.py
@@ -426,3 +426,34 @@ class Constituent(BaseModel):
                 return InlineSubstance(name=name or str(v), chemform=chemform)
 
         return v
+
+
+def construct_location_hierarchy(flat_locations: set[str]) -> dict[str, dict]:
+    """Take a flat list of locations with locations segmented by '>'
+    and construct a nested hierarchy, terminating with empty dicts `{}`.
+
+    Location segments that appear at multiple levels of the hierarchy
+    will be treated as separate locations, e.g., the flat list
+    `["Lab 1 > Shelf 2", "Building A > Lab 1 > Shelf 3"]` will result in
+    the hierarchy `{"Lab 1": {"Shelf 2": {}}, "Building A": {"Lab 1": {"Shelf 3": {}}}`.
+
+    Parameters:
+        flat_locations: The flat set of locations.
+
+    Returns:
+        A nested dictionary containing the location hierarchy.
+
+    """
+    nested_locations: dict[str, dict] = {}
+    for location_locators in flat_locations:
+        comprising_locations = location_locators.split(">")
+        curr_dict = nested_locations
+        for location in comprising_locations:
+            location = location.strip()
+            if not location:
+                continue
+            if location not in curr_dict:
+                curr_dict[location] = {}
+            curr_dict = curr_dict[location]
+
+    return nested_locations

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -1852,6 +1852,10 @@ def get_access_token_info(refcode: str):
 
 @ITEMS.route("/locations", methods=["GET"])
 def get_locations_for_items():
+    """List all distinct locations that the current user has access to, whether via
+    items at those locations, or pre-defined locations for the overall deployment.
+
+    """
     locations = set(
         flask_mongo.db.items.distinct(
             "location",
@@ -1870,4 +1874,9 @@ def get_locations_for_items():
         LOGGER.error("Error constructing location hierarchy for %s: %s", locations, exc)
         nested_locations = {}
 
-    return jsonify({"flat_locations": list(locations), "nested_locations": nested_locations}), 200
+    return jsonify(
+        {
+            "data": {"flat_locations": list(locations), "nested_locations": nested_locations},
+            "status": "success",
+        }
+    ), 200

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -1860,20 +1860,10 @@ def get_locations_for_items():
     for location_locators in flat_locations:
         comprising_locations = location_locators.split(">")
         curr_dict = nested_locations
-        for index, location in enumerate(comprising_locations):
+        for location in comprising_locations:
             location = location.strip()
-            if (
-                location in curr_dict
-                and index + 1 < len(comprising_locations)
-                and comprising_locations[index + 1] not in curr_dict[location]
-            ):
-                curr_dict[location][comprising_locations[index + 1].strip()] = {}
-                curr_dict = curr_dict[location]
-            elif index + 1 < len(comprising_locations):
-                curr_dict[location] = {comprising_locations[index + 1].strip(): {}}
-                curr_dict = curr_dict[location]
-            elif index + 1 >= len(comprising_locations) and index == 0:
+            if location not in curr_dict:
                 curr_dict[location] = {}
-                curr_dict = curr_dict[location]
+            curr_dict = curr_dict[location]
 
     return jsonify({"flat_locations": flat_locations, "nested_locations": nested_locations}), 200

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -1848,20 +1848,20 @@ def get_access_token_info(refcode: str):
 
 @ITEMS.route("/locations", methods=["GET"])
 def get_locations_for_items():
-    items = flask_mongo.db.items.distinct(
-        "location",
-        {
-            "location": {"$ne": None},
-            **get_default_permissions(user_only=False),
-        },
+    locations = set(
+        flask_mongo.db.items.distinct(
+            "location",
+            {
+                "location": {"$ne": None},
+                **get_default_permissions(user_only=False),
+            },
+        )
     )
 
-    config_items = getattr(CONFIG, "EXTRA_LOCATIONS", [])
-    items.extend(config_items)
+    locations |= CONFIG.PREDEFINED_LOCATIONS
 
-    flat_locations = list(items)
     nested_locations = {}
-    for location_locators in flat_locations:
+    for location_locators in locations:
         comprising_locations = location_locators.split(">")
         curr_dict = nested_locations
         for location in comprising_locations:
@@ -1870,4 +1870,4 @@ def get_locations_for_items():
                 curr_dict[location] = {}
             curr_dict = curr_dict[location]
 
-    return jsonify({"flat_locations": flat_locations, "nested_locations": nested_locations}), 200
+    return jsonify({"flat_locations": list(locations), "nested_locations": nested_locations}), 200

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -1844,3 +1844,36 @@ def get_access_token_info(refcode: str):
         ), 200
     else:
         return jsonify({"status": "success", "has_token": False}), 200
+
+
+@ITEMS.route("/locations", methods=["GET"])
+def get_locations_for_items():
+    items = flask_mongo.db.items.distinct(
+        "location",
+        {
+            "location": {"$ne": None},
+            **get_default_permissions(user_only=False),
+        },
+    )
+    flat_locations = list(items)
+    nested_locations = {}
+    for location_locators in flat_locations:
+        comprising_locations = location_locators.split(">")
+        curr_dict = nested_locations
+        for index, location in enumerate(comprising_locations):
+            location = location.strip()
+            if (
+                location in curr_dict
+                and index + 1 < len(comprising_locations)
+                and comprising_locations[index + 1] not in curr_dict[location]
+            ):
+                curr_dict[location][comprising_locations[index + 1].strip()] = {}
+                curr_dict = curr_dict[location]
+            elif index + 1 < len(comprising_locations):
+                curr_dict[location] = {comprising_locations[index + 1].strip(): {}}
+                curr_dict = curr_dict[location]
+            elif index + 1 >= len(comprising_locations) and index == 0:
+                curr_dict[location] = {}
+                curr_dict = curr_dict[location]
+
+    return jsonify({"flat_locations": flat_locations, "nested_locations": nested_locations}), 200

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -19,7 +19,11 @@ from pydatalab.logger import LOGGER
 from pydatalab.models import ITEM_MODELS, ItemVersion, flagged_summary_fields
 from pydatalab.models.items import Item
 from pydatalab.models.relationships import RelationshipType
-from pydatalab.models.utils import InlineSubstance, generate_unique_refcode
+from pydatalab.models.utils import (
+    InlineSubstance,
+    construct_location_hierarchy,
+    generate_unique_refcode,
+)
 from pydatalab.models.versions import (
     CompareVersionsQuery,
     RestoreVersionRequest,
@@ -1860,14 +1864,10 @@ def get_locations_for_items():
 
     locations |= CONFIG.PREDEFINED_LOCATIONS
 
-    nested_locations = {}
-    for location_locators in locations:
-        comprising_locations = location_locators.split(">")
-        curr_dict = nested_locations
-        for location in comprising_locations:
-            location = location.strip()
-            if location not in curr_dict:
-                curr_dict[location] = {}
-            curr_dict = curr_dict[location]
+    try:
+        nested_locations = construct_location_hierarchy(locations)
+    except Exception as exc:
+        LOGGER.error("Error constructing location hierarchy for %s: %s", locations, exc)
+        nested_locations = {}
 
     return jsonify({"flat_locations": list(locations), "nested_locations": nested_locations}), 200

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -1855,6 +1855,10 @@ def get_locations_for_items():
             **get_default_permissions(user_only=False),
         },
     )
+
+    config_items = getattr(CONFIG, "EXTRA_LOCATIONS", [])
+    items.extend(config_items)
+
     flat_locations = list(items)
     nested_locations = {}
     for location_locators in flat_locations:

--- a/pydatalab/tests/server/conftest.py
+++ b/pydatalab/tests/server/conftest.py
@@ -7,6 +7,7 @@ from flask.testing import FlaskClient
 
 from pydatalab.models import Cell, Collection, Equipment, Sample, StartingMaterial
 from pydatalab.models.people import AccountStatus
+from pydatalab.mongo import flask_mongo
 
 TEST_DATABASE_NAME = "__datalab-testing__"
 
@@ -642,6 +643,24 @@ def _insert_and_cleanup_item_from_model(model):
     flask_mongo.db.items.insert_one(model.model_dump(exclude_unset=False))
     yield model
     flask_mongo.db.items.delete_one({"refcode": model.refcode})
+
+
+@pytest.fixture(scope="function", name="item_creator")
+def fixture_item_creator():
+    ref_codes_to_remove = []
+
+    def _insert_item_from_model(model):
+        from pydatalab.models.utils import generate_unique_refcode
+        from pydatalab.mongo import flask_mongo
+
+        refcode = generate_unique_refcode()
+        model.refcode = refcode
+        flask_mongo.db.items.insert_one(model.model_dump(exclude_unset=False))
+        ref_codes_to_remove.append(refcode)
+        return model
+
+    yield _insert_item_from_model
+    flask_mongo.db.items.delete_many({"refcode": {"$in": ref_codes_to_remove}})
 
 
 @pytest.fixture(scope="module", name="insert_default_sample")

--- a/pydatalab/tests/server/conftest.py
+++ b/pydatalab/tests/server/conftest.py
@@ -74,6 +74,7 @@ def app_config(secret_key, files_directory):
         "MAIL_DEBUG": True,
         "MAIL_SUPPRESS_SEND": True,
         "MAIL_PASSWORD": "test",
+        "EXTRA_LOCATIONS": ["Cambridge > Lab 1 > Location A", "Cambridge > Lab 2"],
         # Set to 10 MB to check that larger files fail; this should be larger than all of our example files.
         # Elsewhere, we can generate an artificial large file to check that it fails.
         "MAX_CONTENT_LENGTH": 10 * 1000**2,

--- a/pydatalab/tests/server/conftest.py
+++ b/pydatalab/tests/server/conftest.py
@@ -74,7 +74,7 @@ def app_config(secret_key, files_directory):
         "MAIL_DEBUG": True,
         "MAIL_SUPPRESS_SEND": True,
         "MAIL_PASSWORD": "test",
-        "EXTRA_LOCATIONS": ["Cambridge > Lab 1 > Location A", "Cambridge > Lab 2"],
+        "PREDEFINED_LOCATIONS": ["Cambridge > Lab 1 > Location A", "Cambridge > Lab 2"],
         # Set to 10 MB to check that larger files fail; this should be larger than all of our example files.
         # Elsewhere, we can generate an artificial large file to check that it fails.
         "MAX_CONTENT_LENGTH": 10 * 1000**2,

--- a/pydatalab/tests/server/test_items.py
+++ b/pydatalab/tests/server/test_items.py
@@ -34,19 +34,17 @@ def test_fts_fields():
 def test_location_endpoint_server_defaults(client, item_creator, user_id):
     response = client.get("/locations")
     assert response.status_code == 200
-    assert "flat_locations" in response.json
 
-    assert set(response.json["flat_locations"]).issuperset(
+    assert set(response.json["data"]["flat_locations"]).issuperset(
         {"Cambridge > Lab 1 > Location A", "Cambridge > Lab 2"}
     )
 
     # non-flat checks
-    assert "nested_locations" in response.json
-    assert response.json["nested_locations"] is not None
-    assert "Cambridge" in response.json["nested_locations"]
-    assert "Lab 1" in response.json["nested_locations"]["Cambridge"]
-    assert "Lab 2" in response.json["nested_locations"]["Cambridge"]
-    assert "Location A" in response.json["nested_locations"]["Cambridge"]["Lab 1"]
+    assert response.json["data"]["nested_locations"] is not None
+    assert "Cambridge" in response.json["data"]["nested_locations"]
+    assert "Lab 1" in response.json["data"]["nested_locations"]["Cambridge"]
+    assert "Lab 2" in response.json["data"]["nested_locations"]["Cambridge"]
+    assert "Location A" in response.json["data"]["nested_locations"]["Cambridge"]["Lab 1"]
 
 
 def test_location_endpoint(client, item_creator, user_id):
@@ -62,20 +60,18 @@ def test_location_endpoint(client, item_creator, user_id):
 
     response = client.get("/locations")
     assert response.status_code == 200
-    assert "flat_locations" in response.json
-    assert set(response.json["flat_locations"]).issuperset(set(locations))
+    assert set(response.json["data"]["flat_locations"]).issuperset(set(locations))
 
     # non-flat checks
-    assert "nested_locations" in response.json
-    assert response.json["nested_locations"] is not None
-    assert "Place4" in response.json["nested_locations"]
-    assert "Place5" in response.json["nested_locations"]["Place4"]
-    assert "Place6" in response.json["nested_locations"]["Place4"]["Place5"]
-    assert "Place1" in response.json["nested_locations"]
-    assert "Place2" in response.json["nested_locations"]["Place1"]
-    assert "Place7" in response.json["nested_locations"]["Place1"]
-    assert "Place3" in response.json["nested_locations"]["Place1"]["Place2"]
-    assert "Place8" in response.json["nested_locations"]["Place1"]["Place7"]
+    assert response.json["data"]["nested_locations"] is not None
+    assert "Place4" in response.json["data"]["nested_locations"]
+    assert "Place5" in response.json["data"]["nested_locations"]["Place4"]
+    assert "Place6" in response.json["data"]["nested_locations"]["Place4"]["Place5"]
+    assert "Place1" in response.json["data"]["nested_locations"]
+    assert "Place2" in response.json["data"]["nested_locations"]["Place1"]
+    assert "Place7" in response.json["data"]["nested_locations"]["Place1"]
+    assert "Place3" in response.json["data"]["nested_locations"]["Place1"]["Place2"]
+    assert "Place8" in response.json["data"]["nested_locations"]["Place1"]["Place7"]
 
 
 def test_location_endpoint_with_spaced_signs(client, item_creator, user_id):
@@ -91,17 +87,15 @@ def test_location_endpoint_with_spaced_signs(client, item_creator, user_id):
 
     response = client.get("/locations")
     assert response.status_code == 200
-    assert "flat_locations" in response.json
 
-    assert set(response.json["flat_locations"]).issuperset(set(locations))
-    assert "nested_locations" in response.json
-    assert "Lab 1" in response.json["nested_locations"]
-    assert "Shelf 2" in response.json["nested_locations"]["Lab 1"]
-    assert "Shelf 3" in response.json["nested_locations"]["Lab 1"]
-    assert "Position A" in response.json["nested_locations"]["Lab 1"]["Shelf 2"]
+    assert set(response.json["data"]["flat_locations"]).issuperset(set(locations))
+    assert "Lab 1" in response.json["data"]["nested_locations"]
+    assert "Shelf 2" in response.json["data"]["nested_locations"]["Lab 1"]
+    assert "Shelf 3" in response.json["data"]["nested_locations"]["Lab 1"]
+    assert "Position A" in response.json["data"]["nested_locations"]["Lab 1"]["Shelf 2"]
 
-    assert "Lab 2" in response.json["nested_locations"]
-    assert "Shelf 1" in response.json["nested_locations"]["Lab 2"]
+    assert "Lab 2" in response.json["data"]["nested_locations"]
+    assert "Shelf 1" in response.json["data"]["nested_locations"]["Lab 2"]
 
 
 def test_location_endpoint_with_bad_segments(client, item_creator):
@@ -122,14 +116,14 @@ def test_location_endpoint_with_bad_segments(client, item_creator):
 
     response = client.get("/locations")
     assert response.status_code == 200
-    assert "flat_locations" in response.json
 
-    assert set(response.json["flat_locations"]).issuperset(locations)
-    assert "nested_locations" in response.json
-    assert all(k in response.json["nested_locations"] for k in ["Lab 1", "Building A", "Shelf 3"])
-    assert response.json["nested_locations"]["Building A"]["Lab 1"] == {"Shelf 3": {}}
-    assert response.json["nested_locations"]["Shelf 3"] == {}
-    assert response.json["nested_locations"]["Lab 1"] == {"Shelf 2": {}}
+    assert set(response.json["data"]["flat_locations"]).issuperset(locations)
+    assert all(
+        k in response.json["data"]["nested_locations"] for k in ["Lab 1", "Building A", "Shelf 3"]
+    )
+    assert response.json["data"]["nested_locations"]["Building A"]["Lab 1"] == {"Shelf 3": {}}
+    assert response.json["data"]["nested_locations"]["Shelf 3"] == {}
+    assert response.json["data"]["nested_locations"]["Lab 1"] == {"Shelf 2": {}}
 
 
 def test_location_endpoint_with_duplicated_segments(client, item_creator):
@@ -147,14 +141,14 @@ def test_location_endpoint_with_duplicated_segments(client, item_creator):
 
     response = client.get("/locations")
     assert response.status_code == 200
-    assert "flat_locations" in response.json
 
-    assert set(response.json["flat_locations"]).issuperset(locations)
-    assert "nested_locations" in response.json
-    assert all(k in response.json["nested_locations"] for k in ["Lab 1", "Building A", "Shelf 3"])
-    assert response.json["nested_locations"]["Building A"]["Lab 1"] == {"Shelf 3": {}}
-    assert response.json["nested_locations"]["Shelf 3"] == {}
-    assert response.json["nested_locations"]["Lab 1"] == {"Shelf 2": {}}
+    assert set(response.json["data"]["flat_locations"]).issuperset(locations)
+    assert all(
+        k in response.json["data"]["nested_locations"] for k in ["Lab 1", "Building A", "Shelf 3"]
+    )
+    assert response.json["data"]["nested_locations"]["Building A"]["Lab 1"] == {"Shelf 3": {}}
+    assert response.json["data"]["nested_locations"]["Shelf 3"] == {}
+    assert response.json["data"]["nested_locations"]["Lab 1"] == {"Shelf 2": {}}
 
 
 def test_location_endpoint_with_single_non_nested_location(client, item_creator, user_id):
@@ -168,11 +162,9 @@ def test_location_endpoint_with_single_non_nested_location(client, item_creator,
     )
     response = client.get("/locations")
     assert response.status_code == 200
-    assert "flat_locations" in response.json
 
-    assert set(response.json["flat_locations"]).issuperset({"Lab 1"})
-    assert "nested_locations" in response.json
-    assert "Lab 1" in response.json["nested_locations"]
+    assert set(response.json["data"]["flat_locations"]).issuperset({"Lab 1"})
+    assert "Lab 1" in response.json["data"]["nested_locations"]
 
 
 def test_regression_test_against_overwriting_problem(client, item_creator, user_id):
@@ -196,17 +188,17 @@ def test_regression_test_against_overwriting_problem(client, item_creator, user_
 
     response = client.get("/locations")
     assert response.status_code == 200
-    assert "flat_locations" in response.json
 
-    assert set(response.json["flat_locations"]).issuperset(
+    assert set(response.json["data"]["flat_locations"]).issuperset(
         {
             "Cambridge > Lab 6 > Shelf 1",
             "Cambridge > Lab 6 > Shelf 2 > Position A",
         }
     )
-    assert "nested_locations" in response.json
-    assert "Cambridge" in response.json["nested_locations"]
-    assert "Lab 6" in response.json["nested_locations"]["Cambridge"]
-    assert "Shelf 1" in response.json["nested_locations"]["Cambridge"]["Lab 6"]
-    assert "Shelf 2" in response.json["nested_locations"]["Cambridge"]["Lab 6"]
-    assert "Position A" in response.json["nested_locations"]["Cambridge"]["Lab 6"]["Shelf 2"]
+    assert "Cambridge" in response.json["data"]["nested_locations"]
+    assert "Lab 6" in response.json["data"]["nested_locations"]["Cambridge"]
+    assert "Shelf 1" in response.json["data"]["nested_locations"]["Cambridge"]["Lab 6"]
+    assert "Shelf 2" in response.json["data"]["nested_locations"]["Cambridge"]["Lab 6"]
+    assert (
+        "Position A" in response.json["data"]["nested_locations"]["Cambridge"]["Lab 6"]["Shelf 2"]
+    )

--- a/pydatalab/tests/server/test_items.py
+++ b/pydatalab/tests/server/test_items.py
@@ -31,6 +31,24 @@ def test_fts_fields():
     assert all(field in get_items_fts_fields() for field in fields)
 
 
+def test_location_endpoint_server_defaults(client, item_creator, user_id):
+    response = client.get("/locations")
+    assert response.status_code == 200
+    assert "flat_locations" in response.json
+
+    assert set(response.json["flat_locations"]).issuperset(
+        {"Cambridge > Lab 1 > Location A", "Cambridge > Lab 2"}
+    )
+
+    # non-flat checks
+    assert "nested_locations" in response.json
+    assert response.json["nested_locations"] is not None
+    assert "Cambridge" in response.json["nested_locations"]
+    assert "Lab 1" in response.json["nested_locations"]["Cambridge"]
+    assert "Lab 2" in response.json["nested_locations"]["Cambridge"]
+    assert "Location A" in response.json["nested_locations"]["Cambridge"]["Lab 1"]
+
+
 def test_location_endpoint(client, item_creator, user_id):
     item_creator(
         Cell(
@@ -203,8 +221,7 @@ def test_location_endpoint(client, item_creator, user_id):
 
     # non-flat checks
     assert "nested_locations" in response.json
-    assert response.json["nested_locations"]
-    print(response.json["nested_locations"])
+    assert response.json["nested_locations"] is not None
     assert "Place4" in response.json["nested_locations"]
     assert "Place5" in response.json["nested_locations"]["Place4"]
     assert "Place6" in response.json["nested_locations"]["Place4"]["Place5"]

--- a/pydatalab/tests/server/test_items.py
+++ b/pydatalab/tests/server/test_items.py
@@ -441,3 +441,102 @@ def test_location_endpoint_with_single_non_nested_location(client, item_creator,
     assert set(response.json["flat_locations"]).issuperset({"Lab 1"})
     assert "nested_locations" in response.json
     assert "Lab 1" in response.json["nested_locations"]
+
+
+def test_regression_test_against_overwriting_problem(client, item_creator, user_id):
+    # test ensures that items don't get over (i.e. Position A should not get overwritten)
+    item_creator(
+        Cell(
+            **{
+                "item_id": "test_cell_4",
+                "name": "test cell",
+                "date": "1970-02-01",
+                "negative_electrode": [
+                    {
+                        "item": {"item_id": "test", "type": "starting_materials"},
+                        "quantity": 5.0,
+                        "unit": "mg",
+                    },
+                    {
+                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
+                        "quantity": 1.0,
+                        "unit": "mg",
+                    },
+                ],
+                "positive_electrode": [
+                    {
+                        "item": {
+                            "item_id": "test_cathode",
+                            "chemform": "LiCoO2",
+                            "type": "samples",
+                        },
+                        "quantity": 500,
+                        "unit": "kg",
+                    }
+                ],
+                "electrolyte": [
+                    {"item": {"name": "inlined reference"}, "quantity": 10, "unit": "ml"}
+                ],
+                "cell_format": "swagelok",
+                "type": "cells",
+                "creator_ids": [user_id],
+                "Location": "Cambridge > Lab 6 > Shelf 2 > Position A",
+            }
+        )
+    )
+    item_creator(
+        Cell(
+            **{
+                "item_id": "test_cell0",
+                "name": "test cell",
+                "date": "1970-02-01",
+                "negative_electrode": [
+                    {
+                        "item": {"item_id": "test", "type": "starting_materials"},
+                        "quantity": 2.0,
+                        "unit": "mg",
+                    },
+                    {
+                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
+                        "quantity": 2.0,
+                        "unit": "mg",
+                    },
+                ],
+                "positive_electrode": [
+                    {
+                        "item": {
+                            "item_id": "test_cathode",
+                            "chemform": "LiCoO2",
+                            "type": "samples",
+                        },
+                        "quantity": 2000,
+                        "unit": "kg",
+                    }
+                ],
+                "electrolyte": [
+                    {"item": {"name": "inlined reference"}, "quantity": 100, "unit": "ml"}
+                ],
+                "cell_format": "swagelok",
+                "type": "cells",
+                "creator_ids": [user_id],
+                "Location": "Cambridge > Lab 6 > Shelf 1",
+            }
+        )
+    )
+
+    response = client.get("/locations")
+    assert response.status_code == 200
+    assert "flat_locations" in response.json
+
+    assert set(response.json["flat_locations"]).issuperset(
+        {
+            "Cambridge > Lab 6 > Shelf 1",
+            "Cambridge > Lab 6 > Shelf 2 > Position A",
+        }
+    )
+    assert "nested_locations" in response.json
+    assert "Cambridge" in response.json["nested_locations"]
+    assert "Lab 6" in response.json["nested_locations"]["Cambridge"]
+    assert "Shelf 1" in response.json["nested_locations"]["Cambridge"]["Lab 6"]
+    assert "Shelf 2" in response.json["nested_locations"]["Cambridge"]["Lab 6"]
+    assert "Position A" in response.json["nested_locations"]["Cambridge"]["Lab 6"]["Shelf 2"]

--- a/pydatalab/tests/server/test_items.py
+++ b/pydatalab/tests/server/test_items.py
@@ -1,3 +1,6 @@
+from pydatalab.models import Cell
+
+
 def test_single_item_endpoints(client, inserted_default_items):
     for item in inserted_default_items:
         response = client.get(f"/items/{item.refcode}")
@@ -26,3 +29,415 @@ def test_fts_fields():
 
     fields = ("item_id", "name", "description", "refcode", "synthesis_description", "supplier")
     assert all(field in get_items_fts_fields() for field in fields)
+
+
+def test_location_endpoint(client, item_creator, user_id):
+    item_creator(
+        Cell(
+            **{
+                "item_id": "test_cell0",
+                "name": "test cell",
+                "date": "1970-02-01",
+                "negative_electrode": [
+                    {
+                        "item": {"item_id": "test", "type": "starting_materials"},
+                        "quantity": 2.0,
+                        "unit": "mg",
+                    },
+                    {
+                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
+                        "quantity": 2.0,
+                        "unit": "mg",
+                    },
+                ],
+                "positive_electrode": [
+                    {
+                        "item": {
+                            "item_id": "test_cathode",
+                            "chemform": "LiCoO2",
+                            "type": "samples",
+                        },
+                        "quantity": 2000,
+                        "unit": "kg",
+                    }
+                ],
+                "electrolyte": [
+                    {"item": {"name": "inlined reference"}, "quantity": 100, "unit": "ml"}
+                ],
+                "cell_format": "swagelok",
+                "type": "cells",
+                "creator_ids": [user_id],
+                "Location": "Place1>Place2>Place3",
+            }
+        )
+    )
+    item_creator(
+        Cell(
+            **{
+                "item_id": "test_cell_2",
+                "name": "test cell",
+                "date": "1970-02-01",
+                "negative_electrode": [
+                    {
+                        "item": {"item_id": "test", "type": "starting_materials"},
+                        "quantity": 5.0,
+                        "unit": "mg",
+                    },
+                    {
+                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
+                        "quantity": 1.0,
+                        "unit": "mg",
+                    },
+                ],
+                "positive_electrode": [
+                    {
+                        "item": {
+                            "item_id": "test_cathode",
+                            "chemform": "LiCoO2",
+                            "type": "samples",
+                        },
+                        "quantity": 500,
+                        "unit": "kg",
+                    }
+                ],
+                "electrolyte": [
+                    {"item": {"name": "inlined reference"}, "quantity": 10, "unit": "ml"}
+                ],
+                "cell_format": "swagelok",
+                "type": "cells",
+                "creator_ids": [user_id],
+                "Location": "Place1>Place2",
+            }
+        )
+    )
+    item_creator(
+        Cell(
+            **{
+                "item_id": "test_cell_3",
+                "name": "test cell",
+                "date": "1970-02-01",
+                "negative_electrode": [
+                    {
+                        "item": {"item_id": "test", "type": "starting_materials"},
+                        "quantity": 5.0,
+                        "unit": "mg",
+                    },
+                    {
+                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
+                        "quantity": 1.0,
+                        "unit": "mg",
+                    },
+                ],
+                "positive_electrode": [
+                    {
+                        "item": {
+                            "item_id": "test_cathode",
+                            "chemform": "LiCoO2",
+                            "type": "samples",
+                        },
+                        "quantity": 500,
+                        "unit": "kg",
+                    }
+                ],
+                "electrolyte": [
+                    {"item": {"name": "inlined reference"}, "quantity": 10, "unit": "ml"}
+                ],
+                "cell_format": "swagelok",
+                "type": "cells",
+                "creator_ids": [user_id],
+                "Location": "Place4>Place5>Place6",
+            }
+        )
+    )
+    item_creator(
+        Cell(
+            **{
+                "item_id": "test_cell_4",
+                "name": "test cell",
+                "date": "1970-02-01",
+                "negative_electrode": [
+                    {
+                        "item": {"item_id": "test", "type": "starting_materials"},
+                        "quantity": 5.0,
+                        "unit": "mg",
+                    },
+                    {
+                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
+                        "quantity": 1.0,
+                        "unit": "mg",
+                    },
+                ],
+                "positive_electrode": [
+                    {
+                        "item": {
+                            "item_id": "test_cathode",
+                            "chemform": "LiCoO2",
+                            "type": "samples",
+                        },
+                        "quantity": 500,
+                        "unit": "kg",
+                    }
+                ],
+                "electrolyte": [
+                    {"item": {"name": "inlined reference"}, "quantity": 10, "unit": "ml"}
+                ],
+                "cell_format": "swagelok",
+                "type": "cells",
+                "creator_ids": [user_id],
+                "Location": "Place1>Place7>Place8",
+            }
+        )
+    )
+    response = client.get("/locations")
+    assert response.status_code == 200
+    assert "flat_locations" in response.json
+
+    assert set(response.json["flat_locations"]).issuperset(
+        {
+            "Place1>Place2>Place3",
+            "Place1>Place2",
+            "Place4>Place5>Place6",
+            "Place1>Place7>Place8",
+        }
+    )
+
+    # non-flat checks
+    assert "nested_locations" in response.json
+    assert response.json["nested_locations"]
+    print(response.json["nested_locations"])
+    assert "Place4" in response.json["nested_locations"]
+    assert "Place5" in response.json["nested_locations"]["Place4"]
+    assert "Place6" in response.json["nested_locations"]["Place4"]["Place5"]
+    assert "Place1" in response.json["nested_locations"]
+    assert "Place2" in response.json["nested_locations"]["Place1"]
+    assert "Place7" in response.json["nested_locations"]["Place1"]
+    assert "Place3" in response.json["nested_locations"]["Place1"]["Place2"]
+    assert "Place8" in response.json["nested_locations"]["Place1"]["Place7"]
+
+
+def test_location_endpoint_with_spaced_signs(client, item_creator, user_id):
+    item_creator(
+        Cell(
+            **{
+                "item_id": "test_cell0",
+                "name": "test cell",
+                "date": "1970-02-01",
+                "negative_electrode": [
+                    {
+                        "item": {"item_id": "test", "type": "starting_materials"},
+                        "quantity": 2.0,
+                        "unit": "mg",
+                    },
+                    {
+                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
+                        "quantity": 2.0,
+                        "unit": "mg",
+                    },
+                ],
+                "positive_electrode": [
+                    {
+                        "item": {
+                            "item_id": "test_cathode",
+                            "chemform": "LiCoO2",
+                            "type": "samples",
+                        },
+                        "quantity": 2000,
+                        "unit": "kg",
+                    }
+                ],
+                "electrolyte": [
+                    {"item": {"name": "inlined reference"}, "quantity": 100, "unit": "ml"}
+                ],
+                "cell_format": "swagelok",
+                "type": "cells",
+                "creator_ids": [user_id],
+                "Location": "Lab 1 > Shelf 2",
+            }
+        )
+    )
+    item_creator(
+        Cell(
+            **{
+                "item_id": "test_cell_2",
+                "name": "test cell",
+                "date": "1970-02-01",
+                "negative_electrode": [
+                    {
+                        "item": {"item_id": "test", "type": "starting_materials"},
+                        "quantity": 5.0,
+                        "unit": "mg",
+                    },
+                    {
+                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
+                        "quantity": 1.0,
+                        "unit": "mg",
+                    },
+                ],
+                "positive_electrode": [
+                    {
+                        "item": {
+                            "item_id": "test_cathode",
+                            "chemform": "LiCoO2",
+                            "type": "samples",
+                        },
+                        "quantity": 500,
+                        "unit": "kg",
+                    }
+                ],
+                "electrolyte": [
+                    {"item": {"name": "inlined reference"}, "quantity": 10, "unit": "ml"}
+                ],
+                "cell_format": "swagelok",
+                "type": "cells",
+                "creator_ids": [user_id],
+                "Location": "Lab 1 > Shelf 3",
+            }
+        )
+    )
+    item_creator(
+        Cell(
+            **{
+                "item_id": "test_cell_3",
+                "name": "test cell",
+                "date": "1970-02-01",
+                "negative_electrode": [
+                    {
+                        "item": {"item_id": "test", "type": "starting_materials"},
+                        "quantity": 5.0,
+                        "unit": "mg",
+                    },
+                    {
+                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
+                        "quantity": 1.0,
+                        "unit": "mg",
+                    },
+                ],
+                "positive_electrode": [
+                    {
+                        "item": {
+                            "item_id": "test_cathode",
+                            "chemform": "LiCoO2",
+                            "type": "samples",
+                        },
+                        "quantity": 500,
+                        "unit": "kg",
+                    }
+                ],
+                "electrolyte": [
+                    {"item": {"name": "inlined reference"}, "quantity": 10, "unit": "ml"}
+                ],
+                "cell_format": "swagelok",
+                "type": "cells",
+                "creator_ids": [user_id],
+                "Location": "Lab 2 > Shelf 1",
+            }
+        )
+    )
+    item_creator(
+        Cell(
+            **{
+                "item_id": "test_cell_4",
+                "name": "test cell",
+                "date": "1970-02-01",
+                "negative_electrode": [
+                    {
+                        "item": {"item_id": "test", "type": "starting_materials"},
+                        "quantity": 5.0,
+                        "unit": "mg",
+                    },
+                    {
+                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
+                        "quantity": 1.0,
+                        "unit": "mg",
+                    },
+                ],
+                "positive_electrode": [
+                    {
+                        "item": {
+                            "item_id": "test_cathode",
+                            "chemform": "LiCoO2",
+                            "type": "samples",
+                        },
+                        "quantity": 500,
+                        "unit": "kg",
+                    }
+                ],
+                "electrolyte": [
+                    {"item": {"name": "inlined reference"}, "quantity": 10, "unit": "ml"}
+                ],
+                "cell_format": "swagelok",
+                "type": "cells",
+                "creator_ids": [user_id],
+                "Location": "Lab 1 > Shelf 2 > Position A",
+            }
+        )
+    )
+    response = client.get("/locations")
+    assert response.status_code == 200
+    assert "flat_locations" in response.json
+
+    assert set(response.json["flat_locations"]).issuperset(
+        {
+            "Lab 1 > Shelf 2",
+            "Lab 1 > Shelf 3",
+            "Lab 2 > Shelf 1",
+            "Lab 1 > Shelf 2 > Position A",
+        }
+    )
+    assert "nested_locations" in response.json
+    assert "Lab 1" in response.json["nested_locations"]
+    assert "Shelf 2" in response.json["nested_locations"]["Lab 1"]
+    assert "Shelf 3" in response.json["nested_locations"]["Lab 1"]
+    assert "Position A" in response.json["nested_locations"]["Lab 1"]["Shelf 2"]
+
+    assert "Lab 2" in response.json["nested_locations"]
+    assert "Shelf 1" in response.json["nested_locations"]["Lab 2"]
+
+
+def test_location_endpoint_with_single_non_nested_location(client, item_creator, user_id):
+    item_creator(
+        Cell(
+            **{
+                "item_id": "test_cell_4",
+                "name": "test cell",
+                "date": "1970-02-01",
+                "negative_electrode": [
+                    {
+                        "item": {"item_id": "test", "type": "starting_materials"},
+                        "quantity": 5.0,
+                        "unit": "mg",
+                    },
+                    {
+                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
+                        "quantity": 1.0,
+                        "unit": "mg",
+                    },
+                ],
+                "positive_electrode": [
+                    {
+                        "item": {
+                            "item_id": "test_cathode",
+                            "chemform": "LiCoO2",
+                            "type": "samples",
+                        },
+                        "quantity": 500,
+                        "unit": "kg",
+                    }
+                ],
+                "electrolyte": [
+                    {"item": {"name": "inlined reference"}, "quantity": 10, "unit": "ml"}
+                ],
+                "cell_format": "swagelok",
+                "type": "cells",
+                "creator_ids": [user_id],
+                "Location": "Lab 1",
+            }
+        )
+    )
+    response = client.get("/locations")
+    assert response.status_code == 200
+    assert "flat_locations" in response.json
+
+    assert set(response.json["flat_locations"]).issuperset({"Lab 1"})
+    assert "nested_locations" in response.json
+    assert "Lab 1" in response.json["nested_locations"]

--- a/pydatalab/tests/server/test_items.py
+++ b/pydatalab/tests/server/test_items.py
@@ -50,174 +50,20 @@ def test_location_endpoint_server_defaults(client, item_creator, user_id):
 
 
 def test_location_endpoint(client, item_creator, user_id):
-    item_creator(
-        Cell(
-            **{
-                "item_id": "test_cell0",
-                "name": "test cell",
-                "date": "1970-02-01",
-                "negative_electrode": [
-                    {
-                        "item": {"item_id": "test", "type": "starting_materials"},
-                        "quantity": 2.0,
-                        "unit": "mg",
-                    },
-                    {
-                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
-                        "quantity": 2.0,
-                        "unit": "mg",
-                    },
-                ],
-                "positive_electrode": [
-                    {
-                        "item": {
-                            "item_id": "test_cathode",
-                            "chemform": "LiCoO2",
-                            "type": "samples",
-                        },
-                        "quantity": 2000,
-                        "unit": "kg",
-                    }
-                ],
-                "electrolyte": [
-                    {"item": {"name": "inlined reference"}, "quantity": 100, "unit": "ml"}
-                ],
-                "cell_format": "swagelok",
-                "type": "cells",
-                "creator_ids": [user_id],
-                "Location": "Place1>Place2>Place3",
-            }
-        )
-    )
-    item_creator(
-        Cell(
-            **{
-                "item_id": "test_cell_2",
-                "name": "test cell",
-                "date": "1970-02-01",
-                "negative_electrode": [
-                    {
-                        "item": {"item_id": "test", "type": "starting_materials"},
-                        "quantity": 5.0,
-                        "unit": "mg",
-                    },
-                    {
-                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
-                        "quantity": 1.0,
-                        "unit": "mg",
-                    },
-                ],
-                "positive_electrode": [
-                    {
-                        "item": {
-                            "item_id": "test_cathode",
-                            "chemform": "LiCoO2",
-                            "type": "samples",
-                        },
-                        "quantity": 500,
-                        "unit": "kg",
-                    }
-                ],
-                "electrolyte": [
-                    {"item": {"name": "inlined reference"}, "quantity": 10, "unit": "ml"}
-                ],
-                "cell_format": "swagelok",
-                "type": "cells",
-                "creator_ids": [user_id],
-                "Location": "Place1>Place2",
-            }
-        )
-    )
-    item_creator(
-        Cell(
-            **{
-                "item_id": "test_cell_3",
-                "name": "test cell",
-                "date": "1970-02-01",
-                "negative_electrode": [
-                    {
-                        "item": {"item_id": "test", "type": "starting_materials"},
-                        "quantity": 5.0,
-                        "unit": "mg",
-                    },
-                    {
-                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
-                        "quantity": 1.0,
-                        "unit": "mg",
-                    },
-                ],
-                "positive_electrode": [
-                    {
-                        "item": {
-                            "item_id": "test_cathode",
-                            "chemform": "LiCoO2",
-                            "type": "samples",
-                        },
-                        "quantity": 500,
-                        "unit": "kg",
-                    }
-                ],
-                "electrolyte": [
-                    {"item": {"name": "inlined reference"}, "quantity": 10, "unit": "ml"}
-                ],
-                "cell_format": "swagelok",
-                "type": "cells",
-                "creator_ids": [user_id],
-                "Location": "Place4>Place5>Place6",
-            }
-        )
-    )
-    item_creator(
-        Cell(
-            **{
-                "item_id": "test_cell_4",
-                "name": "test cell",
-                "date": "1970-02-01",
-                "negative_electrode": [
-                    {
-                        "item": {"item_id": "test", "type": "starting_materials"},
-                        "quantity": 5.0,
-                        "unit": "mg",
-                    },
-                    {
-                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
-                        "quantity": 1.0,
-                        "unit": "mg",
-                    },
-                ],
-                "positive_electrode": [
-                    {
-                        "item": {
-                            "item_id": "test_cathode",
-                            "chemform": "LiCoO2",
-                            "type": "samples",
-                        },
-                        "quantity": 500,
-                        "unit": "kg",
-                    }
-                ],
-                "electrolyte": [
-                    {"item": {"name": "inlined reference"}, "quantity": 10, "unit": "ml"}
-                ],
-                "cell_format": "swagelok",
-                "type": "cells",
-                "creator_ids": [user_id],
-                "Location": "Place1>Place7>Place8",
-            }
-        )
-    )
+    locations = [
+        "Place1>Place2>Place3",
+        "Place1>Place2",
+        "Place4>Place5>Place6",
+        "Place1>Place7>Place8",
+    ]
+    for ind, loc in enumerate(locations):
+        cell = Cell(**{"item_id": f"test_cell_{ind + 10}", "location": loc})
+        item_creator(cell)
+
     response = client.get("/locations")
     assert response.status_code == 200
     assert "flat_locations" in response.json
-
-    assert set(response.json["flat_locations"]).issuperset(
-        {
-            "Place1>Place2>Place3",
-            "Place1>Place2",
-            "Place4>Place5>Place6",
-            "Place1>Place7>Place8",
-        }
-    )
+    assert set(response.json["flat_locations"]).issuperset(set(locations))
 
     # non-flat checks
     assert "nested_locations" in response.json
@@ -233,174 +79,21 @@ def test_location_endpoint(client, item_creator, user_id):
 
 
 def test_location_endpoint_with_spaced_signs(client, item_creator, user_id):
-    item_creator(
-        Cell(
-            **{
-                "item_id": "test_cell0",
-                "name": "test cell",
-                "date": "1970-02-01",
-                "negative_electrode": [
-                    {
-                        "item": {"item_id": "test", "type": "starting_materials"},
-                        "quantity": 2.0,
-                        "unit": "mg",
-                    },
-                    {
-                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
-                        "quantity": 2.0,
-                        "unit": "mg",
-                    },
-                ],
-                "positive_electrode": [
-                    {
-                        "item": {
-                            "item_id": "test_cathode",
-                            "chemform": "LiCoO2",
-                            "type": "samples",
-                        },
-                        "quantity": 2000,
-                        "unit": "kg",
-                    }
-                ],
-                "electrolyte": [
-                    {"item": {"name": "inlined reference"}, "quantity": 100, "unit": "ml"}
-                ],
-                "cell_format": "swagelok",
-                "type": "cells",
-                "creator_ids": [user_id],
-                "Location": "Lab 1 > Shelf 2",
-            }
-        )
-    )
-    item_creator(
-        Cell(
-            **{
-                "item_id": "test_cell_2",
-                "name": "test cell",
-                "date": "1970-02-01",
-                "negative_electrode": [
-                    {
-                        "item": {"item_id": "test", "type": "starting_materials"},
-                        "quantity": 5.0,
-                        "unit": "mg",
-                    },
-                    {
-                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
-                        "quantity": 1.0,
-                        "unit": "mg",
-                    },
-                ],
-                "positive_electrode": [
-                    {
-                        "item": {
-                            "item_id": "test_cathode",
-                            "chemform": "LiCoO2",
-                            "type": "samples",
-                        },
-                        "quantity": 500,
-                        "unit": "kg",
-                    }
-                ],
-                "electrolyte": [
-                    {"item": {"name": "inlined reference"}, "quantity": 10, "unit": "ml"}
-                ],
-                "cell_format": "swagelok",
-                "type": "cells",
-                "creator_ids": [user_id],
-                "Location": "Lab 1 > Shelf 3",
-            }
-        )
-    )
-    item_creator(
-        Cell(
-            **{
-                "item_id": "test_cell_3",
-                "name": "test cell",
-                "date": "1970-02-01",
-                "negative_electrode": [
-                    {
-                        "item": {"item_id": "test", "type": "starting_materials"},
-                        "quantity": 5.0,
-                        "unit": "mg",
-                    },
-                    {
-                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
-                        "quantity": 1.0,
-                        "unit": "mg",
-                    },
-                ],
-                "positive_electrode": [
-                    {
-                        "item": {
-                            "item_id": "test_cathode",
-                            "chemform": "LiCoO2",
-                            "type": "samples",
-                        },
-                        "quantity": 500,
-                        "unit": "kg",
-                    }
-                ],
-                "electrolyte": [
-                    {"item": {"name": "inlined reference"}, "quantity": 10, "unit": "ml"}
-                ],
-                "cell_format": "swagelok",
-                "type": "cells",
-                "creator_ids": [user_id],
-                "Location": "Lab 2 > Shelf 1",
-            }
-        )
-    )
-    item_creator(
-        Cell(
-            **{
-                "item_id": "test_cell_4",
-                "name": "test cell",
-                "date": "1970-02-01",
-                "negative_electrode": [
-                    {
-                        "item": {"item_id": "test", "type": "starting_materials"},
-                        "quantity": 5.0,
-                        "unit": "mg",
-                    },
-                    {
-                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
-                        "quantity": 1.0,
-                        "unit": "mg",
-                    },
-                ],
-                "positive_electrode": [
-                    {
-                        "item": {
-                            "item_id": "test_cathode",
-                            "chemform": "LiCoO2",
-                            "type": "samples",
-                        },
-                        "quantity": 500,
-                        "unit": "kg",
-                    }
-                ],
-                "electrolyte": [
-                    {"item": {"name": "inlined reference"}, "quantity": 10, "unit": "ml"}
-                ],
-                "cell_format": "swagelok",
-                "type": "cells",
-                "creator_ids": [user_id],
-                "Location": "Lab 1 > Shelf 2 > Position A",
-            }
-        )
-    )
+    locations = [
+        "Lab 1 > Shelf 2",
+        "Lab 1 > Shelf 3",
+        "Lab 2 > Shelf 1",
+        "Lab 1 > Shelf 2 > Position A",
+    ]
+    for ind, loc in enumerate(locations):
+        cell = Cell(**{"item_id": f"test_cell_{ind + 20}", "location": loc})
+        item_creator(cell)
+
     response = client.get("/locations")
     assert response.status_code == 200
     assert "flat_locations" in response.json
 
-    assert set(response.json["flat_locations"]).issuperset(
-        {
-            "Lab 1 > Shelf 2",
-            "Lab 1 > Shelf 3",
-            "Lab 2 > Shelf 1",
-            "Lab 1 > Shelf 2 > Position A",
-        }
-    )
+    assert set(response.json["flat_locations"]).issuperset(set(locations))
     assert "nested_locations" in response.json
     assert "Lab 1" in response.json["nested_locations"]
     assert "Shelf 2" in response.json["nested_locations"]["Lab 1"]
@@ -416,38 +109,7 @@ def test_location_endpoint_with_single_non_nested_location(client, item_creator,
         Cell(
             **{
                 "item_id": "test_cell_4",
-                "name": "test cell",
-                "date": "1970-02-01",
-                "negative_electrode": [
-                    {
-                        "item": {"item_id": "test", "type": "starting_materials"},
-                        "quantity": 5.0,
-                        "unit": "mg",
-                    },
-                    {
-                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
-                        "quantity": 1.0,
-                        "unit": "mg",
-                    },
-                ],
-                "positive_electrode": [
-                    {
-                        "item": {
-                            "item_id": "test_cathode",
-                            "chemform": "LiCoO2",
-                            "type": "samples",
-                        },
-                        "quantity": 500,
-                        "unit": "kg",
-                    }
-                ],
-                "electrolyte": [
-                    {"item": {"name": "inlined reference"}, "quantity": 10, "unit": "ml"}
-                ],
-                "cell_format": "swagelok",
-                "type": "cells",
-                "creator_ids": [user_id],
-                "Location": "Lab 1",
+                "location": "Lab 1",
             }
         )
     )
@@ -466,38 +128,7 @@ def test_regression_test_against_overwriting_problem(client, item_creator, user_
         Cell(
             **{
                 "item_id": "test_cell_4",
-                "name": "test cell",
-                "date": "1970-02-01",
-                "negative_electrode": [
-                    {
-                        "item": {"item_id": "test", "type": "starting_materials"},
-                        "quantity": 5.0,
-                        "unit": "mg",
-                    },
-                    {
-                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
-                        "quantity": 1.0,
-                        "unit": "mg",
-                    },
-                ],
-                "positive_electrode": [
-                    {
-                        "item": {
-                            "item_id": "test_cathode",
-                            "chemform": "LiCoO2",
-                            "type": "samples",
-                        },
-                        "quantity": 500,
-                        "unit": "kg",
-                    }
-                ],
-                "electrolyte": [
-                    {"item": {"name": "inlined reference"}, "quantity": 10, "unit": "ml"}
-                ],
-                "cell_format": "swagelok",
-                "type": "cells",
-                "creator_ids": [user_id],
-                "Location": "Cambridge > Lab 6 > Shelf 2 > Position A",
+                "location": "Cambridge > Lab 6 > Shelf 2 > Position A",
             }
         )
     )
@@ -505,38 +136,7 @@ def test_regression_test_against_overwriting_problem(client, item_creator, user_
         Cell(
             **{
                 "item_id": "test_cell0",
-                "name": "test cell",
-                "date": "1970-02-01",
-                "negative_electrode": [
-                    {
-                        "item": {"item_id": "test", "type": "starting_materials"},
-                        "quantity": 2.0,
-                        "unit": "mg",
-                    },
-                    {
-                        "item": {"item_id": "test_carbon", "chemform": "C", "type": "samples"},
-                        "quantity": 2.0,
-                        "unit": "mg",
-                    },
-                ],
-                "positive_electrode": [
-                    {
-                        "item": {
-                            "item_id": "test_cathode",
-                            "chemform": "LiCoO2",
-                            "type": "samples",
-                        },
-                        "quantity": 2000,
-                        "unit": "kg",
-                    }
-                ],
-                "electrolyte": [
-                    {"item": {"name": "inlined reference"}, "quantity": 100, "unit": "ml"}
-                ],
-                "cell_format": "swagelok",
-                "type": "cells",
-                "creator_ids": [user_id],
-                "Location": "Cambridge > Lab 6 > Shelf 1",
+                "location": "Cambridge > Lab 6 > Shelf 1",
             }
         )
     )

--- a/pydatalab/tests/server/test_items.py
+++ b/pydatalab/tests/server/test_items.py
@@ -104,6 +104,59 @@ def test_location_endpoint_with_spaced_signs(client, item_creator, user_id):
     assert "Shelf 1" in response.json["nested_locations"]["Lab 2"]
 
 
+def test_location_endpoint_with_bad_segments(client, item_creator):
+    """Tests that malformed locations (e.g., double >) do not break endpoint."""
+
+    locations = [
+        "Lab 1 >> Shelf 2",
+        "Building A > Lab 1 > Shelf 3",
+        "Shelf 3",
+        ">>>>>>>>>>",
+        "<<<<",
+    ]
+
+    for ind, loc in enumerate(locations):
+        item_creator(Cell(**{"item_id": f"test_cell_{ind + 99}", "location": loc}))
+
+    # expected_nest = {"Lab 1": ["Shelf 2"], "Building A": {"Lab 1": ["Shelf 3"], "Shelf 3": {}}}
+
+    response = client.get("/locations")
+    assert response.status_code == 200
+    assert "flat_locations" in response.json
+
+    assert set(response.json["flat_locations"]).issuperset(locations)
+    assert "nested_locations" in response.json
+    assert all(k in response.json["nested_locations"] for k in ["Lab 1", "Building A", "Shelf 3"])
+    assert response.json["nested_locations"]["Building A"]["Lab 1"] == {"Shelf 3": {}}
+    assert response.json["nested_locations"]["Shelf 3"] == {}
+    assert response.json["nested_locations"]["Lab 1"] == {"Shelf 2": {}}
+
+
+def test_location_endpoint_with_duplicated_segments(client, item_creator):
+    """Tests that duplicated segments appearing at different levels
+    are treated as separate things.
+
+    """
+
+    locations = ["Lab 1 > Shelf 2", "Building A > Lab 1 > Shelf 3", "Shelf 3"]
+
+    for ind, loc in enumerate(locations):
+        item_creator(Cell(**{"item_id": f"test_cell_{ind + 99}", "location": loc}))
+
+    # expected_nest = {"Lab 1": ["Shelf 2"], "Building A": {"Lab 1": ["Shelf 3"], "Shelf 3": {}}}
+
+    response = client.get("/locations")
+    assert response.status_code == 200
+    assert "flat_locations" in response.json
+
+    assert set(response.json["flat_locations"]).issuperset(locations)
+    assert "nested_locations" in response.json
+    assert all(k in response.json["nested_locations"] for k in ["Lab 1", "Building A", "Shelf 3"])
+    assert response.json["nested_locations"]["Building A"]["Lab 1"] == {"Shelf 3": {}}
+    assert response.json["nested_locations"]["Shelf 3"] == {}
+    assert response.json["nested_locations"]["Lab 1"] == {"Shelf 2": {}}
+
+
 def test_location_endpoint_with_single_non_nested_location(client, item_creator, user_id):
     item_creator(
         Cell(
@@ -123,7 +176,7 @@ def test_location_endpoint_with_single_non_nested_location(client, item_creator,
 
 
 def test_regression_test_against_overwriting_problem(client, item_creator, user_id):
-    # test ensures that items don't get over (i.e. Position A should not get overwritten)
+    # test ensures that items don't get overwritten (i.e. Position A should not get overwritten)
     item_creator(
         Cell(
             **{


### PR DESCRIPTION
Supersedes #2001 (This new version is not from a fork and thus can be "stacked")

Closes #1981 and closes #1982

Locations are where things are stored. Currently we are using a single string in the database to store the location and then frontend application logic on top to create a nested hierarchy. Moving forward it would be ideal to move some of this logic to the backend to prevent locations being generated from stale/deprecated data that has been stored in the frontend.
## Features
- Introduces `GET \locations` endpoint.
  - Which returns a flat list of all locations and a nested list of all locations.
- Introduces `HasLocation` attribute for all items
## Example
An example return from the endpoint is here
`{"flat_locations":["Hub1 > Hub2 > Place 1","LHud One","Lab 1 > Shelf 1 > Place A","Lab 4 > Shelf 1","lab1"],"nested_locations":{"Hub1":{"Hub2":{"Place 1":{}}},"LHud One":{},"Lab 1":{"Shelf 1":{"Place A":{}}},"Lab 4":{"Shelf 1":{}},"lab1":{}}}
`
## Testing
Currently three tests have been written to test this endpoint functionality (`GET \locations`).

## Further planned functionality
Implement this into the frontend so that it queries this endpoint instead of using frontend storage. 