### PR TITLE
Add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,137 @@
+# Security Policy
+
+*datalab* is typically used to store research data - much of it unpublished, some of it commercially or academically sensitive - on infrastructure operated by the research groups and consortia that use it.
+This document describes how to report a vulnerability, what the software defends against, and which parts of the problem are left up to whoever deploys it.
+
+## Reporting a vulnerability
+
+**Please do not report security issues in public GitHub issues.**
+
+Report privately through either channel:
+
+- [GitHub private vulnerability reporting](https://github.com/datalab-org/datalab/security/advisories/new) (preferred)
+- Email `dev@datalab-org.io`
+
+Please include the affected version, a description of the issue, and ideally a proof of concept and an assessment of impact.
+
+What to expect:
+
+| Stage | Target |
+| --- | --- |
+| Acknowledgement of your report | 3 working days |
+| Initial assessment and severity triage | 10 working days |
+| Fix or documented mitigation for high-severity issues | 90 days from triage |
+
+We will keep you updated as we work, credit you in the advisory unless you would
+rather we didn't, and publish a GitHub Security Advisory when a fix is released, where appropriate.
+If we conclude a report is not a vulnerability, we will explain why.
+
+*datalab* is maintained by a small academic-focused team (with commercial support
+through [datalab industries ltd.](https://datalab.industries)), not a dedicated security
+organisation.
+
+We will not pursue or support legal action against researchers who act in good
+faith: testing only against instances they own or have written permission to test,
+avoiding access to other people's data, avoiding degradation of live services, and
+giving us reasonable time to respond before disclosing publicly.
+
+**Do not test against instances you do not operate**, including the public demo.
+Most deployments hold real, unpublished research data belonging to third parties.
+
+## Supported versions
+
+Security fixes are typically issued for the **latest released minor version** only, though backports will be considered where there is a specific demand.
+*datalab* is pre-1.0 and under active development; operators are expected to track releases reasonably closely.
+
+## Trust model
+
+### What the software enforces
+
+- **Authenticated access.** Users authenticate via OAuth (ORCID, GitHub), magic-link email, or API keys.
+  Registration can be restricted by GitHub organisation membership or email domain, and accounts require admin activation by default.
+- **Per-item and per-group permissions.** Every read and write is filtered by a permission query derived from the requesting user's identity, their group memberships, and any managed users.
+  Items may inherit read access from collections they belong to; write access is never inherited.
+- **Hashed credentials at rest.** API keys and item access tokens are stored as hashes, never in plaintext.
+- **A write audit trail.** Item edits are snapshotted as versions, attributed to the user who made them.
+
+### What it does not defend against
+
+- **Instance administrators.** An admin can read every item in the deployment via super-user mode.
+  This is intentional but it means *the operator of a shared or consortium instance can see all members' data*.
+  Consortia should establish who holds admin, and satisfy themselves about the governance around it, as an organisational control.
+  Improved logging of administrative reads is [planned](#planned-work).
+- **Plugins.** Plugins are Python packages loaded into the server process.
+  They have full access to the database, the filesystem, and the network.
+  **Installing a plugin is therefore deployment decision with the same weight as a code change**, and should be reviewed as one.
+  There is no sandbox, and adding one is [non-trivial](#planned-work).
+- **Malicious authenticated users.** Users are treated as semi-trusted colleagues.
+  Permissions constrain which data they reach, but a user who is authenticated and actively hostile has a large surface to work with, notably file uploads, which are parsed by a wide range of third-party scientific libraries which may be vulnerable to exploitation.
+- **Infrastructure compromise.** Host, container runtime, database, and network security are the operator's responsibility.
+
+## What the project does upstream
+
+Practices in place in this repository today:
+
+**Dependency management**
+- Dependabot covers four ecosystems monthly: Python (`uv`), npm, GitHub Actions, and the Docker base images.
+- Security advisories are provided by GitHub and Dependabot, and are triaged by the maintainers. Critical advisories are addressed in patch releases as soon as possible.
+- A scheduled workflow refreshes `uv.lock` pins monthly, so transitive dependencies don't drift and quietly retain known-vulnerable versions.
+- Server dependencies are fully pinned via `uv.lock`; CI and container builds install from the lockfile.
+- Aside from internal Python packages, no dependency newer than 5 days old is used in production.
+- JavaScript app dependencies are pinned to exact versions in `yarn.lock`; `yarn install --frozen-lockfile` is used in CI and container builds.
+
+**Static analysis and CI**
+- For server code, `ruff` runs with the [`flake8-bandit`](https://docs.astral.sh/ruff/rules/#flake8-bandit-s) (`S`) security ruleset enabled, alongside `mypy` type checking.
+  Both are enforced in CI through `pre-commit` hooks.
+- The full test suite runs against a matrix of supported Python versions on every pull request, with coverage reported.
+- The webapp is built and linted with `eslint` and this build is tested in CI on every pull request.
+- The web app is tested with a suite of Cypress end-to-end and component tests, run in the CI on every pull request.
+- The web app build and the plugin-installation path are both exercised in CI.
+
+**Application hardening**
+- The Flask `SECRET_KEY` is checked for sufficient entropy at startup; the server refuses to run with a weak or absent key unless an explicit insecure-override environment variable is set.
+- Cross-origin access is split by credential type: the public API is readable from any origin using an explicit `DATALAB-API-KEY` header, while cookie-authenticated sessions are restricted to configured first-party origins.
+- Uploaded filenames are sanitised before being written to disk.
+- User-supplied SVG and Markdown are sanitised with DOMPurify before rendering.
+
+**Release integrity**
+- PyPI releases use [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) via OIDC, so no long-lived publishing token exists to be stolen.
+- Releases are built from tagged commits in GitHub Actions environments requiring approval.
+
+## Operator responsibilities
+
+*datalab* is self-hostable, and a correctly written application on a badly configured host is not secure.
+The following are the deploying institution's responsibility:
+
+- **Transport security.** Terminate TLS at a reverse proxy and set `BEHIND_REVERSE_PROXY`.
+  Never expose the API directly over plain HTTP.
+- **Database access.** MongoDB should be reachable only from the API container.
+  Enable authentication on the database if it is reachable from anywhere else.
+- **Origin configuration.** Set `APP_URL` to the web app's URL so that cookie-authenticated requests are restricted to it.
+- **Secrets.** Supply `PYDATALAB_SECRET_KEY` and any OAuth secrets from the environment or a secrets manager, never from a file in version control.
+- **Storage encryption.** Enable full-disk encryption on the host volume, and encrypt backup artifacts.
+Note the limits of this: it protects against a stolen disk or a leaked snapshot, and not at all against compromise of a running server, since the database decrypts transparently for anyone who can connect.
+- **Backups.** Configure and, importantly, **periodically test restoring** them, ideally following the 3-2-1 rule.
+*datalab* provides a native way of creating scheduled snapshots, though this should likely be complemented with an incremental backup process (e.g., borg).
+- **Remote filesystems.** Scope any configured remote filesystem to the narrowest possible directory, using a dedicated account with read-only access.
+- **Plugins.** Review and pin them; treat additions as deployment changes.
+- **Updates.** Track releases and subscribe to this repository's security advisories.
+
+There are a series of Ansible roles made available by datalab industries ltd. in [`datalab-ansible-terraform`](https://github.com/datalab-industries/datalab-ansible-terraform) that cover several of these cases automatically.
+For example, certificate provisioning, backup scheduling and retention, monitoring and log ingestion are handled by the playbooks.
+See the deployment repository's own `SECURITY.md` for the infrastructure-side half of this policy.
+
+## Planned work
+
+Improvements we intend to make. They are listed here so operators can see what is
+coming and what is not yet true; **several are only meaningful in combination with a
+particular deployment**, and none should be assumed present in a running instance.
+
+- **A separate audit log stream.** Security-relevant events (administrative reads, authentication, permission elevation) currently go to the general application log, which rotates with everything else.
+  Emitting them on a dedicated logger would let operators retain them for longer and ship them to separate storage.
+  *The retention and destination remain a deployment choice — the software can only make the events cleanly separable.*
+- **Process isolation for block execution.** Running block parsing in a worker with no database credentials and no network egress.
+- **A rework of the existing permissions system.** To enable increased flexiblility and to support more complex use cases, including the ability to delegate permissions to other users or groups across projects.
+
+If any of these are blocking an adoption decision, please open an issue or get in
+touch; knowing which matter to real deployments helps us prioritise future development.

--- a/pydatalab/docs/.pages
+++ b/pydatalab/docs/.pages
@@ -14,5 +14,6 @@ nav:
     - Deployment:
         - deployment.md
         - config.md
+        - SECURITY.md
     - About: about.md
     - Changelog: CHANGELOG.md

--- a/pydatalab/docs/SECURITY.md
+++ b/pydatalab/docs/SECURITY.md
@@ -1,0 +1,1 @@
+../../SECURITY.md

--- a/pydatalab/docs/index.md
+++ b/pydatalab/docs/index.md
@@ -12,11 +12,7 @@ If you have never seen *datalab* before, the quickest introduction is to
 [try the public demo instance](https://demo.datalab-org.io);
 for background on the project itself, see [About *datalab*](about.md).
 
-!!! important "Every *datalab* is different"
-    *datalab* can be self-hosted and is extensible via plugins, so **no two deployments are alike**.
-    These docs primarily describe the *upstream* project, rather than a specific *datalab* instance.
-
-## Where to go next
+## Getting started
 
 <div class="grid cards home-cards" markdown>
 
@@ -27,9 +23,12 @@ for background on the project itself, see [About *datalab*](about.md).
     Using a *datalab* instance: recording samples and cells,
     attaching data, and getting your data back out again.
 
+
     [:material-book-open-variant: &nbsp; User guide](https://guide.datalab-org.io)
 
-    [:material-file-tree: &nbsp; Data models](schemas/items.md)
+    [:simple-doi: &nbsp; White paper](https://doi.org/10.26434/chemrxiv.15001945/v1)
+
+    [:material-file-tree: &nbsp; Data model](schemas/items.md)
 
     [:material-cube-outline: &nbsp; Data blocks](blocks/reference/base.md)
 
@@ -41,6 +40,8 @@ for background on the project itself, see [About *datalab*](about.md).
 
     Extending *datalab* with your own blocks and plugins, or contributing to the
     core server and web app.
+
+    [:material-account-multiple: &nbsp; Contributing Guide](CONTRIBUTING.md)
 
     [:material-console: &nbsp; Development setup](INSTALL.md)
 
@@ -61,6 +62,8 @@ for background on the project itself, see [About *datalab*](about.md).
     [:material-cog-outline: &nbsp; Server configuration](config.md)
 
     [:simple-ansible: &nbsp; Ansible & Terraform Automations](https://github.com/datalab-org/datalab-ansible-terraform)
+
+    [:material-security: &nbsp; Security Policy](SECURITY.md)
 
     [:material-history: &nbsp; Changelog](CHANGELOG.md)
 


### PR DESCRIPTION
This PR adds a security policy indicating how we approach our development in a secure way, how to report security concerns, and which aspects are left up to the person that deploys the server.

Also renders this into a nice docs page and adds some links to the top-level cards for balance.