### PR TITLE
Improvements to item versioning UI

### DIFF
--- a/pydatalab/src/pydatalab/models/versions.py
+++ b/pydatalab/src/pydatalab/models/versions.py
@@ -16,6 +16,7 @@ class VersionAction(str, Enum):
     AUTO_SAVE = "auto_save"
     RESTORED = "restored"
     AGENT_SAVE = "agent_save"
+    PERMISSIONS_UPDATE = "permissions_update"
 
 
 class ItemVersion(BaseModel):

--- a/pydatalab/src/pydatalab/models/versions.py
+++ b/pydatalab/src/pydatalab/models/versions.py
@@ -32,11 +32,7 @@ class ItemVersion(BaseModel):
     timestamp: datetime = Field(
         ..., description="When this version was created (ISO format with timezone)"
     )
-    action: VersionAction = Field(
-        ...,
-        description="The action that triggered this version: 'created' (item creation), "
-        "'manual_save' (user save), 'auto_save' (system save), or 'restored' (version restore)",
-    )
+    action: VersionAction = Field(..., description="The action that triggered this version.")
     user_id: PyObjectId | None = Field(
         None, description="User's ObjectId for efficient querying and indexing"
     )

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -995,6 +995,21 @@ def _process_item_permissions(
             400,
         )
 
+    # Record the new ownership in the item's history as a version
+    version_response, version_status = save_version_snapshot(
+        refcode, action=VersionAction.PERMISSIONS_UPDATE
+    )
+    if version_status != 200:
+        LOGGER.error(
+            "Failed to save version for item %s after updating permissions: %s",
+            refcode,
+            version_response,
+        )
+    elif "version" in version_response:
+        flask_mongo.db.items.update_one(
+            {"refcode": refcode}, {"$set": {"version": version_response["version"]}}
+        )
+
     return {"status": "success"}, 200
 
 

--- a/pydatalab/src/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/items.py
@@ -1526,7 +1526,7 @@ def restore_version(refcode):
 
     # Update metadata to reflect the restore action
     restored_data["version"] = next_version_number
-    restored_data["last_modified"] = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+    restored_data["last_modified"] = datetime.datetime.now(tz=datetime.timezone.utc)
 
     # Validate restored data against the item model
     item_type = current_item["type"]

--- a/pydatalab/src/pydatalab/versioning.py
+++ b/pydatalab/src/pydatalab/versioning.py
@@ -2,7 +2,6 @@
 
 import datetime
 
-from bson import json_util
 from flask import request
 from flask_login import current_user
 from pydantic import ValidationError
@@ -166,13 +165,6 @@ def save_version_snapshot(
                 "No changes detected for %s, skipping version save: %s", refcode, current_data
             )
             return {"status": "success", "message": "No changes detected, version not saved."}, 200
-
-        LOGGER.debug(
-            "Changes detected for %s, saving new version. Old: %s, New: %s",
-            refcode,
-            json_util.dumps(last_data),
-            json_util.dumps(current_data),
-        )
 
     # Extract user information for hybrid storage approach
     user_id = None

--- a/pydatalab/src/pydatalab/versioning.py
+++ b/pydatalab/src/pydatalab/versioning.py
@@ -2,6 +2,7 @@
 
 import datetime
 
+from bson import json_util
 from flask import request
 from flask_login import current_user
 from pydantic import ValidationError
@@ -54,6 +55,30 @@ def apply_protected_fields(restored_data: dict, current_item: dict) -> dict:
             restored_data[field] = current_item[field]
 
     return restored_data
+
+
+MECHANICAL_FIELDS = {
+    "last_modified",
+    "version",
+    "_id",
+    "immutable_id",
+    "refcode",
+    "creators",
+    "groups",
+}
+"""Fields ignored when deciding whether an item's content has changed.
+
+Covers those that change on every save without reflecting a real edit (`last_modified`,
+`version`); identifiers fixed for the life of an item (`_id`, `immutable_id`,
+`refcode`), which cannot legitimately differ between an item and its own snapshot; and
+`creators`/`groups`, which are inlined by joins for display and written inconsistently
+by the creation and save paths -- item creation omits them, `/save-item/` stores
+`groups` as null.
+
+The permissions themselves (`creator_ids` and `group_ids`) are deliberately *not* here:
+a change of ownership is recorded in an item's history like any other edit.
+
+"""
 
 
 def get_next_version_number(refcode: str) -> int:
@@ -130,18 +155,24 @@ def save_version_snapshot(
 
     # Skip creating a new version if content is identical to the last snapshot.
     # Excludes fields that change mechanically on every save and don't reflect real edits.
-    _MECHANICAL_FIELDS = {"last_modified", "version", "_id"}
     last_version = flask_mongo.db.item_versions.find_one(
         {"refcode": refcode}, sort=[("version", -1)]
     )
     if last_version:
-        current_data = {k: v for k, v in item.items() if k not in _MECHANICAL_FIELDS}
-        last_data = {k: v for k, v in last_version["data"].items() if k not in _MECHANICAL_FIELDS}
+        current_data = {k: v for k, v in item.items() if k not in MECHANICAL_FIELDS}
+        last_data = {k: v for k, v in last_version["data"].items() if k not in MECHANICAL_FIELDS}
         if current_data == last_data:
+            LOGGER.debug(
+                "No changes detected for %s, skipping version save: %s", refcode, current_data
+            )
             return {"status": "success", "message": "No changes detected, version not saved."}, 200
 
-    # Atomically get the next version number
-    next_version_number = get_next_version_number(refcode)
+        LOGGER.debug(
+            "Changes detected for %s, saving new version. Old: %s, New: %s",
+            refcode,
+            json_util.dumps(last_data),
+            json_util.dumps(current_data),
+        )
 
     # Extract user information for hybrid storage approach
     user_id = None
@@ -164,7 +195,7 @@ def save_version_snapshot(
 
     version_entry = {
         "refcode": refcode,
-        "version": next_version_number,
+        "version": 1,
         "timestamp": datetime.datetime.now(tz=datetime.timezone.utc),
         "action": action,  # Audit trail: why this version was created
         "user_id": user_id,  # ObjectId for efficient querying
@@ -191,10 +222,15 @@ def save_version_snapshot(
             400,
         )
 
+    # Only now allocate the version number: the counter is persistent and monotonic, so
+    # taking a number before validation burns it whenever validation fails, leaving a
+    # permanent gap in the item's version history.
+    next_version_number = get_next_version_number(refcode)
+
     # Insert validated data (convert to dict and exclude None values)
-    flask_mongo.db.item_versions.insert_one(
-        validated_version.dict(by_alias=True, exclude_none=True)
-    )
+    version_doc = validated_version.dict(by_alias=True, exclude_none=True)
+    version_doc["version"] = next_version_number
+    flask_mongo.db.item_versions.insert_one(version_doc)
     return (
         {"status": "success", "message": "Version saved.", "version": next_version_number},
         200,

--- a/pydatalab/tests/server/test_item_versions.py
+++ b/pydatalab/tests/server/test_item_versions.py
@@ -1,7 +1,27 @@
 """Tests for item version control endpoints."""
 
+import datetime
+
 import pytest
 from bson import ObjectId
+
+
+@pytest.fixture
+def api_sample(client, default_sample_dict):
+    """Create the conftest's default sample through the API, and clean it up the same
+    way.
+
+    Function-scoped, unlike `insert_default_sample`, because each test needs an item
+    with its own version history. Everything downstream observes the item only over
+    HTTP, so the tests exercise the paths a real client takes.
+    """
+    response = client.post("/new-sample/", json=default_sample_dict)
+    assert response.status_code == 201
+    entry = response.json["sample_list_entry"]
+
+    yield {"item_id": entry["item_id"], "refcode": entry["refcode"].split(":")[1]}
+
+    client.post("/delete-sample/", json={"item_id": entry["item_id"]})
 
 
 @pytest.fixture
@@ -169,7 +189,6 @@ class TestListVersions:
         timezone offset and clients (e.g. JS `Date` parsing) misinterpret it as
         local time.
         """
-        import datetime
 
         from pydatalab.mongo import flask_mongo
 
@@ -1390,3 +1409,145 @@ def test_sample_lifecycle(client, sample_with_version):
     flask_mongo.db.version_counters.delete_one({"refcode": refcode})
 
     print("[TEST] ✓ Lifecycle test completed successfully")
+
+
+# Content-bearing fields on a sample, paired with a value that differs from the
+# `api_sample` fixture. Editing any one of these is a real change and must mint a
+# version.
+CONTENT_FIELDS = [
+    ("name", "A renamed sample"),
+    ("description", "A different description"),
+    ("chemform", "NaCoO2"),
+    ("synthesis_description", "A different synthesis"),
+    ("date", "2025-06-01T00:00:00+00:00"),
+    ("smiles", "CCO"),
+    ("inchi", "InChI=1S/H2O/h1H2"),
+    ("CAS", "7732-18-5"),
+    ("molar_mass", 123.45),
+    ("GHS_codes", "H301"),
+    ("status", "planned"),
+    ("display_order", ["somefakeblockid"]),
+    (
+        "synthesis_constituents",
+        [{"item": {"name": "Inline constituent", "chemform": "H2O"}, "quantity": 1.0, "unit": "g"}],
+    ),
+]
+
+
+class TestWhatMintsAVersion:
+    """Pin down exactly which edits do and do not mint a version, one field at a time.
+
+    Each test saves the item once to establish a baseline, then saves again with a
+    single field altered, so a minted version can only be attributed to that field.
+    """
+
+    @pytest.mark.parametrize("field,new_value", CONTENT_FIELDS)
+    def test_changing_a_field_mints_a_version(self, client, api_sample, field, new_value):
+        """Editing a single content field must mint exactly one new version."""
+        item_data = client.get(f"/get-item-data/{api_sample['item_id']}").json["item_data"]
+
+        response = client.post(
+            "/save-item/", json={"item_id": api_sample["item_id"], "data": dict(item_data)}
+        )
+        assert response.status_code == 200
+        before = len(client.get(f"/items/{api_sample['refcode']}/versions/").json["versions"])
+
+        item_data[field] = new_value
+        response = client.post(
+            "/save-item/", json={"item_id": api_sample["item_id"], "data": dict(item_data)}
+        )
+        assert response.status_code == 200
+
+        versions = client.get(f"/items/{api_sample['refcode']}/versions/").json["versions"]
+        assert len(versions) == before + 1, f"changing {field!r} should have minted a version"
+
+    @pytest.mark.parametrize("field,new_value", CONTENT_FIELDS)
+    def test_resaving_the_same_field_mints_nothing(self, client, api_sample, field, new_value):
+        """Re-submitting a field with an unchanged value must not mint a version.
+
+        This is the inventory-sync case: an agent re-sends the item verbatim every run,
+        and each identical save has to be a no-op.
+        """
+        item_data = client.get(f"/get-item-data/{api_sample['item_id']}").json["item_data"]
+        item_data[field] = new_value
+        client.post("/save-item/", json={"item_id": api_sample["item_id"], "data": dict(item_data)})
+
+        before = len(client.get(f"/items/{api_sample['refcode']}/versions/").json["versions"])
+
+        for _ in range(3):
+            response = client.post(
+                "/save-item/", json={"item_id": api_sample["item_id"], "data": dict(item_data)}
+            )
+            assert response.status_code == 200
+            assert response.json.get("unchanged") is True
+
+        versions = client.get(f"/items/{api_sample['refcode']}/versions/").json["versions"]
+        assert len(versions) == before, f"re-saving an unchanged {field!r} should not mint"
+
+    def test_repeated_identical_saves_do_not_accumulate_versions(self, client, api_sample):
+        """Many identical saves in a row mint at most one version between them."""
+        item_data = client.get(f"/get-item-data/{api_sample['item_id']}").json["item_data"]
+
+        for _ in range(10):
+            response = client.post(
+                "/save-item/", json={"item_id": api_sample["item_id"], "data": dict(item_data)}
+            )
+            assert response.status_code == 200
+
+        versions = client.get(f"/items/{api_sample['refcode']}/versions/").json["versions"]
+        assert len(versions) == 1
+
+    def test_creation_then_identical_save_mints_nothing(self, client, api_sample):
+        """An item saved verbatim right after creation must not mint a second version.
+
+        Creation and `/save-item/` serialise the item differently -- creation omits
+        `groups` and writes a null `immutable_id`, while `/save-item/` writes `groups`
+        as null and `immutable_id` as the item's ObjectId -- so a naive comparison sees
+        a change on every item's first sync after it is created.
+        """
+        item_data = client.get(f"/get-item-data/{api_sample['item_id']}").json["item_data"]
+
+        response = client.post(
+            "/save-item/", json={"item_id": api_sample["item_id"], "data": item_data}
+        )
+        assert response.status_code == 200
+
+        versions = client.get(f"/items/{api_sample['refcode']}/versions/").json["versions"]
+        assert len(versions) == 1, "an unmodified item should still have only its `created` version"
+
+    def test_permission_changes_mint_a_version(self, client, api_sample, admin_user_id):
+        """Changing who owns an item is recorded in its history.
+
+        The permissions route writes to the item directly rather than going through
+        `/save-item/`, so it has to snapshot for itself -- otherwise ownership changes
+        are invisible in the version history.
+        """
+        before = len(client.get(f"/items/{api_sample['refcode']}/versions/").json["versions"])
+
+        response = client.patch(
+            f"/items/{api_sample['refcode']}/permissions",
+            json={"creators": [{"immutable_id": str(admin_user_id)}]},
+        )
+        assert response.status_code == 200
+
+        versions = client.get(f"/items/{api_sample['refcode']}/versions/").json["versions"]
+        assert len(versions) == before + 1, "a permission change should be versioned"
+        assert versions[0]["action"] == "permissions_update"
+
+        latest = client.get(f"/items/{api_sample['refcode']}/versions/{versions[0]['_id']}/").json[
+            "version"
+        ]
+        assert str(admin_user_id) in [str(c) for c in latest["data"]["creator_ids"]]
+
+    def test_unchanged_permissions_mint_nothing(self, client, api_sample, user_id):
+        """Re-submitting the permissions an item already has is a no-op."""
+        before = len(client.get(f"/items/{api_sample['refcode']}/versions/").json["versions"])
+
+        response = client.patch(
+            f"/items/{api_sample['refcode']}/permissions",
+            json={"creators": [{"immutable_id": str(user_id)}]},
+        )
+        assert response.status_code == 200
+
+        versions = client.get(f"/items/{api_sample['refcode']}/versions/").json["versions"]
+        assert len(versions) == before

--- a/webapp/src/components/VersionHistoryModal.vue
+++ b/webapp/src/components/VersionHistoryModal.vue
@@ -31,6 +31,7 @@
               <tr>
                 <th>Version</th>
                 <th>Saved</th>
+                <th>Saved by</th>
                 <th>Action</th>
                 <th></th>
               </tr>
@@ -41,7 +42,7 @@
                 :key="version._id"
                 class="version-row"
                 :class="{ 'table-active': version.version === currentVersion }"
-                @click="previewVersionData(version._id, version.version)"
+                @click="previewVersionData(version)"
               >
                 <td>
                   <strong>{{ version.version }}</strong>
@@ -53,6 +54,10 @@
                   <span :title="formatDate(version.timestamp)">
                     {{ formatDistanceToNow(new Date(version.timestamp), { addSuffix: true }) }}
                   </span>
+                </td>
+                <td>
+                  <Creators v-if="version.creator" :creators="[version.creator]" :size="24" />
+                  <span v-else class="text-muted">Unknown</span>
                 </td>
                 <td>
                   <span class="text-muted">{{
@@ -76,107 +81,92 @@
       </div>
 
       <!-- Preview Mode -->
-      <div v-else class="preview-container">
+      <div v-else class="preview-container container-fluid">
+        <dl v-if="previewVersionRecord" class="row mb-3">
+          <dt class="col-sm-3">Saved by</dt>
+          <dd class="col-sm-9">
+            <Creators
+              v-if="previewVersionRecord.creator"
+              :creators="[previewVersionRecord.creator]"
+              :size="24"
+            />
+            <span v-else class="text-muted">Unknown</span>
+          </dd>
+
+          <dt class="col-sm-3">Saved</dt>
+          <dd class="col-sm-9">
+            {{ formatDate(previewVersionRecord.timestamp) }}
+            <span class="text-muted">
+              ({{
+                formatDistanceToNow(new Date(previewVersionRecord.timestamp), { addSuffix: true })
+              }})
+            </span>
+          </dd>
+
+          <dt class="col-sm-3">Action</dt>
+          <dd class="col-sm-9">
+            {{
+              formatAction(previewVersionRecord.action, previewVersionRecord.restored_from_version)
+            }}
+          </dd>
+
+          <dt class="col-sm-3">Saved via</dt>
+          <dd class="col-sm-9">
+            <span v-if="previewVersionRecord.user_agent">{{
+              previewVersionRecord.user_agent
+            }}</span>
+            <span v-else class="text-muted">Not recorded</span>
+          </dd>
+        </dl>
+
         <div class="alert alert-info mb-3">
           <font-awesome-icon icon="info-circle" fixed-width />
-          You are viewing a read-only preview of version {{ previewVersion }}. Changes made in this
-          version are highlighted below.
+          <span v-if="isPermissionsUpdate">
+            Version {{ previewVersion }} records a change to who can access this item. The item's
+            content was not edited.
+          </span>
+          <span v-else-if="previousVersionNumber">
+            What changed in version {{ previewVersion }}, compared with version
+            {{ previousVersionNumber }}.
+          </span>
+          <span v-else> Version {{ previewVersion }} is the first recorded version. </span>
         </div>
 
         <!-- Loading preview -->
         <div v-if="isLoadingPreview" class="text-center py-5">
           <font-awesome-icon icon="spinner" class="fa-spin" size="2x" style="color: gray" />
-          <p class="mt-3">Loading version data...</p>
+          <p class="mt-3">Loading changes...</p>
         </div>
 
-        <!-- Preview content -->
-        <div v-else-if="previewData" class="preview-content">
-          <!-- Debug: Show raw data structure -->
-          <details class="mb-3">
-            <summary style="cursor: pointer; color: #666">
-              <small>Debug: View raw data</small>
-            </summary>
-            <pre style="max-height: 200px; overflow-y: auto; font-size: 0.8em">{{
-              JSON.stringify(previewData, null, 2)
-            }}</pre>
-          </details>
+        <div v-else-if="isPermissionsUpdate" />
 
-          <h5>Item Information</h5>
-          <div class="row mb-3">
-            <div class="col-md-6">
-              <strong>Name:</strong>
-              <p>{{ previewData.name || "N/A" }}</p>
-            </div>
-            <div class="col-md-6">
-              <strong>Date:</strong>
-              <p>{{ previewData.date || "N/A" }}</p>
-            </div>
-          </div>
+        <div v-else-if="!previousVersionNumber" class="text-muted py-3">
+          There is no earlier version to compare it against.
+        </div>
 
-          <div class="row mb-3">
-            <div class="col-12">
-              <strong>Description:</strong>
-              <p>{{ previewData.description || "N/A" }}</p>
-            </div>
-          </div>
+        <div v-else-if="changes.length === 0" class="text-muted py-3">
+          No changes to the item's content were recorded in this version.
+        </div>
 
-          <div v-if="previewData.synthesis_description" class="row mb-3">
-            <div class="col-12">
-              <strong>Synthesis Description:</strong>
-              <p>{{ previewData.synthesis_description }}</p>
-            </div>
-          </div>
-
-          <div v-if="previewData.chemical_formula" class="row mb-3">
-            <div class="col-md-6">
-              <strong>Chemical Formula:</strong>
-              <p>{{ previewData.chemical_formula }}</p>
-            </div>
-          </div>
-
-          <div v-if="previewData.location" class="row mb-3">
-            <div class="col-12">
-              <strong>Location:</strong>
-              <p><LocationInput :model-value="previewData.location" :readonly="true" /></p>
-            </div>
-          </div>
-
-          <div v-if="previewData.manufacturer" class="row mb-3">
-            <div class="col-md-6">
-              <strong>Manufacturer:</strong>
-              <p>{{ previewData.manufacturer }}</p>
-            </div>
-          </div>
-
-          <div
-            v-if="previewData.display_order && previewData.display_order.length > 0"
-            class="mt-4"
-          >
-            <h5>Data Blocks ({{ previewData.display_order.length }})</h5>
-            <ul class="list-group">
-              <li
-                v-for="blockId in previewData.display_order"
-                :key="blockId"
-                class="list-group-item"
-              >
-                <strong>{{ getBlockTitle(blockId) }}</strong>
-                <span class="text-muted ml-2">({{ getBlockType(blockId) }})</span>
-              </li>
-            </ul>
-          </div>
-
-          <div v-if="previewData.files && previewData.files.length > 0" class="mt-4">
-            <h5>Files ({{ previewData.files.length }})</h5>
-            <ul class="list-group">
-              <li
-                v-for="file in previewData.files"
-                :key="file.immutable_id"
-                class="list-group-item"
-              >
-                {{ file.name }}
-              </li>
-            </ul>
-          </div>
+        <div v-else class="table-responsive">
+          <table class="table table-sm changes-table">
+            <thead>
+              <tr>
+                <th>Field</th>
+                <th>Before</th>
+                <th>After</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="change in changes" :key="change.field">
+                <td>
+                  <code>{{ change.field }}</code>
+                </td>
+                <td class="change-value change-before">{{ change.before }}</td>
+                <td class="change-value change-after">{{ change.after }}</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
 
         <!-- Preview actions -->
@@ -201,15 +191,29 @@
 
 <script>
 import Modal from "@/components/Modal.vue";
-import { getItemVersions, getItemVersion, restoreItemVersion } from "@/server_fetch_utils";
+import { getItemVersions, compareItemVersions, restoreItemVersion } from "@/server_fetch_utils";
 import { formatDistanceToNow } from "date-fns";
 import { DialogService } from "@/services/DialogService";
-import LocationInput from "@/components/LocationInput";
+import Creators from "@/components/Creators.vue";
+
+// Fields that are bookkeeping rather than item content: they change on every save, or
+// are inlined by the server for display, so listing them as changes is just noise.
+const IGNORED_FIELDS = [
+  "last_modified",
+  "version",
+  "_id",
+  "immutable_id",
+  "refcode",
+  "creators",
+  "groups",
+  "creator_ids",
+  "group_ids",
+];
 
 export default {
   components: {
     Modal,
-    LocationInput,
+    Creators,
   },
   props: {
     modelValue: Boolean,
@@ -235,13 +239,21 @@ export default {
       isPreviewMode: false,
       previewVersion: null,
       previewVersionId: null,
-      previewData: null,
+      previewVersionRecord: null,
+      previousVersionNumber: null,
+      changes: [],
       isLoadingPreview: false,
+      // Incremented whenever the active preview changes, so responses from an
+      // earlier (slower) comparison can be discarded instead of overwriting it.
+      previewRequestId: 0,
     };
   },
   computed: {
     sortedVersions() {
       return [...this.versions].sort((a, b) => b.version - a.version);
+    },
+    isPermissionsUpdate() {
+      return this.previewVersionRecord?.action === "permissions_update";
     },
   },
   watch: {
@@ -264,8 +276,11 @@ export default {
     },
     formatAction(action, restoredFromVersion) {
       const actionLabels = {
+        created: "Created",
         manual_save: "Manual Save",
         auto_save: "Auto Save",
+        agent_save: "Agent Save",
+        permissions_update: "Permissions Update",
         restored: restoredFromVersion
           ? `Restored from v${this.getVersionNumberById(restoredFromVersion)}`
           : "Restored",
@@ -287,25 +302,135 @@ export default {
         this.isLoadingVersions = false;
       }
     },
-    async previewVersionData(versionId, versionNumber) {
+    async previewVersionData(version) {
+      const versionId = version._id;
+      const versionNumber = version.version;
+      const requestId = ++this.previewRequestId;
+
       this.isPreviewMode = true;
       this.previewVersion = versionNumber;
       this.previewVersionId = versionId;
-      this.isLoadingPreview = true;
+      this.previewVersionRecord = version;
+      this.changes = [];
+      this.previousVersionNumber = null;
 
+      // A permissions update never touches the item's content, so a field-level diff
+      // has nothing useful to say about it.
+      if (this.isPermissionsUpdate) {
+        return;
+      }
+
+      // Compare against the closest earlier version rather than `versionNumber - 1`,
+      // since numbering can skip where a snapshot was deleted.
+      let previous = this.findPreviousVersion(versionNumber);
+      if (!previous) {
+        // The list may predate versions minted since the modal was opened, so confirm
+        // against the server before concluding this is the earliest version.
+        await this.loadVersions();
+        if (requestId !== this.previewRequestId) {
+          return;
+        }
+        previous = this.findPreviousVersion(versionNumber);
+        // `loadVersions` replaces the records, so re-point at the refreshed one.
+        this.previewVersionRecord =
+          this.versions.find((v) => v.version === versionNumber) || this.previewVersionRecord;
+      }
+      this.previousVersionNumber = previous ? previous.version : null;
+
+      if (!previous) {
+        return;
+      }
+
+      this.isLoadingPreview = true;
       try {
-        this.previewData = await getItemVersion(this.refcode, versionId);
+        const diff = await compareItemVersions(this.refcode, previous._id, versionId);
+        if (requestId !== this.previewRequestId) {
+          return;
+        }
+        this.changes = this.summariseDiff(diff);
       } catch (error) {
-        console.error("Failed to load version preview:", error);
-        this.previewData = null;
+        if (requestId !== this.previewRequestId) {
+          return;
+        }
+        console.error("Failed to load version changes:", error);
+        this.changes = [];
       } finally {
-        this.isLoadingPreview = false;
+        if (requestId === this.previewRequestId) {
+          this.isLoadingPreview = false;
+        }
       }
     },
+    findPreviousVersion(versionNumber) {
+      // `sortedVersions` is descending, so the first entry below this one is its
+      // immediate predecessor.
+      return this.sortedVersions.find((v) => v.version < versionNumber) || null;
+    },
+    summariseDiff(diff) {
+      // The server returns raw DeepDiff output, keyed by the kind of change, each
+      // mapping a path like `root['blocks_obj']['abc']['title']` to its values.
+      const changes = [];
+      const push = (path, before, after) => {
+        const field = this.formatFieldPath(path);
+        if (!field || IGNORED_FIELDS.includes(field.split(/[.[]/)[0])) {
+          return;
+        }
+        changes.push({
+          field,
+          before: this.formatValue(before),
+          after: this.formatValue(after),
+        });
+      };
+
+      for (const [path, change] of Object.entries(diff?.values_changed || {})) {
+        push(path, change.old_value, change.new_value);
+      }
+      for (const [path, change] of Object.entries(diff?.type_changes || {})) {
+        push(path, change.old_value, change.new_value);
+      }
+      for (const key of ["dictionary_item_added", "iterable_item_added"]) {
+        for (const [path, value] of Object.entries(diff?.[key] || {})) {
+          push(path, undefined, value);
+        }
+      }
+      for (const key of ["dictionary_item_removed", "iterable_item_removed"]) {
+        for (const [path, value] of Object.entries(diff?.[key] || {})) {
+          push(path, value, undefined);
+        }
+      }
+
+      return changes.sort((a, b) => a.field.localeCompare(b.field));
+    },
+    formatFieldPath(path) {
+      // `root['blocks_obj']['abc'][0]` -> `blocks_obj.abc[0]`
+      const parts = [...String(path).matchAll(/\['([^']*)'\]|\[(\d+)\]/g)];
+      return parts
+        .map(([, key, index], i) => {
+          if (index !== undefined) return `[${index}]`;
+          return i === 0 ? key : `.${key}`;
+        })
+        .join("");
+    },
+    formatValue(value) {
+      if (value === undefined) return "-";
+      if (value === null) return "null";
+      if (typeof value === "string") {
+        return value.length > 200 ? `${value.slice(0, 200)}...` : value || '""';
+      }
+      if (typeof value === "object") {
+        const serialised = JSON.stringify(value);
+        return serialised.length > 200 ? `${serialised.slice(0, 200)}...` : serialised;
+      }
+      return String(value);
+    },
     exitPreview() {
+      // Invalidate any comparison still in flight for the version being left.
+      this.previewRequestId++;
       this.isPreviewMode = false;
       this.previewVersion = null;
-      this.previewData = null;
+      this.previewVersionRecord = null;
+      this.previousVersionNumber = null;
+      this.changes = [];
+      this.isLoadingPreview = false;
     },
     async confirmRestore(versionId, versionNumber) {
       const confirmed = await DialogService.confirm({
@@ -348,26 +473,18 @@ export default {
         // Error dialog already shown by API function
       }
     },
-    getBlockTitle(blockId) {
-      if (!this.previewData.blocks_obj || !this.previewData.blocks_obj[blockId]) {
-        return blockId;
-      }
-      return this.previewData.blocks_obj[blockId].title || blockId;
-    },
-    getBlockType(blockId) {
-      if (!this.previewData.blocks_obj || !this.previewData.blocks_obj[blockId]) {
-        return "unknown";
-      }
-      return this.previewData.blocks_obj[blockId].blocktype || "unknown";
-    },
     closeModal() {
       this.isOpen = false;
       this.resetState();
     },
     resetState() {
+      this.previewRequestId++;
       this.isPreviewMode = false;
       this.previewVersion = null;
-      this.previewData = null;
+      this.previewVersionRecord = null;
+      this.previousVersionNumber = null;
+      this.changes = [];
+      this.isLoadingPreview = false;
       this.versions = [];
     },
   },
@@ -394,31 +511,25 @@ export default {
   overflow-y: auto;
 }
 
-.preview-content {
-  padding: 1rem;
-  background-color: #f8f9fa;
-  border-radius: 0.25rem;
-}
-
-.preview-content h5 {
-  margin-top: 1.5rem;
-  margin-bottom: 1rem;
-  font-weight: 600;
-}
-
-.preview-content h5:first-child {
-  margin-top: 0;
-}
-
-.preview-content strong {
+.changes-table code {
   color: #495057;
-  display: block;
-  margin-bottom: 0.25rem;
+  word-break: break-all;
 }
 
-.preview-content p {
-  margin-bottom: 0;
+.change-value {
   white-space: pre-wrap;
+  word-break: break-word;
+  max-width: 20rem;
+}
+
+.change-before {
+  color: #842029;
+  background-color: rgba(220, 53, 69, 0.05);
+}
+
+.change-after {
+  color: #0f5132;
+  background-color: rgba(25, 135, 84, 0.05);
 }
 
 .badge {

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -1499,14 +1499,14 @@ export async function restoreItemVersion(refcode, versionId) {
     });
 }
 
-export async function compareItemVersions(refcode, baseVersion, targetVersion) {
-  var url = new URL(`${API_URL}/items/${refcode}/versions/compare`);
-  url.searchParams.append("base", baseVersion);
-  url.searchParams.append("target", targetVersion);
+export async function compareItemVersions(refcode, versionId1, versionId2) {
+  var url = new URL(`${API_URL}/items/${refcode}/compare-versions/`);
+  url.searchParams.append("v1", versionId1);
+  url.searchParams.append("v2", versionId2);
 
   return fetch_get(url)
     .then(function (response_json) {
-      return response_json.comparison;
+      return response_json.diff;
     })
     .catch((error) => {
       DialogService.error({


### PR DESCRIPTION
Headline changes: 

- permissions updates now mint a new version with a special action
- timestamps are properly written as timestamps when restoring
- more computed fields are ignored to exclude extraneous version updates
- new tests for this
- updates version history UI to show who made the change, the user agent, and the diff

Closes #2010, closes #1784