### PR TITLE
Docs refresh and link out to new user guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 > [!NOTE]
-> Release candidates are not included in this changelog; there may be more
+> Release candidates and other pre-releases are not included in this changelog; there may be more
 recent changes described in the [release notes on GitHub](https://github.com/datalab-org/datalab/releases).
 
 ## v0.7.4 (August 2026)
@@ -288,7 +288,8 @@ There is also a new tool called [`beholder`](https://github.com/datalab-industri
 * Add Google and Microsoft OAuth authentication by @DianaAliabieva in https://github.com/datalab-org/datalab/pull/1706
 * Fix for dev server unable to load .env by @ml-evs in https://github.com/datalab-org/datalab/pull/1770
 
-## New Contributors
+### New Contributors
+
 * @isabelcooley made their first contribution in https://github.com/datalab-org/datalab/pull/1532
 * @wuppersaver made their first contribution in https://github.com/datalab-org/datalab/pull/1727
 
@@ -445,8 +446,6 @@ fixes, performance improvements and backwards-compatible API enhancements.
 > [!WARNING]
 > This release also bumps the supported MongoDB version all the way from v3 to v8. Whilst older MongoDB versions should still continue to work, version 8 will now be tested and used in the docker builds, so we recommend you upgrade. For existing databases this requires you to first dump the database using `mongodump` with the old MongoDB version, then upgrade to the new version and restore the database with `mongorestore`. If you unsure about this process then please ask us for help!
 
-### Highlights
-
 - Extra functionality for all data tables: column selection, persistent user
   preferences and improved filtering.
 - Improved inventory management: native UI for hazard labels, CAS numbers and external barcodes,
@@ -507,11 +506,9 @@ The Ansible playbooks at [datalab-ansible-terraform](https://github.com/datalab-
 
 Many thanks to all contributors: developers, user feedback and deployment managers!
 
-### Breaking changes
-
-* The Python server has been entirely repackaged with `uv` for much more streamlined dependency management (especially for external plugins). If you are using the docker deployments, then nothing should change for you, but developers may need to adjust their development setups following the [installation instructions](./INSTALL.md).
-
-### Highlights
+> [!warning] Breaking changes
+>
+> * The Python server has been entirely repackaged with `uv` for much more streamlined dependency management (especially for external plugins). If you are using the docker deployments, then nothing should change for you, but developers may need to adjust their development setups following the [installation instructions](./INSTALL.md).
 
 * The table component used to display all items has been entirely rewritten, and is now more visually responsive and can accommodate custom schemas/components.
 * QR code generation and scanning for all items, optionally using the new [datalab pURL service](https://purl.datalab-org.io/) when configured with `VUE_APP_QR_CODE_RESOLVER_URL`.
@@ -596,8 +593,6 @@ It is also accompanied by the first release of the *datalab* Python API package 
 
 Special thanks go to @vrajpatel9988 and especially @BenjaminCharmes who both made their first contributions to *datalab* in this release!
 
-### Highlights
-
 - User accounts: users can now update their name and contact info, as well as connect external accounts and regenerate API keys directly from the web UI. The ability to login via ORCID is now enabled by default (but must be configured at the instance level).
 - Admin dashboard: adds the ability for admins to do user management from the UI directly.
 - Electrochemistry block: support for Neware file formats, MPR files written by ECLab > 11.50 and cyclic voltammetry data.
@@ -609,11 +604,11 @@ Special thanks go to @vrajpatel9988 and especially @BenjaminCharmes who both mad
 - General improvements to block error reporting and reactivity, as well as several bug fixes.
 
 
-### Notes for upgrading to v0.4.0
-
-- Users now have an `"unverified"` status by default. For some deployments, this may require an admin to first self-verify their account directly with a database update (`"account_status" -> "active"`), after which they can verify all other users in the UI.
-- The data mount point of the `database` container in the default `./docker-compose.yml` has changed to use `/data/db` on the host system. Deployments using this configuration should be careful to backup and restore from their existing database, or continue to use the `docker volume` approach (feel free to raise an issue with any questions).
-- Similarly, the development set up has changed slightly and may need to be remade after upgrading.
+> [!note] Notes for upgrading to v0.4.0
+>
+> - Users now have an `"unverified"` status by default. For some deployments, this may require an admin to first self-verify their account directly with a database update (`"account_status" -> "active"`), after which they can verify all other users in the UI.
+> - The data mount point of the `database` container in the default `./docker-compose.yml` has changed to use `/data/db` on the host system. Deployments using this configuration should be careful to backup and restore from their existing database, or continue to use the `docker volume` approach (feel free to raise an issue with any questions).
+> - Similarly, the development set up has changed slightly and may need to be remade after upgrading.
 
 ### What's Changed
 * Dynamically set production app container config in entrypoint by @ml-evs in https://github.com/the-grey-group/datalab/pull/605
@@ -735,8 +730,6 @@ It also adds the ability for data blocks to pass errors and warnings to the fron
 This is the long overdue v0.3.0 release of datalab, which coincides with many new deployments popping up. It is strongly recommended to upgrade and continue to keep up-to-date with releases as they come out. There are no intentional breaking changes between this release and the previous release candidates, so please report any issues you come across on the [GitHub issue tracker](https://github.com/the-grey-group/datalab/issues).
 
 Thanks to new contributor @elbee99 who has added support for Raman spectroscopy, plus new contributors with as-of-yet unreleased changes!
-
-### Highlights
 
 - Support for Biologic data files created with the most recent versions of ECLab 11.50+, plus enhanced support for Arbin data files
 - A new 1D Raman block that can parse both Renishaw WDF and Oxford Instrument's spectra

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@
 > Release candidates and other pre-releases are not included in this changelog; there may be more
 recent changes described in the [release notes on GitHub](https://github.com/datalab-org/datalab/releases).
 
+## v0.7.5 (August 2026)
+
+This is expected to be the final release in the 0.7.x series. It includes:
+
+- Several dependency updates for both JS and Python.
+- The option to enable stricter CORS rules in the API.
+- Improvements to the diff display in the item versioning UI.
+- An improved metadata viewer that all datablocks can use.
+- An overhaul of the documentation pages, including a new [user guide](https://guide.datalab-org.io).
+
+We expect to release an alpha of 0.8.x soon with an overhaul for Pydantic v2 and ask that all future developments are based on that.
+
+### What's Changed
+
+* Update and fix latest Python sub-deps by @github-actions[bot] in https://github.com/datalab-org/datalab/pull/1996
+* Tweaks to suppress new warnings after JS updates, lock primevue by @ml-evs in https://github.com/datalab-org/datalab/pull/2003
+* Add stricter CORS rules when `APP_URL` is configured by @ml-evs in https://github.com/datalab-org/datalab/pull/2017
+* Improvements to item versioning UI by @ml-evs in https://github.com/datalab-org/datalab/pull/2011
+* Bump nmrglue to 0.12 by @ml-evs in https://github.com/datalab-org/datalab/pull/2021
+* Add `MetadataViewer` option on all blocks by @ml-evs in https://github.com/datalab-org/datalab/pull/2022
+* Docs refresh and link out to new user guide by @ml-evs in https://github.com/datalab-org/datalab/pull/2013
+
+
+**Full Changelog**: https://github.com/datalab-org/datalab/compare/v0.7.4...v0.7.5
+
 ## v0.7.4 (August 2026)
 
 This patch release adds a series of quality-of-life improvements, principally:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to *datalab*
+
+*datalab* is developed in the open and we welcome bug reports, feature requests, documentation fixes and code from anyone using it.
+
+*datalab* runs in production in research groups around the world, and each deployment is self-hosted and extended with its own plugins.
+That shapes what we look for in a contribution more than anything else: changes should be incremental, backwards-compatible, and safe to pick up mid-term without anyone losing data.
+
+## Code of conduct
+
+We expect all contributors to follow the [code of conduct](CODE_OF_CONDUCT.md) in all interactions with the project.
+
+## Before you start
+
+**Please search for and open issues before writing code**, whether you are fixing a bug or adding a feature.
+It is the cheapest way to find out that someone is already working on something, that the change belongs in a plugin rather than the core, or that it needs a different shape to fit the deployments we support.
+There may also be ongoing larger PRs that are close to merging that we would suggest you base your changes upon, rather than introducing conflicts or delays in merging.
+
+If the change is small and/or obvious, e.g., a typo or a broken link, then please go straight to a pull request.
+
+Places to look first:
+
+- [Open issues](https://github.com/datalab-org/datalab/issues), particularly those labelled [suggestions](https://github.com/datalab-org/datalab/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20label%3Asuggestions), [EPIC](https://github.com/datalab-org/datalab/issues?q=sort%3Aupdated-desc+state%3Aopen+label%3A%22EPIC%22+) and [plugin-request](https://github.com/datalab-org/datalab/issues?q=sort%3Aupdated-desc+state%3Aopen+label%3A%22plugin-request%22+).
+- The [roadmap](https://docs.datalab-org.io/en/latest/roadmap/), which collects the larger planned pieces of work. If your use case depends on something there, say so on the relevant issue to helps us prioritise future developments.
+
+## What we expect from a contribution
+
+We have some instructions for AI agents that may also be useful for humans at
+[`AGENTS.md`](https://github.com/datalab-org/datalab/blob/main/AGENTS.md) at the repository root.
+
+- **Most new domain code belongs in a plugin**, not in the core `apps/` directory.
+  See the [plugin docs](https://docs.datalab-org.io/en/latest/plugins/) and the [plugin template](https://github.com/datalab-org/datalab-app-plugin-template).
+- **Avoid database migrations.** Prefer new optional fields with `None` defaults, so that documents in existing deployments stay valid.
+- **Extend tests rather than editing existing assertions.** If an existing expected value genuinely has to change, change it deliberately and explain why in the pull request.
+- **Stay backwards-compatible.** Where a breaking change is unavoidable, provide a migration path and flag it clearly.
+- **Document what you add.** Update the README, the installation guide or the relevant page under `pydatalab/docs/` rather than relying on code comments alone.
+
+## AI-assisted contributions
+
+Whilst we are not opposed to contributions written with the help of AI tools, we assert that **every AI-assisted commit must be reviewed by a human before it is submitted**.
+
+Concretely, we ask that you:
+
+- Do not list an AI tool as an author or co-author. The person who reviewed the change is the author, and takes responsibility for it.
+- Read every line you submit. If you cannot explain why a change is correct, it is not ready.
+- Keep AI-assisted pull requests small. Large generated diffs are difficult to review and are likely to be closed with a request to break them up.
+- Configure your tooling to read our [`AGENTS.md`](https://github.com/datalab-org/datalab/blob/main/AGENTS.md) file and follow the instructions there.
+  (For Claude code, this may mean symlinking your `CLAUDE.md` to `AGENTS.md` or otherwise referring to it via `@AGENTS.md` in your prompt.)
+
+Agents working in this repository are instructed (via [`AGENTS.md`](https://github.com/datalab-org/datalab/blob/main/AGENTS.md)) to leave a comment at the top of each file they edit noting that it requires human review.
+Remove those comments once you have done that review.
+
+## Development setup
+
+The [installation guide](https://docs.datalab-org.io/en/latest/INSTALL/) covers running the server and web app locally. In short:
+
+```bash
+# Python server
+cd pydatalab && uv sync --all-extras --dev --locked && uv run pytest
+
+# Web app
+cd webapp && yarn install && yarn test:e2e
+```
+
+Please install the pre-commit hooks before your first commit, as CI runs the same checks:
+
+```bash
+pre-commit install
+pre-commit run --all-files
+```
+
+## Getting help
+
+- Ask in the [public *datalab* Slack workspace](https://join.slack.com/t/datalab-world/shared_invite/zt-2h58ev3pc-VV496~5je~QoT2TgFIwn4g).
+- Open a [GitHub issue](https://github.com/datalab-org/datalab/issues) for bugs and feature requests.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ We are available for consultations on setting up and managing *datalab* deployme
 
 ## Contributions
 
+Bug reports, feature requests and pull requests are all welcome.
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for how to get started, what we expect from a
+contribution, and our policy on AI-assisted changes.
+
 <!-- --8<-- [start:credits] -->
 This software was conceived and developed by:
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
----
-title: Introduction
----
-
-
 # <div align="center"><i>datalab</i></div>
 
 <div align="center" style="padding-bottom: 5px">
@@ -33,14 +28,17 @@ title: Introduction
 <a href="https://join.slack.com/t/datalab-world/shared_invite/zt-2h58ev3pc-VV496~5je~QoT2TgFIwn4g"><img src="https://img.shields.io/badge/Slack-chat_with_us-yellow?logo=slack"></a>
 </div>
 
+<!-- --8<-- [start:intro] -->
 _datalab_ is a user-friendly, open-source platform that can capture all the experimental data and metadata produced in a scientific lab, targeted (broadly) at materials chemistry but with customisability and extensability in mind.
 _datalab_ records data and metadata securely and makes it accessible and reusable by both humans and machines _via_ the web UI and API, respectively.
 _datalab_ can be self-hosted and managed deployments are also available.
+<!-- --8<-- [end:intro] -->
 
 You can try the demo deployment at [demo.datalab-org.io](https://demo.datalab-org.io/) and read the online documentation at [docs.datalab-org.io](https://docs.datalab-org.io) with release notes and changelog available on [GitHub](https://github.com/datalab-org/datalab/releases/) and [online](https://docs.datalab-org.io/en/latest/CHANGELOG).
 
 Features:
 
+<!-- --8<-- [start:features] -->
 * Capture and store sample and device metadata
 * Connect and sync raw data directly and from laboratory instruments
 * Built-in support for multiple characterisation techniques (XRD, NMR, echem, TEM, TGA, Mass Spec, Raman and more).
@@ -49,6 +47,7 @@ Features:
 * Join the [_datalab_ federation](https://github.com/datalab-org/datalab-federation): you can add your _datalab_ to the federation for additional shared features.
 * [Plugin ecosystem](https://docs.datalab-org.io/en/latest/plugins) allowing for custom data blocks, [AI integration](https://github.com/datalab-org/yellowhammer) and other instance-specific code.
 * [Deployment and infrastructure automation](https://github.com/datalab-industries/datalab-ansible-terraform) via Ansible playbooks.
+<!-- --8<-- [end:features] -->
 
 <div align="center">
 <video width="400" controls src="https://github.com/datalab-org/datalab/assets/7916000/0065cdd6-a5f0-4391-b192-0137fe208acc">
@@ -60,12 +59,19 @@ Features:
 
 ## Getting started
 
-To set up your own _datalab_ instance or to get started with development, you can follow the installation and deployment instructions in the [online documentation](https://docs.datalab-org.io/en/latest/INSTALL).
+The full documentation lives at [docs.datalab-org.io](https://docs.datalab-org.io), split by audience:
+
+- **[For users](https://guide.datalab-org.io/)** — using an instance that someone else runs: recording samples and cells, attaching data, and getting it back out again via the [Python API](https://github.com/datalab-org/datalab-api).
+- **[For developers](https://docs.datalab-org.io/en/latest/INSTALL)** — running *datalab* locally, writing [plugins](https://docs.datalab-org.io/en/latest/plugins), and contributing to the core.
+- **[For deployments](https://docs.datalab-org.io/en/latest/deployment)** — standing up and [configuring](https://docs.datalab-org.io/en/latest/config) an instance for your group.
+
+Note that *datalab* is self-hosted and plugin-extensible, so no two instances are alike: the item types, data blocks and metadata fields available to you depend on how your instance has been configured and which plugins it has installed.
 
 We can also provide paid managed deployments via [_datalab industries ltd._](https://datalab.industries): contact us at [hello@datalab.industries](mailto:hello@datalab.industries).
 
 ## Design philosophy and architecture
 
+<!-- --8<-- [start:architecture] -->
 The _datalab_ architecture is shown below:
 
 <center>
@@ -139,6 +145,7 @@ The main aim of *datalab* is to provide a platform for capturing the significant
 The platform provides researchers with a way to record sample- and cell-specific metadata, attach and sync raw data from instruments, and perform analysis and visualisation of many characterisation techniques in the browser (XRD, NMR, electrochemical cycling, TEM, TGA, Mass Spec, Raman).
 
 Importantly, *datalab* stores a network of interconnected research objects in the lab, such that individual pieces of data are stored with the context needed to make them scientifically useful.
+<!-- --8<-- [end:architecture] -->
 
 ## License
 
@@ -149,7 +156,9 @@ Please see [LICENSE](./LICENSE) for the full text of the license.
 
 Should you use _datalab_ in your research, please consider citing the following preprint:
 
+<!-- --8<-- [start:citation] -->
 > Matthew L. Evans, Joshua D. Bocarsly, Benjamin Charmes, Ben E. Smith, Gian-Marco Rignanese, David Waroquiers, Clare P. Grey, **datalab: Federated data management infrastructure for materials chemistry and beyond**, ChemRxiv (2026). DOI: [10.26434/chemrxiv.15001945/v1](https://doi.org/10.26434/chemrxiv.15001945/v1)
+<!-- --8<-- [end:citation] -->
 
 ## Contact
 
@@ -157,6 +166,7 @@ We are available for consultations on setting up and managing *datalab* deployme
 
 ## Contributions
 
+<!-- --8<-- [start:credits] -->
 This software was conceived and developed by:
 
 - [Prof Joshua Bocarsly](https://jdbocarsly.github.io) ([Department of Chemistry, University of Houston](https://www.uh.edu/nsm/chemistry), previously [Department of Chemistry, University of Cambridge](https://www.ch.cam.ac.uk/))
@@ -182,3 +192,4 @@ In particular, the developers thank:
 - Initial proof-of-concept funding from the European Union's Horizon 2020 research and innovation programme under grant agreement 957189 (DOI: [10.3030/957189](https://doi.org/10.3030/957189)), the [Battery Interface Genome - Materials Acceleration Platform (BIG-MAP)](https://www.big-map.eu), as an external stakeholder project.
 - The [Faraday Institution](https://www.faraday.ac.uk) CATMAT project (FIRG016) for support of Dr Joshua Bocarsly during initial development of *datalab*.
 - The [Leverhulme Trust](https://leverhulme.ac.uk) and [Isaac Newton Trust](https://newtontrust.cam.ac.uk) for support provided by an early career fellowship for Dr Matthew Evans.
+<!-- --8<-- [end:credits] -->

--- a/pydatalab/docs/.pages
+++ b/pydatalab/docs/.pages
@@ -5,6 +5,8 @@ nav:
         - Data models: schemas
         - Data blocks: blocks/reference
     - Development:
+        - Contributing: CONTRIBUTING.md
+        - Code of conduct: CODE_OF_CONDUCT.md
         - INSTALL.md
         - plugins.md
         - Writing data blocks: blocks/index.md

--- a/pydatalab/docs/.pages
+++ b/pydatalab/docs/.pages
@@ -1,10 +1,16 @@
 nav:
     - index.md
-    - INSTALL.md
-    - deployment.md
-    - config.md
-    - schemas
-    - blocks
-    - plugins.md
-    - roadmap.md
-    - CHANGELOG.md
+    - User guide: https://guide.datalab-org.io
+    - Reference:
+        - Data models: schemas
+        - Data blocks: blocks/reference
+    - Development:
+        - INSTALL.md
+        - plugins.md
+        - Writing data blocks: blocks/index.md
+        - roadmap.md
+    - Deployment:
+        - deployment.md
+        - config.md
+    - About: about.md
+    - Changelog: CHANGELOG.md

--- a/pydatalab/docs/CODE_OF_CONDUCT.md
+++ b/pydatalab/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+../../CODE_OF_CONDUCT.md

--- a/pydatalab/docs/CONTRIBUTING.md
+++ b/pydatalab/docs/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+../../CONTRIBUTING.md

--- a/pydatalab/docs/about.md
+++ b/pydatalab/docs/about.md
@@ -1,0 +1,34 @@
+---
+title: About datalab
+---
+
+# About *datalab*
+
+--8<-- "README.md:intro"
+
+The main aim of *datalab* is to capture the significant amounts of long-tail experimental
+data and metadata produced in a typical lab, and to enable storage, filtering and future
+data re-use by both humans and machines.
+
+## Features
+
+--8<-- "README.md:features"
+
+## Design philosophy and architecture
+
+--8<-- "README.md:architecture"
+
+## Citation
+
+Should you use *datalab* in your research, please consider citing the following preprint:
+
+--8<-- "README.md:citation"
+
+## Contributions
+
+--8<-- "README.md:credits"
+
+## License
+
+*datalab* is released under the terms of the MIT license; see [LICENSE](LICENSE) for the
+full text.

--- a/pydatalab/docs/css/reference.css
+++ b/pydatalab/docs/css/reference.css
@@ -3,3 +3,155 @@
 .md-grid {
     max-width: 60rem;
 }
+
+/* The landing page keeps the left-hand nav but drops the table of contents, so
+   give it a slightly wider grid than the 60rem used for prose pages: enough room
+   for the three audience cards to sit side-by-side next to the nav. */
+body:has(.home-cards) .md-grid {
+    max-width: 68rem;
+}
+
+/* Hold those three cards in one row on wider screens. Material's default
+   `auto-fit` would otherwise drop to two columns and orphan the third. */
+@media screen and (min-width: 68.25em) {
+    .md-typeset .home-cards {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+/* Line the links up across all three cards regardless of how long each card's
+   blurb is: stack the card contents and let the blurb absorb the slack, so the
+   link lists (identical in length) all end up flush with the card bottom.
+   Material wraps the cards in a `display: contents` <ul>, so the cards are the
+   <li> inside it, not children of the grid itself; the `.grid.cards` prefix is
+   needed to out-specify Material's own `display: block` on those <li>. */
+.md-typeset .grid.cards.home-cards > ul > li {
+    display: flex;
+    flex-direction: column;
+}
+
+.md-typeset .grid.cards.home-cards > ul > li > hr + p {
+    flex: 1 0 auto;
+}
+
+/* Icon-led links inside the cards: keep the icon and label on one line. */
+.md-typeset .home-cards .twemoji {
+    vertical-align: -0.15em;
+}
+
+/* Labels marking how a model field relates to the database, injected by the
+   `virtual` / `foreign_key` annotations in `pydatalab.models.traits`. */
+.md-typeset .field-flag {
+    display: inline-block;
+    padding: 0.05em 0.5em;
+    margin-right: 0.3em;
+    border-radius: 0.6em;
+    font-size: 0.72em;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    vertical-align: 0.15em;
+    cursor: help;
+}
+
+.md-typeset .field-flag--virtual {
+    color: var(--md-default-bg-color);
+    background: var(--md-accent-fg-color);
+}
+
+.md-typeset .field-flag--foreign_key {
+    color: var(--md-default-fg-color--light);
+    border: 1px solid var(--md-default-fg-color--lighter);
+}
+
+/* New contributors, rewritten from a list of near-identical sentences by
+   `docs/hooks.py`: a row of avatar chips, one per person. */
+.md-typeset .contributors-label {
+    margin-bottom: 0.4em;
+    color: var(--md-default-fg-color--light);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.md-typeset .contributors-label + .contributors {
+    margin-top: 0;
+}
+
+.md-typeset .contributors {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin: 1em 0;
+    padding: 0;
+    list-style: none;
+}
+
+.md-typeset .contributors li {
+    margin: 0;
+}
+
+.md-typeset .contributor {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4em;
+    padding: 0.15em 0.7em 0.15em 0.15em;
+    border: 1px solid var(--md-default-fg-color--lighter);
+    border-radius: 2em;
+    color: var(--md-default-fg-color--light);
+    font-size: 0.8em;
+    font-weight: 700;
+}
+
+.md-typeset .contributor:hover {
+    border-color: var(--md-accent-fg-color);
+    color: var(--md-accent-fg-color);
+}
+
+/* Sized in `em` so the avatar tracks the chip's own font size. A background
+   keeps the circle intact if GitHub does not serve an avatar for the account. */
+.md-typeset .contributor img {
+    width: 2em;
+    height: 2em;
+    border-radius: 50%;
+    background: var(--md-default-fg-color--lightest);
+}
+
+/* Release tags at the foot of each changelog entry, rewritten from GitHub's bare
+   compare URL by `docs/hooks.py`. Styled as chips so the two versions read as
+   labels rather than as more link text in a page already dense with links. */
+.md-typeset .changelog-tag {
+    display: inline-block;
+    padding: 0.05em 0.6em;
+    border: 1px solid var(--md-default-fg-color--lighter);
+    border-radius: 1em;
+    color: var(--md-default-fg-color--light);
+    font-size: 0.85em;
+    font-weight: 700;
+}
+
+.md-typeset .changelog-tag:hover {
+    border-color: var(--md-accent-fg-color);
+    color: var(--md-accent-fg-color);
+}
+
+.md-typeset .changelog-compare {
+    margin-left: 0.4em;
+    color: var(--md-default-fg-color--light);
+    font-size: 0.85em;
+}
+
+/* Keep every icon on these lines sitting on the text baseline. */
+.md-typeset .changelog-tag .twemoji,
+.md-typeset .changelog-compare .twemoji {
+    vertical-align: -0.15em;
+}
+
+/* Material renders admonitions and `details` at 0.64rem against 0.8rem body
+   text, which makes a callout read as an aside rather than as part of the page.
+   Match the surrounding prose instead; `inherit` keeps nested ones consistent. */
+.md-typeset .admonition,
+.md-typeset details {
+    font-size: inherit;
+}

--- a/pydatalab/docs/griffe_extensions.py
+++ b/pydatalab/docs/griffe_extensions.py
@@ -1,0 +1,93 @@
+"""Griffe extensions used when building the documentation.
+
+`griffe-pydantic` recognises models by looking for `pydantic.BaseModel` among a
+class's bases, falling back to the statically resolved MRO. That fails for
+`ServerConfig`, which inherits from `BaseSettings`: pydantic ships compiled
+modules, so griffe cannot parse them and the resolved MRO comes back empty.
+The result is that `Field(..., description=...)` is never picked up and the
+field renders as a raw `Field(...)` call expression instead of prose.
+
+This extension teaches the check about the settings base classes for both
+pydantic v1 (`pydantic.BaseSettings`) and v2 (`pydantic_settings.BaseSettings`),
+so the docs keep working across the v2 migration.
+
+It also drops validator methods from the rendered models. Validators are an
+implementation detail of a model rather than part of its public schema, and
+rendering one section per validator buries the fields the page is actually
+about. They are identified by the `pydantic-validator` label that
+`griffe-pydantic` attaches, rather than by name, since validator names follow no
+consistent convention.
+"""
+
+from typing import Any
+
+from griffe import Class, Expr, Module, Object
+from griffe_pydantic import PydanticExtension
+from griffe_pydantic._internal import static
+
+SETTINGS_BASES = {
+    # pydantic v1
+    "pydantic.BaseSettings",
+    "pydantic.env_settings.BaseSettings",
+    # pydantic v2, via the separate pydantic-settings package
+    "pydantic_settings.BaseSettings",
+    "pydantic_settings.main.BaseSettings",
+}
+
+VALIDATOR_DECORATORS = {
+    # pydantic v1
+    "pydantic.validator",
+    "pydantic.root_validator",
+    # pydantic v2
+    "pydantic.field_validator",
+    "pydantic.model_validator",
+}
+
+
+class PydanticSettingsExtension(PydanticExtension):
+    """`PydanticExtension` that also treats `BaseSettings` subclasses as models."""
+
+    def on_package(self, *, pkg: Module, **kwargs: Any) -> None:
+        original = static._inherits_pydantic
+
+        def _inherits_pydantic(cls: Class) -> bool:
+            for base in cls.bases:
+                path = base.canonical_path if isinstance(base, Expr) else str(base)
+                if path in SETTINGS_BASES:
+                    return True
+            return original(cls)
+
+        # Patch only for the duration of the package pass, so that the override
+        # cannot leak into unrelated griffe consumers.
+        static._inherits_pydantic = _inherits_pydantic
+        try:
+            super().on_package(pkg=pkg, **kwargs)
+        finally:
+            static._inherits_pydantic = original
+
+        _drop_validators(pkg)
+
+
+def _is_validator(member: Any) -> bool:
+    """Tell whether a member is a Pydantic validator.
+
+    `griffe-pydantic` only labels the v2 decorators, so fall back to matching the
+    decorator path directly, which also covers the v1 names still in use here.
+    """
+    if "pydantic-validator" in getattr(member, "labels", ()):
+        return True
+    return any(
+        decorator.callable_path in VALIDATOR_DECORATORS
+        for decorator in getattr(member, "decorators", ())
+    )
+
+
+def _drop_validators(obj: Object) -> None:
+    """Recursively remove validator methods from Pydantic models."""
+    if isinstance(obj, Class):
+        for name in [name for name, member in obj.members.items() if _is_validator(member)]:
+            del obj.members[name]
+
+    for member in list(obj.members.values()):
+        if isinstance(member, Object):
+            _drop_validators(member)

--- a/pydatalab/docs/hooks.py
+++ b/pydatalab/docs/hooks.py
@@ -1,0 +1,218 @@
+"""MkDocs build hooks.
+
+The changelog is a symlink to the repo's `CHANGELOG.md`, which is assembled from
+GitHub's generated release notes. Each release carries a "What's Changed" list of
+every merged PR, which is worth keeping but buries the hand-written summary above
+it. Rather than editing the changelog itself — it has to stay readable on GitHub,
+and every future release would need the same treatment by hand — fold those lists
+into collapsible blocks as the page is rendered.
+"""
+
+import re
+
+# GitHub's callout syntax has no notion of a title: `> [!WARNING]` must sit alone
+# on its line, and anything after it makes the whole block degrade to a plain
+# blockquote — on GitHub as well as under the `github-callouts` extension. Both
+# spellings below are promoted to a titled Material admonition instead.
+CALLOUT = re.compile(
+    r"^>\s*\[!(?P<kind>NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*(?P<title>.*?)\s*$",
+    re.IGNORECASE,
+)
+BOLD_TITLE = re.compile(r"^\*\*(?P<title>.+?)\*\*\s*$")
+# Material has no `important` admonition, and names GitHub's `caution` `danger`.
+CALLOUT_TYPES = {
+    "note": "note",
+    "tip": "tip",
+    "important": "info",
+    "warning": "warning",
+    "caution": "danger",
+}
+
+# Release notes have been pasted in at various heading levels and spellings over
+# the years, so match any of them rather than assuming the `### What's Changed`
+# used by recent releases.
+CHANGES_HEADING = re.compile(r"^#{2,4}\s+What's changed\??\s*$", re.IGNORECASE)
+CONTRIBUTORS_HEADING = re.compile(r"^#{2,4}\s+New contributors\s*$", re.IGNORECASE)
+# `* @user made their first contribution in <url>`, as GitHub generates it.
+CONTRIBUTOR = re.compile(
+    r"^\*\s+@(?P<user>[\w-]+) made their first contribution in "
+    r"https://github\.com/(?P<repo>[\w.-]+/[\w.-]+)/pull/(?P<pull>\d+)\s*$"
+)
+ANY_HEADING = re.compile(r"^#{1,6}\s")
+# Kept outside the collapsed block: it is one line, and it is the link people
+# actually follow when they want the full diff for a release.
+FULL_CHANGELOG = re.compile(r"^\*\*Full Changelog\*\*")
+# The same line, parsed: GitHub writes it as a bare compare URL between two tags.
+COMPARE_LINK = re.compile(
+    r"^\*\*Full Changelog\*\*:\s*"
+    r"(?P<url>https://github\.com/(?P<repo>[\w.-]+/[\w.-]+)/compare/"
+    r"(?P<base>[^.\s]\S*?)\.\.\.(?P<head>\S+))\s*$"
+)
+
+# Any Material admonition type works here: `info`, `abstract`, `example`, `quote`,
+# `tip`, `question`… It only sets the colour and icon of the collapsed box.
+ADMONITION = "abstract"
+
+
+def _titled_callouts(markdown: str) -> str:
+    """Promote titled GitHub callouts to Material admonitions.
+
+    Two spellings are accepted: the title on the marker line itself, or a bold
+    first line inside the callout. The latter is the one worth using in files that
+    are also read on GitHub, since GitHub renders it as a proper alert with a bold
+    lead. Untitled callouts are left for the `github-callouts` extension.
+    """
+    lines = markdown.splitlines()
+    out: list[str] = []
+    index = 0
+
+    while index < len(lines):
+        match = CALLOUT.match(lines[index])
+        if match is None:
+            out.append(lines[index])
+            index += 1
+            continue
+
+        start = index
+        index += 1
+        body = []
+        while index < len(lines) and lines[index].startswith(">"):
+            body.append(re.sub(r"^>\s?", "", lines[index]))
+            index += 1
+
+        title = match["title"]
+        if not title:
+            for position, entry in enumerate(body):
+                if not entry.strip():
+                    continue
+                bold = BOLD_TITLE.match(entry)
+                if bold:
+                    title = bold["title"]
+                    del body[position]
+                break
+
+        if not title:
+            # Untitled: hand it back verbatim for the extension to deal with.
+            out.extend(lines[start:index])
+            continue
+
+        while body and not body[0].strip():
+            body.pop(0)
+        while body and not body[-1].strip():
+            body.pop()
+
+        kind = CALLOUT_TYPES[match["kind"].lower()]
+        out.append(f'!!! {kind} "{title.replace(chr(34), "&quot;")}"')
+        out.append("")
+        out.extend(f"    {entry}" if entry.strip() else "" for entry in body)
+        out.append("")
+
+    return "\n".join(out)
+
+
+def _release_tags(match: re.Match) -> str:
+    """Render a compare URL as two linked release tags either side of an arrow.
+
+    GitHub's generated notes end each release with a bare compare URL, which
+    renders as a wall of link text. The two tags either side of the `...` are the
+    useful part, so show those as chips linking to their own release pages, and
+    keep the comparison itself on a trailing link.
+    """
+    repo, url = match["repo"], match["url"]
+
+    def tag(ref: str) -> str:
+        release = f"https://github.com/{repo}/releases/tag/{ref}"
+        return f"[:octicons-tag-24: {ref}]({release}){{ .changelog-tag }}"
+
+    return (
+        f"{tag(match['base'])} :octicons-arrow-right-24: {tag(match['head'])} "
+        f"[:octicons-git-compare-24: compare]({url}){{ .changelog-compare }}"
+    )
+
+
+def _contributor_bubbles(entries: list[str]) -> list[str]:
+    """Render "new contributor" lines as a row of linked avatars.
+
+    Twelve near-identical sentences say much less than twelve faces, so drop the
+    prose (and the heading above it) and keep the names and avatars. The row is
+    labelled for screen readers, which would otherwise be left with no clue as to
+    what the links are, now that the heading is gone.
+    """
+    bubbles = []
+    for entry in entries:
+        match = CONTRIBUTOR.match(entry)
+        if match is None:
+            # Anything that does not fit the generated wording is left alone.
+            return entries
+        user, repo, pull = match["user"], match["repo"], match["pull"]
+        bubbles.append(
+            f'<li><a class="contributor" href="https://github.com/{user}"'
+            f' title="@{user} — first contribution in {repo}#{pull}">'
+            f'<img src="https://github.com/{user}.png?size=64" alt="" loading="lazy"'
+            f' width="48" height="48">{user}</a></li>'
+        )
+
+    if not bubbles:
+        return entries
+
+    return [
+        # A plain label rather than a heading: it names the row for sighted
+        # readers without putting another entry per release into the table of
+        # contents, which is what dropping the original heading achieved.
+        '<p class="contributors-label">New contributors</p>',
+        '<ul class="contributors" aria-label="New contributors">',
+        *bubbles,
+        "</ul>",
+        "",
+    ]
+
+
+def on_page_markdown(markdown: str, page, config, files) -> str | None:
+    """Wrap each release's "What's Changed" list in a collapsed `details` block."""
+    markdown = _titled_callouts(markdown)
+    if page.file.src_uri != "CHANGELOG.md":
+        return markdown
+
+    lines = markdown.splitlines()
+    out: list[str] = []
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        if CONTRIBUTORS_HEADING.match(line):
+            index += 1
+            entries: list[str] = []
+            while index < len(lines):
+                if ANY_HEADING.match(lines[index]) or FULL_CHANGELOG.match(lines[index]):
+                    break
+                if lines[index].strip():
+                    entries.append(lines[index])
+                index += 1
+            out.extend(_contributor_bubbles(entries))
+            continue
+
+        if not CHANGES_HEADING.match(line):
+            compare = COMPARE_LINK.match(line)
+            out.append(_release_tags(compare) if compare else line)
+            index += 1
+            continue
+
+        # Collect the list itself, stopping at whatever comes next in the release.
+        index += 1
+        body: list[str] = []
+        while index < len(lines):
+            if ANY_HEADING.match(lines[index]) or FULL_CHANGELOG.match(lines[index]):
+                break
+            body.append(lines[index])
+            index += 1
+
+        while body and not body[-1].strip():
+            body.pop()
+
+        out.append(f'??? {ADMONITION} "What\'s Changed"')
+        out.append("")
+        # `pymdownx.details` takes its content as an indented block.
+        out.extend(f"    {entry}" if entry.strip() else "" for entry in body)
+        out.append("")
+
+    return "\n".join(out)

--- a/pydatalab/docs/index.md
+++ b/pydatalab/docs/index.md
@@ -1,1 +1,73 @@
-../../README.md
+---
+title: Documentation
+hide:
+  - toc
+---
+
+# *datalab* documentation
+
+--8<-- "README.md:intro"
+
+If you have never seen *datalab* before, the quickest introduction is to
+[try the public demo instance](https://demo.datalab-org.io);
+for background on the project itself, see [About *datalab*](about.md).
+
+!!! important "Every *datalab* is different"
+    *datalab* can be self-hosted and is extensible via plugins, so **no two deployments are alike**.
+    These docs primarily describe the *upstream* project, rather than a specific *datalab* instance.
+
+## Where to go next
+
+<div class="grid cards home-cards" markdown>
+
+-   :material-flask-outline:{ .lg .middle } __For users__
+
+    ---
+
+    Using a *datalab* instance: recording samples and cells,
+    attaching data, and getting your data back out again.
+
+    [:material-book-open-variant: &nbsp; User guide](https://guide.datalab-org.io)
+
+    [:material-file-tree: &nbsp; Data models](schemas/items.md)
+
+    [:material-cube-outline: &nbsp; Data blocks](blocks/reference/base.md)
+
+    [:simple-python: &nbsp; Python API](https://github.com/datalab-org/datalab-api)
+
+-   :material-code-braces:{ .lg .middle } __For developers__
+
+    ---
+
+    Extending *datalab* with your own blocks and plugins, or contributing to the
+    core server and web app.
+
+    [:material-console: &nbsp; Development setup](INSTALL.md)
+
+    [:material-puzzle-outline: &nbsp; Writing plugins](plugins.md)
+
+    [:material-api: &nbsp; Writing data blocks](blocks/index.md)
+
+    [:material-map-marker-path: &nbsp; Roadmap](roadmap.md)
+
+-   :material-server-network:{ .lg .middle } __For deployments__
+
+    ---
+
+    Deploying and administering an instance for your group or others.
+
+    [:material-server: &nbsp; Deployment guide](deployment.md)
+
+    [:material-cog-outline: &nbsp; Server configuration](config.md)
+
+    [:simple-ansible: &nbsp; Ansible & Terraform Automations](https://github.com/datalab-org/datalab-ansible-terraform)
+
+    [:material-history: &nbsp; Changelog](CHANGELOG.md)
+
+</div>
+
+## Getting help
+
+- Join the [public *datalab* Slack workspace](https://join.slack.com/t/datalab-world/shared_invite/zt-2h58ev3pc-VV496~5je~QoT2TgFIwn4g) to ask questions and hear about releases.
+- Report bugs and request features on [GitHub](https://github.com/datalab-org/datalab/issues).
+- Managed deployments and consultancy are available from [*datalab industries ltd.*](https://datalab.industries) — [hello@datalab.industries](mailto:hello@datalab.industries).

--- a/pydatalab/docs/schemas/cells.md
+++ b/pydatalab/docs/schemas/cells.md
@@ -2,8 +2,4 @@
 
 ::: pydatalab.models.cells
     options:
-        inherited_members: true
-        summary:
-          attributes: true
-          functions: false
-          modules: false
+        inherited_members: false

--- a/pydatalab/docs/schemas/collections.md
+++ b/pydatalab/docs/schemas/collections.md
@@ -2,11 +2,7 @@
 
 ::: pydatalab.models.collections
     options:
-        inherited_members: true
-        summary:
-          attributes: true
-          functions: false
-          modules: false
+        inherited_members: false
         filters:  # override default filters to include collections
           - "!^_[^_]"
           - "!__json_encoder__$"

--- a/pydatalab/docs/schemas/equipment.md
+++ b/pydatalab/docs/schemas/equipment.md
@@ -2,8 +2,4 @@
 
 ::: pydatalab.models.equipment
     options:
-        inherited_members: true
-        summary:
-          attributes: true
-          functions: false
-          modules: false
+        inherited_members: false

--- a/pydatalab/docs/schemas/items.md
+++ b/pydatalab/docs/schemas/items.md
@@ -2,8 +2,4 @@
 
 ::: pydatalab.models.items
     options:
-        inherited_members: true
-        summary:
-          attributes: true
-          functions: false
-          modules: false
+        inherited_members: false

--- a/pydatalab/docs/schemas/samples.md
+++ b/pydatalab/docs/schemas/samples.md
@@ -2,8 +2,4 @@
 
 ::: pydatalab.models.samples
     options:
-        inherited_members: true
-        summary:
-          attributes: true
-          functions: false
-          modules: false
+        inherited_members: false

--- a/pydatalab/docs/schemas/starting_materials.md
+++ b/pydatalab/docs/schemas/starting_materials.md
@@ -1,9 +1,5 @@
-# Starting Materials
+# Starting materials
 
 ::: pydatalab.models.starting_materials
     options:
-        inherited_members: true
-        summary:
-          attributes: true
-          functions: false
-          modules: false
+        inherited_members: false

--- a/pydatalab/docs/schemas/traits.md
+++ b/pydatalab/docs/schemas/traits.md
@@ -1,0 +1,10 @@
+# Traits
+
+The item models in *datalab* are assembled from **traits**: small mixin models that each
+contribute a related group of fields.
+Rather than every item type redeclaring who owns it
+or which collections it belongs to, it inherits the corresponding trait.
+
+::: pydatalab.models.traits
+    options:
+        inherited_members: false

--- a/pydatalab/docs/templates/python/material/pydantic_model.html.jinja
+++ b/pydatalab/docs/templates/python/material/pydantic_model.html.jinja
@@ -1,0 +1,9 @@
+{% extends "_base/pydantic_model.html.jinja" %}
+
+{#
+  griffe-pydantic lists every field name and type at the top of a model, but the
+  per-attribute sections below already carry that information plus the field
+  descriptions. Suppress the summary list and keep the detailed sections, which
+  are what cross-link config object types such as `RemoteFilesystem`.
+#}
+{% block fields %}{% endblock fields %}

--- a/pydatalab/mkdocs.yml
+++ b/pydatalab/mkdocs.yml
@@ -1,6 +1,10 @@
 site_name: datalab
 site_description: Documentation for datalab
-site_url: https://docs.datalab-org.io
+# Read the Docs serves each version under its own path (e.g. /en/stable/), and
+# `404.html` is the one page MkDocs builds with absolute asset URLs derived from
+# `site_url` — a bare domain here leaves it pointing at /assets/, which does not
+# exist. `READTHEDOCS_CANONICAL_URL` carries the versioned URL at build time.
+site_url: !ENV [READTHEDOCS_CANONICAL_URL, "https://docs.datalab-org.io"]
 
 theme:
   name: material
@@ -40,6 +44,17 @@ repo_url: https://github.com/datalab-org/datalab
 
 docs_dir: "docs"
 
+# Build-time tooling that lives alongside the docs it supports, rather than being
+# copied into the built site as a static asset.
+exclude_docs: |
+  griffe_extensions.py
+  hooks.py
+  templates/
+  __pycache__/
+
+hooks:
+  - docs/hooks.py
+
 extra:
   social:
     - icon: fontawesome/brands/github
@@ -47,9 +62,15 @@ extra:
 
 markdown_extensions:
   - admonition
+  - attr_list
+  - md_in_html
   - pymdownx.details
   - pymdownx.highlight
   - github-callouts
+  # Enables the :material-*: and :octicons-*: icon shorthands used by the grid cards
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.superfences:
       # Allows mermaid code blocks to be rendered via mermaid.js
       custom_fences:
@@ -61,7 +82,13 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.tasklist
-  - pymdownx.snippets
+  # `base_path` reaches the repo root so that docs pages can pull named sections
+  # out of the README, keeping it the single source for the shared prose.
+  - pymdownx.snippets:
+      base_path:
+        - "docs"
+        - ".."
+      check_paths: true
   - pymdownx.magiclink:
       repo_url_shorthand: true
       hide_protocol: true
@@ -78,6 +105,7 @@ extra_css:
 plugins:
   - mkdocstrings:
       default_handler: python
+      custom_templates: docs/templates
       handlers:
         python:
           inventories:
@@ -87,6 +115,10 @@ plugins:
             extensions:
               - griffe_inherited_docstrings
               - docstring_inheritance.griffe
+              # Surfaces `Field(..., description=...)` as rendered prose; without
+              # this, griffe only sees an opaque `Field(...)` call expression.
+              # Local subclass so that `BaseSettings` models are detected too.
+              - docs/griffe_extensions.py:PydanticSettingsExtension
             show_root_heading: false
             show_root_toc_entry: false
             show_root_full_path: true
@@ -106,7 +138,9 @@ plugins:
             group_by_category: true
             heading_level: 2
             summary:
-              attributes: true
+              # The per-attribute sections below already carry the descriptions
+              # and the cross-linked types, so a summary table just repeats them.
+              attributes: false
               functions: false
               modules: false
             docstring_options:

--- a/pydatalab/pyproject.toml
+++ b/pydatalab/pyproject.toml
@@ -126,6 +126,7 @@ dev = [
     "mkdocstrings[python] ~= 1.0",
     "docstring-inheritance>=2.2,<4.0",
     "griffe-inherited-docstrings ~= 1.1",
+    "griffe-pydantic ~= 1.1",
     "mkdocs-awesome-pages-plugin ~= 2.9",
     "markdown-callouts ~= 0.4",
 ]

--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -1,8 +1,23 @@
 {
   "title": "Cell",
-  "description": "A model for representing electrochemical cells.",
+  "description": "A model for representing electrochemical cells.\n\nA cell is an electrochemical device assembled from other items, recording its\ncomponents and the format it was built in.",
   "type": "object",
   "properties": {
+    "files": {
+      "title": "Files",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/File"
+      }
+    },
+    "file_ObjectIds": {
+      "title": "File Objectids",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "blocks_obj": {
       "title": "Blocks Obj",
       "default": {},
@@ -122,21 +137,6 @@
       "title": "Name",
       "type": "string"
     },
-    "files": {
-      "title": "Files",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/File"
-      }
-    },
-    "file_ObjectIds": {
-      "title": "File Objectids",
-      "default": [],
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
     "status": {
       "default": "active",
       "allOf": [
@@ -202,91 +202,6 @@
     "item_id"
   ],
   "definitions": {
-    "DataBlockResponse": {
-      "title": "DataBlockResponse",
-      "description": "A generic response model for a block, i.e., what is stored in `self.data`\nin the corresponding DataBlock class.\n\nIt is expected but not mandatory that this model will be extended by the specific block type\nwhere possible.",
-      "type": "object",
-      "properties": {
-        "blocktype": {
-          "title": "Blocktype",
-          "type": "string"
-        },
-        "block_id": {
-          "title": "Block Id",
-          "type": "string"
-        },
-        "item_id": {
-          "title": "Item Id",
-          "type": "string"
-        },
-        "collection_id": {
-          "title": "Collection Id",
-          "type": "string"
-        },
-        "title": {
-          "title": "Title",
-          "type": "string"
-        },
-        "freeform_comment": {
-          "title": "Freeform Comment",
-          "type": "string"
-        },
-        "file_id": {
-          "title": "File Id",
-          "type": "string"
-        },
-        "file_ids": {
-          "title": "File Ids",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "errors": {
-          "title": "Errors",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "warnings": {
-          "title": "Warnings",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "b64_encoded_image": {
-          "title": "B64 Encoded Image",
-          "datalab_exclude_from_db": true,
-          "datalab_exclude_from_load": true,
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "bokeh_plot_data": {
-          "title": "Bokeh Plot Data",
-          "datalab_exclude_from_db": true,
-          "datalab_exclude_from_load": true,
-          "type": "object"
-        },
-        "computed": {
-          "title": "Computed",
-          "datalab_exclude_from_load": true,
-          "type": "object"
-        },
-        "metadata": {
-          "title": "Metadata",
-          "datalab_exclude_from_load": true,
-          "type": "object"
-        }
-      },
-      "required": [
-        "blocktype",
-        "block_id"
-      ]
-    },
     "RelationshipType": {
       "title": "RelationshipType",
       "description": "An enumeration of the possible types of relationship between two entries.\n\n```mermaid\nclassDiagram\nclass entryC\nentryC --|> entryA: parent\nentryC ..|> entryD\nentryA <..> entryD: sibling\nentryA --|> entryB : child\n```",
@@ -563,102 +478,6 @@
         }
       }
     },
-    "Collection": {
-      "title": "Collection",
-      "description": "An Entry is an abstract base class for any model that can be\ndeserialized and stored in the database.",
-      "type": "object",
-      "properties": {
-        "blocks_obj": {
-          "title": "Blocks Obj",
-          "default": {},
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/DataBlockResponse"
-          }
-        },
-        "display_order": {
-          "title": "Display Order",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "creator_ids": {
-          "title": "Creator Ids",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "creators": {
-          "title": "Creators",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Person"
-          }
-        },
-        "group_ids": {
-          "title": "Group Ids",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "groups": {
-          "title": "Groups",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Group"
-          }
-        },
-        "type": {
-          "title": "Type",
-          "default": "collections",
-          "const": "collections",
-          "pattern": "^collections$",
-          "type": "string"
-        },
-        "immutable_id": {
-          "title": "Immutable ID",
-          "format": "uuid",
-          "type": "string"
-        },
-        "last_modified": {
-          "title": "Last Modified",
-          "type": "string",
-          "format": "date-time"
-        },
-        "relationships": {
-          "title": "Relationships",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/TypedRelationship"
-          }
-        },
-        "collection_id": {
-          "title": "Collection Id",
-          "minLength": 1,
-          "maxLength": 40,
-          "pattern": "^(?:[a-zA-Z0-9]+|[a-zA-Z0-9][a-zA-Z0-9._-]+[a-zA-Z0-9])$",
-          "type": "string"
-        },
-        "title": {
-          "title": "Title",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "type": "string"
-        },
-        "num_items": {
-          "title": "Num Items",
-          "type": "integer"
-        }
-      }
-    },
     "FileChecksums": {
       "title": "FileChecksums",
       "description": "Content checksums for a file.",
@@ -834,6 +653,187 @@
         "time_added",
         "is_live"
       ]
+    },
+    "DataBlockResponse": {
+      "title": "DataBlockResponse",
+      "description": "A generic response model for a block, i.e., what is stored in `self.data`\nin the corresponding DataBlock class.\n\nIt is expected but not mandatory that this model will be extended by the specific block type\nwhere possible.",
+      "type": "object",
+      "properties": {
+        "blocktype": {
+          "title": "Blocktype",
+          "type": "string"
+        },
+        "block_id": {
+          "title": "Block Id",
+          "type": "string"
+        },
+        "item_id": {
+          "title": "Item Id",
+          "type": "string"
+        },
+        "collection_id": {
+          "title": "Collection Id",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "freeform_comment": {
+          "title": "Freeform Comment",
+          "type": "string"
+        },
+        "file_id": {
+          "title": "File Id",
+          "type": "string"
+        },
+        "file_ids": {
+          "title": "File Ids",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "errors": {
+          "title": "Errors",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "warnings": {
+          "title": "Warnings",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "b64_encoded_image": {
+          "title": "B64 Encoded Image",
+          "datalab_exclude_from_db": true,
+          "datalab_exclude_from_load": true,
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "bokeh_plot_data": {
+          "title": "Bokeh Plot Data",
+          "datalab_exclude_from_db": true,
+          "datalab_exclude_from_load": true,
+          "type": "object"
+        },
+        "computed": {
+          "title": "Computed",
+          "datalab_exclude_from_load": true,
+          "type": "object"
+        },
+        "metadata": {
+          "title": "Metadata",
+          "datalab_exclude_from_load": true,
+          "type": "object"
+        }
+      },
+      "required": [
+        "blocktype",
+        "block_id"
+      ]
+    },
+    "Collection": {
+      "title": "Collection",
+      "description": "A model for representing a group of related items, for example all the samples\nbelonging to one batch or project.",
+      "type": "object",
+      "properties": {
+        "blocks_obj": {
+          "title": "Blocks Obj",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/DataBlockResponse"
+          }
+        },
+        "display_order": {
+          "title": "Display Order",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "creator_ids": {
+          "title": "Creator Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "creators": {
+          "title": "Creators",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Person"
+          }
+        },
+        "group_ids": {
+          "title": "Group Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "groups": {
+          "title": "Groups",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Group"
+          }
+        },
+        "type": {
+          "title": "Type",
+          "default": "collections",
+          "const": "collections",
+          "pattern": "^collections$",
+          "type": "string"
+        },
+        "immutable_id": {
+          "title": "Immutable ID",
+          "format": "uuid",
+          "type": "string"
+        },
+        "last_modified": {
+          "title": "Last Modified",
+          "type": "string",
+          "format": "date-time"
+        },
+        "relationships": {
+          "title": "Relationships",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TypedRelationship"
+          }
+        },
+        "collection_id": {
+          "title": "Collection Id",
+          "minLength": 1,
+          "maxLength": 40,
+          "pattern": "^(?:[a-zA-Z0-9]+|[a-zA-Z0-9][a-zA-Z0-9._-]+[a-zA-Z0-9])$",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "num_items": {
+          "title": "Num Items",
+          "type": "integer"
+        }
+      }
     },
     "CellStatus": {
       "title": "CellStatus",

--- a/pydatalab/schemas/equipment.json
+++ b/pydatalab/schemas/equipment.json
@@ -1,8 +1,23 @@
 {
   "title": "Equipment",
-  "description": "A model for representing an experimental sample.",
+  "description": "A model for representing a piece of equipment.\n\nEquipment represents an instrument or apparatus in the lab, which can be linked to\nthe items measured on it.",
   "type": "object",
   "properties": {
+    "files": {
+      "title": "Files",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/File"
+      }
+    },
+    "file_ObjectIds": {
+      "title": "File Objectids",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "blocks_obj": {
       "title": "Blocks Obj",
       "default": {},
@@ -122,21 +137,6 @@
       "title": "Name",
       "type": "string"
     },
-    "files": {
-      "title": "Files",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/File"
-      }
-    },
-    "file_ObjectIds": {
-      "title": "File Objectids",
-      "default": [],
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
     "status": {
       "default": "working",
       "allOf": [
@@ -166,91 +166,6 @@
     "item_id"
   ],
   "definitions": {
-    "DataBlockResponse": {
-      "title": "DataBlockResponse",
-      "description": "A generic response model for a block, i.e., what is stored in `self.data`\nin the corresponding DataBlock class.\n\nIt is expected but not mandatory that this model will be extended by the specific block type\nwhere possible.",
-      "type": "object",
-      "properties": {
-        "blocktype": {
-          "title": "Blocktype",
-          "type": "string"
-        },
-        "block_id": {
-          "title": "Block Id",
-          "type": "string"
-        },
-        "item_id": {
-          "title": "Item Id",
-          "type": "string"
-        },
-        "collection_id": {
-          "title": "Collection Id",
-          "type": "string"
-        },
-        "title": {
-          "title": "Title",
-          "type": "string"
-        },
-        "freeform_comment": {
-          "title": "Freeform Comment",
-          "type": "string"
-        },
-        "file_id": {
-          "title": "File Id",
-          "type": "string"
-        },
-        "file_ids": {
-          "title": "File Ids",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "errors": {
-          "title": "Errors",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "warnings": {
-          "title": "Warnings",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "b64_encoded_image": {
-          "title": "B64 Encoded Image",
-          "datalab_exclude_from_db": true,
-          "datalab_exclude_from_load": true,
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "bokeh_plot_data": {
-          "title": "Bokeh Plot Data",
-          "datalab_exclude_from_db": true,
-          "datalab_exclude_from_load": true,
-          "type": "object"
-        },
-        "computed": {
-          "title": "Computed",
-          "datalab_exclude_from_load": true,
-          "type": "object"
-        },
-        "metadata": {
-          "title": "Metadata",
-          "datalab_exclude_from_load": true,
-          "type": "object"
-        }
-      },
-      "required": [
-        "blocktype",
-        "block_id"
-      ]
-    },
     "RelationshipType": {
       "title": "RelationshipType",
       "description": "An enumeration of the possible types of relationship between two entries.\n\n```mermaid\nclassDiagram\nclass entryC\nentryC --|> entryA: parent\nentryC ..|> entryD\nentryA <..> entryD: sibling\nentryA --|> entryB : child\n```",
@@ -527,102 +442,6 @@
         }
       }
     },
-    "Collection": {
-      "title": "Collection",
-      "description": "An Entry is an abstract base class for any model that can be\ndeserialized and stored in the database.",
-      "type": "object",
-      "properties": {
-        "blocks_obj": {
-          "title": "Blocks Obj",
-          "default": {},
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/DataBlockResponse"
-          }
-        },
-        "display_order": {
-          "title": "Display Order",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "creator_ids": {
-          "title": "Creator Ids",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "creators": {
-          "title": "Creators",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Person"
-          }
-        },
-        "group_ids": {
-          "title": "Group Ids",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "groups": {
-          "title": "Groups",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Group"
-          }
-        },
-        "type": {
-          "title": "Type",
-          "default": "collections",
-          "const": "collections",
-          "pattern": "^collections$",
-          "type": "string"
-        },
-        "immutable_id": {
-          "title": "Immutable ID",
-          "format": "uuid",
-          "type": "string"
-        },
-        "last_modified": {
-          "title": "Last Modified",
-          "type": "string",
-          "format": "date-time"
-        },
-        "relationships": {
-          "title": "Relationships",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/TypedRelationship"
-          }
-        },
-        "collection_id": {
-          "title": "Collection Id",
-          "minLength": 1,
-          "maxLength": 40,
-          "pattern": "^(?:[a-zA-Z0-9]+|[a-zA-Z0-9][a-zA-Z0-9._-]+[a-zA-Z0-9])$",
-          "type": "string"
-        },
-        "title": {
-          "title": "Title",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "type": "string"
-        },
-        "num_items": {
-          "title": "Num Items",
-          "type": "integer"
-        }
-      }
-    },
     "FileChecksums": {
       "title": "FileChecksums",
       "description": "Content checksums for a file.",
@@ -798,6 +617,187 @@
         "time_added",
         "is_live"
       ]
+    },
+    "DataBlockResponse": {
+      "title": "DataBlockResponse",
+      "description": "A generic response model for a block, i.e., what is stored in `self.data`\nin the corresponding DataBlock class.\n\nIt is expected but not mandatory that this model will be extended by the specific block type\nwhere possible.",
+      "type": "object",
+      "properties": {
+        "blocktype": {
+          "title": "Blocktype",
+          "type": "string"
+        },
+        "block_id": {
+          "title": "Block Id",
+          "type": "string"
+        },
+        "item_id": {
+          "title": "Item Id",
+          "type": "string"
+        },
+        "collection_id": {
+          "title": "Collection Id",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "freeform_comment": {
+          "title": "Freeform Comment",
+          "type": "string"
+        },
+        "file_id": {
+          "title": "File Id",
+          "type": "string"
+        },
+        "file_ids": {
+          "title": "File Ids",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "errors": {
+          "title": "Errors",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "warnings": {
+          "title": "Warnings",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "b64_encoded_image": {
+          "title": "B64 Encoded Image",
+          "datalab_exclude_from_db": true,
+          "datalab_exclude_from_load": true,
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "bokeh_plot_data": {
+          "title": "Bokeh Plot Data",
+          "datalab_exclude_from_db": true,
+          "datalab_exclude_from_load": true,
+          "type": "object"
+        },
+        "computed": {
+          "title": "Computed",
+          "datalab_exclude_from_load": true,
+          "type": "object"
+        },
+        "metadata": {
+          "title": "Metadata",
+          "datalab_exclude_from_load": true,
+          "type": "object"
+        }
+      },
+      "required": [
+        "blocktype",
+        "block_id"
+      ]
+    },
+    "Collection": {
+      "title": "Collection",
+      "description": "A model for representing a group of related items, for example all the samples\nbelonging to one batch or project.",
+      "type": "object",
+      "properties": {
+        "blocks_obj": {
+          "title": "Blocks Obj",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/DataBlockResponse"
+          }
+        },
+        "display_order": {
+          "title": "Display Order",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "creator_ids": {
+          "title": "Creator Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "creators": {
+          "title": "Creators",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Person"
+          }
+        },
+        "group_ids": {
+          "title": "Group Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "groups": {
+          "title": "Groups",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Group"
+          }
+        },
+        "type": {
+          "title": "Type",
+          "default": "collections",
+          "const": "collections",
+          "pattern": "^collections$",
+          "type": "string"
+        },
+        "immutable_id": {
+          "title": "Immutable ID",
+          "format": "uuid",
+          "type": "string"
+        },
+        "last_modified": {
+          "title": "Last Modified",
+          "type": "string",
+          "format": "date-time"
+        },
+        "relationships": {
+          "title": "Relationships",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TypedRelationship"
+          }
+        },
+        "collection_id": {
+          "title": "Collection Id",
+          "minLength": 1,
+          "maxLength": 40,
+          "pattern": "^(?:[a-zA-Z0-9]+|[a-zA-Z0-9][a-zA-Z0-9._-]+[a-zA-Z0-9])$",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "num_items": {
+          "title": "Num Items",
+          "type": "integer"
+        }
+      }
     },
     "EquipmentStatus": {
       "title": "EquipmentStatus",

--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -1,6 +1,6 @@
 {
   "title": "Sample",
-  "description": "A model for representing an experimental sample.",
+  "description": "A model for representing an experimental sample.\n\nA physical thing in the lab that can be created, characterised\nand connected to other items.",
   "type": "object",
   "properties": {
     "chemform": {
@@ -57,6 +57,21 @@
     "synthesis_description": {
       "title": "Synthesis Description",
       "type": "string"
+    },
+    "files": {
+      "title": "Files",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/File"
+      }
+    },
+    "file_ObjectIds": {
+      "title": "File Objectids",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "blocks_obj": {
       "title": "Blocks Obj",
@@ -177,21 +192,6 @@
       "title": "Name",
       "type": "string"
     },
-    "files": {
-      "title": "Files",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/File"
-      }
-    },
-    "file_ObjectIds": {
-      "title": "File Objectids",
-      "default": [],
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
     "status": {
       "default": "active",
       "allOf": [
@@ -292,91 +292,6 @@
       "required": [
         "item",
         "quantity"
-      ]
-    },
-    "DataBlockResponse": {
-      "title": "DataBlockResponse",
-      "description": "A generic response model for a block, i.e., what is stored in `self.data`\nin the corresponding DataBlock class.\n\nIt is expected but not mandatory that this model will be extended by the specific block type\nwhere possible.",
-      "type": "object",
-      "properties": {
-        "blocktype": {
-          "title": "Blocktype",
-          "type": "string"
-        },
-        "block_id": {
-          "title": "Block Id",
-          "type": "string"
-        },
-        "item_id": {
-          "title": "Item Id",
-          "type": "string"
-        },
-        "collection_id": {
-          "title": "Collection Id",
-          "type": "string"
-        },
-        "title": {
-          "title": "Title",
-          "type": "string"
-        },
-        "freeform_comment": {
-          "title": "Freeform Comment",
-          "type": "string"
-        },
-        "file_id": {
-          "title": "File Id",
-          "type": "string"
-        },
-        "file_ids": {
-          "title": "File Ids",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "errors": {
-          "title": "Errors",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "warnings": {
-          "title": "Warnings",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "b64_encoded_image": {
-          "title": "B64 Encoded Image",
-          "datalab_exclude_from_db": true,
-          "datalab_exclude_from_load": true,
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "bokeh_plot_data": {
-          "title": "Bokeh Plot Data",
-          "datalab_exclude_from_db": true,
-          "datalab_exclude_from_load": true,
-          "type": "object"
-        },
-        "computed": {
-          "title": "Computed",
-          "datalab_exclude_from_load": true,
-          "type": "object"
-        },
-        "metadata": {
-          "title": "Metadata",
-          "datalab_exclude_from_load": true,
-          "type": "object"
-        }
-      },
-      "required": [
-        "blocktype",
-        "block_id"
       ]
     },
     "RelationshipType": {
@@ -655,102 +570,6 @@
         }
       }
     },
-    "Collection": {
-      "title": "Collection",
-      "description": "An Entry is an abstract base class for any model that can be\ndeserialized and stored in the database.",
-      "type": "object",
-      "properties": {
-        "blocks_obj": {
-          "title": "Blocks Obj",
-          "default": {},
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/DataBlockResponse"
-          }
-        },
-        "display_order": {
-          "title": "Display Order",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "creator_ids": {
-          "title": "Creator Ids",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "creators": {
-          "title": "Creators",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Person"
-          }
-        },
-        "group_ids": {
-          "title": "Group Ids",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "groups": {
-          "title": "Groups",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Group"
-          }
-        },
-        "type": {
-          "title": "Type",
-          "default": "collections",
-          "const": "collections",
-          "pattern": "^collections$",
-          "type": "string"
-        },
-        "immutable_id": {
-          "title": "Immutable ID",
-          "format": "uuid",
-          "type": "string"
-        },
-        "last_modified": {
-          "title": "Last Modified",
-          "type": "string",
-          "format": "date-time"
-        },
-        "relationships": {
-          "title": "Relationships",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/TypedRelationship"
-          }
-        },
-        "collection_id": {
-          "title": "Collection Id",
-          "minLength": 1,
-          "maxLength": 40,
-          "pattern": "^(?:[a-zA-Z0-9]+|[a-zA-Z0-9][a-zA-Z0-9._-]+[a-zA-Z0-9])$",
-          "type": "string"
-        },
-        "title": {
-          "title": "Title",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "type": "string"
-        },
-        "num_items": {
-          "title": "Num Items",
-          "type": "integer"
-        }
-      }
-    },
     "FileChecksums": {
       "title": "FileChecksums",
       "description": "Content checksums for a file.",
@@ -926,6 +745,187 @@
         "time_added",
         "is_live"
       ]
+    },
+    "DataBlockResponse": {
+      "title": "DataBlockResponse",
+      "description": "A generic response model for a block, i.e., what is stored in `self.data`\nin the corresponding DataBlock class.\n\nIt is expected but not mandatory that this model will be extended by the specific block type\nwhere possible.",
+      "type": "object",
+      "properties": {
+        "blocktype": {
+          "title": "Blocktype",
+          "type": "string"
+        },
+        "block_id": {
+          "title": "Block Id",
+          "type": "string"
+        },
+        "item_id": {
+          "title": "Item Id",
+          "type": "string"
+        },
+        "collection_id": {
+          "title": "Collection Id",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "freeform_comment": {
+          "title": "Freeform Comment",
+          "type": "string"
+        },
+        "file_id": {
+          "title": "File Id",
+          "type": "string"
+        },
+        "file_ids": {
+          "title": "File Ids",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "errors": {
+          "title": "Errors",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "warnings": {
+          "title": "Warnings",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "b64_encoded_image": {
+          "title": "B64 Encoded Image",
+          "datalab_exclude_from_db": true,
+          "datalab_exclude_from_load": true,
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "bokeh_plot_data": {
+          "title": "Bokeh Plot Data",
+          "datalab_exclude_from_db": true,
+          "datalab_exclude_from_load": true,
+          "type": "object"
+        },
+        "computed": {
+          "title": "Computed",
+          "datalab_exclude_from_load": true,
+          "type": "object"
+        },
+        "metadata": {
+          "title": "Metadata",
+          "datalab_exclude_from_load": true,
+          "type": "object"
+        }
+      },
+      "required": [
+        "blocktype",
+        "block_id"
+      ]
+    },
+    "Collection": {
+      "title": "Collection",
+      "description": "A model for representing a group of related items, for example all the samples\nbelonging to one batch or project.",
+      "type": "object",
+      "properties": {
+        "blocks_obj": {
+          "title": "Blocks Obj",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/DataBlockResponse"
+          }
+        },
+        "display_order": {
+          "title": "Display Order",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "creator_ids": {
+          "title": "Creator Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "creators": {
+          "title": "Creators",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Person"
+          }
+        },
+        "group_ids": {
+          "title": "Group Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "groups": {
+          "title": "Groups",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Group"
+          }
+        },
+        "type": {
+          "title": "Type",
+          "default": "collections",
+          "const": "collections",
+          "pattern": "^collections$",
+          "type": "string"
+        },
+        "immutable_id": {
+          "title": "Immutable ID",
+          "format": "uuid",
+          "type": "string"
+        },
+        "last_modified": {
+          "title": "Last Modified",
+          "type": "string",
+          "format": "date-time"
+        },
+        "relationships": {
+          "title": "Relationships",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TypedRelationship"
+          }
+        },
+        "collection_id": {
+          "title": "Collection Id",
+          "minLength": 1,
+          "maxLength": 40,
+          "pattern": "^(?:[a-zA-Z0-9]+|[a-zA-Z0-9][a-zA-Z0-9._-]+[a-zA-Z0-9])$",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "num_items": {
+          "title": "Num Items",
+          "type": "integer"
+        }
+      }
     },
     "ItemStatus": {
       "title": "ItemStatus",

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -1,6 +1,6 @@
 {
   "title": "StartingMaterial",
-  "description": "A model for representing an experimental sample, based on the connection\nwith cheminventory.net, which mixes container-level and substance-level\ninformation.",
+  "description": "A model for representing a starting material, i.e., a chemical or precursor held\nin the lab's inventory, from which samples are made.\n\nThe model mixes container-level and substance-level information and can be used to\nrepresent either depending on preference.",
   "type": "object",
   "properties": {
     "chemform": {
@@ -57,6 +57,21 @@
     "synthesis_description": {
       "title": "Synthesis Description",
       "type": "string"
+    },
+    "files": {
+      "title": "Files",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/File"
+      }
+    },
+    "file_ObjectIds": {
+      "title": "File Objectids",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "blocks_obj": {
       "title": "Blocks Obj",
@@ -176,21 +191,6 @@
     "name": {
       "title": "Container Name",
       "type": "string"
-    },
-    "files": {
-      "title": "Files",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/File"
-      }
-    },
-    "file_ObjectIds": {
-      "title": "File Objectids",
-      "default": [],
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
     },
     "status": {
       "default": "available",
@@ -329,91 +329,6 @@
       "required": [
         "item",
         "quantity"
-      ]
-    },
-    "DataBlockResponse": {
-      "title": "DataBlockResponse",
-      "description": "A generic response model for a block, i.e., what is stored in `self.data`\nin the corresponding DataBlock class.\n\nIt is expected but not mandatory that this model will be extended by the specific block type\nwhere possible.",
-      "type": "object",
-      "properties": {
-        "blocktype": {
-          "title": "Blocktype",
-          "type": "string"
-        },
-        "block_id": {
-          "title": "Block Id",
-          "type": "string"
-        },
-        "item_id": {
-          "title": "Item Id",
-          "type": "string"
-        },
-        "collection_id": {
-          "title": "Collection Id",
-          "type": "string"
-        },
-        "title": {
-          "title": "Title",
-          "type": "string"
-        },
-        "freeform_comment": {
-          "title": "Freeform Comment",
-          "type": "string"
-        },
-        "file_id": {
-          "title": "File Id",
-          "type": "string"
-        },
-        "file_ids": {
-          "title": "File Ids",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "errors": {
-          "title": "Errors",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "warnings": {
-          "title": "Warnings",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "b64_encoded_image": {
-          "title": "B64 Encoded Image",
-          "datalab_exclude_from_db": true,
-          "datalab_exclude_from_load": true,
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "bokeh_plot_data": {
-          "title": "Bokeh Plot Data",
-          "datalab_exclude_from_db": true,
-          "datalab_exclude_from_load": true,
-          "type": "object"
-        },
-        "computed": {
-          "title": "Computed",
-          "datalab_exclude_from_load": true,
-          "type": "object"
-        },
-        "metadata": {
-          "title": "Metadata",
-          "datalab_exclude_from_load": true,
-          "type": "object"
-        }
-      },
-      "required": [
-        "blocktype",
-        "block_id"
       ]
     },
     "RelationshipType": {
@@ -692,102 +607,6 @@
         }
       }
     },
-    "Collection": {
-      "title": "Collection",
-      "description": "An Entry is an abstract base class for any model that can be\ndeserialized and stored in the database.",
-      "type": "object",
-      "properties": {
-        "blocks_obj": {
-          "title": "Blocks Obj",
-          "default": {},
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/definitions/DataBlockResponse"
-          }
-        },
-        "display_order": {
-          "title": "Display Order",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "creator_ids": {
-          "title": "Creator Ids",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "creators": {
-          "title": "Creators",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Person"
-          }
-        },
-        "group_ids": {
-          "title": "Group Ids",
-          "default": [],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "groups": {
-          "title": "Groups",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Group"
-          }
-        },
-        "type": {
-          "title": "Type",
-          "default": "collections",
-          "const": "collections",
-          "pattern": "^collections$",
-          "type": "string"
-        },
-        "immutable_id": {
-          "title": "Immutable ID",
-          "format": "uuid",
-          "type": "string"
-        },
-        "last_modified": {
-          "title": "Last Modified",
-          "type": "string",
-          "format": "date-time"
-        },
-        "relationships": {
-          "title": "Relationships",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/TypedRelationship"
-          }
-        },
-        "collection_id": {
-          "title": "Collection Id",
-          "minLength": 1,
-          "maxLength": 40,
-          "pattern": "^(?:[a-zA-Z0-9]+|[a-zA-Z0-9][a-zA-Z0-9._-]+[a-zA-Z0-9])$",
-          "type": "string"
-        },
-        "title": {
-          "title": "Title",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "type": "string"
-        },
-        "num_items": {
-          "title": "Num Items",
-          "type": "integer"
-        }
-      }
-    },
     "FileChecksums": {
       "title": "FileChecksums",
       "description": "Content checksums for a file.",
@@ -963,6 +782,187 @@
         "time_added",
         "is_live"
       ]
+    },
+    "DataBlockResponse": {
+      "title": "DataBlockResponse",
+      "description": "A generic response model for a block, i.e., what is stored in `self.data`\nin the corresponding DataBlock class.\n\nIt is expected but not mandatory that this model will be extended by the specific block type\nwhere possible.",
+      "type": "object",
+      "properties": {
+        "blocktype": {
+          "title": "Blocktype",
+          "type": "string"
+        },
+        "block_id": {
+          "title": "Block Id",
+          "type": "string"
+        },
+        "item_id": {
+          "title": "Item Id",
+          "type": "string"
+        },
+        "collection_id": {
+          "title": "Collection Id",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "freeform_comment": {
+          "title": "Freeform Comment",
+          "type": "string"
+        },
+        "file_id": {
+          "title": "File Id",
+          "type": "string"
+        },
+        "file_ids": {
+          "title": "File Ids",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "errors": {
+          "title": "Errors",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "warnings": {
+          "title": "Warnings",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "b64_encoded_image": {
+          "title": "B64 Encoded Image",
+          "datalab_exclude_from_db": true,
+          "datalab_exclude_from_load": true,
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "bokeh_plot_data": {
+          "title": "Bokeh Plot Data",
+          "datalab_exclude_from_db": true,
+          "datalab_exclude_from_load": true,
+          "type": "object"
+        },
+        "computed": {
+          "title": "Computed",
+          "datalab_exclude_from_load": true,
+          "type": "object"
+        },
+        "metadata": {
+          "title": "Metadata",
+          "datalab_exclude_from_load": true,
+          "type": "object"
+        }
+      },
+      "required": [
+        "blocktype",
+        "block_id"
+      ]
+    },
+    "Collection": {
+      "title": "Collection",
+      "description": "A model for representing a group of related items, for example all the samples\nbelonging to one batch or project.",
+      "type": "object",
+      "properties": {
+        "blocks_obj": {
+          "title": "Blocks Obj",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/DataBlockResponse"
+          }
+        },
+        "display_order": {
+          "title": "Display Order",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "creator_ids": {
+          "title": "Creator Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "creators": {
+          "title": "Creators",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Person"
+          }
+        },
+        "group_ids": {
+          "title": "Group Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "groups": {
+          "title": "Groups",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Group"
+          }
+        },
+        "type": {
+          "title": "Type",
+          "default": "collections",
+          "const": "collections",
+          "pattern": "^collections$",
+          "type": "string"
+        },
+        "immutable_id": {
+          "title": "Immutable ID",
+          "format": "uuid",
+          "type": "string"
+        },
+        "last_modified": {
+          "title": "Last Modified",
+          "type": "string",
+          "format": "date-time"
+        },
+        "relationships": {
+          "title": "Relationships",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TypedRelationship"
+          }
+        },
+        "collection_id": {
+          "title": "Collection Id",
+          "minLength": 1,
+          "maxLength": 40,
+          "pattern": "^(?:[a-zA-Z0-9]+|[a-zA-Z0-9][a-zA-Z0-9._-]+[a-zA-Z0-9])$",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "num_items": {
+          "title": "Num Items",
+          "type": "integer"
+        }
+      }
     },
     "StartingMaterialsStatus": {
       "title": "StartingMaterialsStatus",

--- a/pydatalab/src/pydatalab/models/cells.py
+++ b/pydatalab/src/pydatalab/models/cells.py
@@ -25,7 +25,11 @@ class CellFormat(str, Enum):
 
 
 class Cell(Item):
-    """A model for representing electrochemical cells."""
+    """A model for representing electrochemical cells.
+
+    A cell is an electrochemical device assembled from other items, recording its
+    components and the format it was built in.
+    """
 
     type: str = Field("cells", const="cells", pattern="^cells$")
 

--- a/pydatalab/src/pydatalab/models/collections.py
+++ b/pydatalab/src/pydatalab/models/collections.py
@@ -6,6 +6,11 @@ from pydatalab.models.utils import HumanReadableIdentifier
 
 
 class Collection(Entry, HasOwner, HasBlocks):
+    """A model for representing a group of related items, for example all the samples
+    belonging to one batch or project.
+
+    """
+
     type: str = Field("collections", const="collections", pattern="^collections$")
 
     collection_id: HumanReadableIdentifier = Field(None)

--- a/pydatalab/src/pydatalab/models/equipment.py
+++ b/pydatalab/src/pydatalab/models/equipment.py
@@ -7,7 +7,11 @@ from pydatalab.models.utils import (
 
 
 class Equipment(Item):
-    """A model for representing an experimental sample."""
+    """A model for representing a piece of equipment.
+
+    Equipment represents an instrument or apparatus in the lab, which can be linked to
+    the items measured on it.
+    """
 
     type: str = Field("equipment", const="equipment", pattern="^equipment$")
 

--- a/pydatalab/src/pydatalab/models/items.py
+++ b/pydatalab/src/pydatalab/models/items.py
@@ -1,11 +1,11 @@
 import abc
 
-from pydantic import Field, validator
+from pydantic import validator
 
 from pydatalab.models.entries import Entry
-from pydatalab.models.files import File
 from pydatalab.models.traits import (
     HasBlocks,
+    HasFiles,
     HasOwner,
     HasRevisionControl,
     IsCollectable,
@@ -13,13 +13,18 @@ from pydatalab.models.traits import (
 from pydatalab.models.utils import (
     HumanReadableIdentifier,
     IsoformatDateTime,
-    PyObjectId,
     Refcode,
 )
 
 
-class Item(Entry, HasOwner, HasRevisionControl, IsCollectable, HasBlocks, abc.ABC):
-    """The generic model for data types that will be exposed with their own named endpoints."""
+class Item(Entry, HasOwner, HasRevisionControl, IsCollectable, HasBlocks, HasFiles, abc.ABC):
+    """The generic model for data types that will be exposed with their own named endpoints.
+
+    `Item` is the abstract base shared by every physical item type: samples, cells,
+    starting materials and equipment. `item_id` is normally the only required field;
+    the remaining fields are either optional metadata or bookkeeping that the server
+    populates itself.
+    """
 
     refcode: Refcode = None  # type: ignore
     """A globally unique immutable ID comprised of the deployment prefix (e.g., `grey`)
@@ -37,12 +42,6 @@ class Item(Entry, HasOwner, HasRevisionControl, IsCollectable, HasBlocks, abc.AB
 
     name: str | None
     """An optional human-readable/usable name for the entry."""
-
-    files: list[File] | None
-    """Any files attached to this sample."""
-
-    file_ObjectIds: list[PyObjectId] = Field([])
-    """Links to object IDs of files stored within the database."""
 
     status: str | None
     """The status of the item, with allowed values defined by the specific item class."""

--- a/pydatalab/src/pydatalab/models/samples.py
+++ b/pydatalab/src/pydatalab/models/samples.py
@@ -6,7 +6,11 @@ from pydatalab.models.utils import SampleStatus
 
 
 class Sample(Item, HasSynthesisInfo, HasSubstanceInfo):
-    """A model for representing an experimental sample."""
+    """A model for representing an experimental sample.
+
+    A physical thing in the lab that can be created, characterised
+    and connected to other items.
+    """
 
     type: str = Field("samples", const="samples", pattern="^samples$")
 

--- a/pydatalab/src/pydatalab/models/starting_materials.py
+++ b/pydatalab/src/pydatalab/models/starting_materials.py
@@ -6,10 +6,11 @@ from pydatalab.models.utils import IsoformatDateTime, StartingMaterialsStatus
 
 
 class StartingMaterial(Item, HasSynthesisInfo, HasSubstanceInfo):
-    """A model for representing an experimental sample, based on the connection
-    with cheminventory.net, which mixes container-level and substance-level
-    information.
+    """A model for representing a starting material, i.e., a chemical or precursor held
+    in the lab's inventory, from which samples are made.
 
+    The model mixes container-level and substance-level information and can be used to
+    represent either depending on preference.
     """
 
     type: str = Field(

--- a/pydatalab/src/pydatalab/models/traits.py
+++ b/pydatalab/src/pydatalab/models/traits.py
@@ -8,6 +8,8 @@ from pydatalab.models.utils import Constituent, InlineSubstance, PyObjectId
 
 
 class HasOwner(BaseModel):
+    """Trait mixin for models that record who created them and which groups can access them."""
+
     creator_ids: list[PyObjectId] = Field([])
     """The database IDs of the user(s) who created the item."""
 
@@ -22,6 +24,8 @@ class HasOwner(BaseModel):
 
 
 class HasRevisionControl(BaseModel):
+    """Trait mixin for models that track a revision history of their own state."""
+
     revision: int = 1
     """The revision number of the entry."""
 
@@ -32,7 +36,23 @@ class HasRevisionControl(BaseModel):
     """The version number used by the version control system for tracking snapshots."""
 
 
+class HasFiles(BaseModel):
+    """Trait mixin for models that can have files attached to them."""
+
+    # Imported here rather than at module level to avoid a circular import,
+    # as `models.files` itself depends on this module.
+    from pydatalab.models.files import File
+
+    files: list[File] | None = Field(None)
+    """Any files attached to this item."""
+
+    file_ObjectIds: list[PyObjectId] = Field([])
+    """Links to object IDs of files stored within the database."""
+
+
 class HasBlocks(BaseModel):
+    """Trait mixin for models that can have data blocks attached to them."""
+
     blocks_obj: dict[str, DataBlockResponse] = Field({})
     """A mapping from block ID to block data."""
 

--- a/pydatalab/uv.lock
+++ b/pydatalab/uv.lock
@@ -744,6 +744,7 @@ server = [
 dev = [
     { name = "docstring-inheritance" },
     { name = "griffe-inherited-docstrings" },
+    { name = "griffe-pydantic" },
     { name = "markdown-callouts" },
     { name = "mkdocs" },
     { name = "mkdocs-awesome-pages-plugin" },
@@ -804,6 +805,7 @@ provides-extras = ["server", "apps", "app-plugins-git", "chat", "deploy", "all"]
 dev = [
     { name = "docstring-inheritance", specifier = ">=2.2,<4.0" },
     { name = "griffe-inherited-docstrings", specifier = "~=1.1" },
+    { name = "griffe-pydantic", specifier = "~=1.1" },
     { name = "markdown-callouts", specifier = "~=0.4" },
     { name = "mkdocs", specifier = "~=1.6" },
     { name = "mkdocs-awesome-pages-plugin", specifier = "~=2.9" },
@@ -1184,6 +1186,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cb/da/fd002dc5f215cd896bfccaebe8b4aa1cdeed8ea1d9d60633685bd61ff933/griffe_inherited_docstrings-1.1.3.tar.gz", hash = "sha256:cd1f937ec9336a790e5425e7f9b92f5a5ab17f292ba86917f1c681c0704cb64e", size = 26738, upload-time = "2026-02-21T09:38:44.312Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/20/4bc15f242181daad1c104e0a7d33be49e712461ea89e548152be0365b9ea/griffe_inherited_docstrings-1.1.3-py3-none-any.whl", hash = "sha256:aa7f6e624515c50d9325a5cfdf4b2acac547f1889aca89092d5da7278f739695", size = 6710, upload-time = "2026-02-20T11:06:38.75Z" },
+]
+
+[[package]]
+name = "griffe-pydantic"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/bd/d2eaeaf3f9910c9cd72793af0de18ee3d3a3a27bb30ab01cfd7659c08dc4/griffe_pydantic-1.3.1.tar.gz", hash = "sha256:f7caedfa0effedb22893bf01cc411fd567614f7b4de7ce0c1f4293eb7acb5c44", size = 38176, upload-time = "2026-02-21T09:38:49.674Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/88/17d656aa97406cd509e2be0e6eddcf81fc1666104bf81042b89721d4a44c/griffe_pydantic-1.3.1-py3-none-any.whl", hash = "sha256:475103794a1d5da3933d3968e82a2bd9d9a1fa507c06d5ee1a39ee1fadcca628", size = 15189, upload-time = "2026-02-20T11:34:14.965Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The final PR of the 0.7.x series:

- [x] Restructure landing pages
- [x] Add link out to fledgling user guide (c.f. #280 or #1851, yet)
- [x] Fix 404 page
- [x] Improve some item model docstrings
- [x] Improve handling of pydantic models
- [x] Add contributing docs (closes #1877)