### PR TITLE
Add `MetadataViewer` option on all blocks 

### DIFF
--- a/pydatalab/example_data/NMR/README
+++ b/pydatalab/example_data/NMR/README
@@ -3,3 +3,4 @@
 72.zip: example of 2D (MATPASS) solid-state NMR data
 1h.dx: example of 1D JCAMP-DX data, sourced from [nmRxiv](https://docs.nmrxiv.org/introduction/data/exemplary-data.html#jcamp-datasets)
 13c.dx: example of 1D JCAMP-DX data, sourced from [nmRxiv](https://docs.nmrxiv.org/introduction/data/exemplary-data.html#jcamp-datasets)
+multi_nuclei.zip: a shell example of multi-nuclei NMR data (1H, 13C, 15N, 31P) from Bruker -- contains no raw data and will fail any real test, but useful for folder structure only

--- a/pydatalab/src/pydatalab/apps/nmr/blocks.py
+++ b/pydatalab/src/pydatalab/apps/nmr/blocks.py
@@ -380,8 +380,12 @@ class NMRBlock(DataBlock):
             plot_line=True,
             plot_points=False,
         )
-        # flip x axis, per NMR convention. Note that the figure is the second element
-        # of the layout in the current implementation, but this could be fragile.
-        bokeh_layout.children[1].x_range.flipped = True
+        # Flip the x axis, per NMR convention. The figure is found by looking for
+        # the child that has an x axis at all, rather than by position: the layout
+        # also holds axis selectors and an export button, whose ordering is an
+        # implementation detail of `selectable_axes_plot`.
+        figure = next((child for child in bokeh_layout.children if hasattr(child, "x_range")), None)
+        if figure is not None:
+            figure.x_range.flipped = True
 
         return bokeh.embed.json_item(bokeh_layout, theme=DATALAB_BOKEH_THEME)

--- a/webapp/cypress/e2e/batchSampleFeature.cy.js
+++ b/webapp/cypress/e2e/batchSampleFeature.cy.js
@@ -168,7 +168,7 @@ describe("Batch sample creation", () => {
     cy.get('[data-testid="add-block-button-top"]').click();
     cy.get('[data-testid="add-block-dropdown"]').findByText("Comment").click();
 
-    cy.get(".datablock-content div").first().type("a comment is added here.");
+    cy.get(".datablock-content [contenteditable]").first().type("a comment is added here.");
 
     cy.get(".fa-save").click();
     cy.findByText("Home").click();
@@ -181,7 +181,7 @@ describe("Batch sample creation", () => {
     cy.findByLabelText("Description").type("this is a description of baseB.");
     cy.get('[data-testid="add-block-button-top"]').click();
     cy.get('[data-testid="add-block-dropdown"]').findByText("Comment").click();
-    cy.get(".datablock-content div").first().type("a comment is added here.");
+    cy.get(".datablock-content [contenteditable]").first().type("a comment is added here.");
 
     cy.findByLabelText("Procedure").type("a description of the synthesis here");
 

--- a/webapp/cypress/e2e/editPage.cy.js
+++ b/webapp/cypress/e2e/editPage.cy.js
@@ -325,7 +325,7 @@ describe("Edit Page", () => {
 
     cy.get('[data-testid="add-block-button-top"]').click();
     cy.get('[data-testid="add-block-dropdown"]').contains("Media").click();
-    cy.findAllByText("Select a file:").eq(0).should("exist");
+    cy.findAllByText("Select a file").eq(0).should("exist");
     cy.get("select.file-select-dropdown").eq(0).select(test_fname);
 
     // Check that the img with id "media-block-img" is present
@@ -342,7 +342,7 @@ describe("Edit Page", () => {
 
     cy.get('[data-testid="add-block-button-top"]').click();
     cy.get('[data-testid="add-block-dropdown"]').contains("Media").click();
-    cy.findAllByText("Select a file:").eq(1).should("exist");
+    cy.findAllByText("Select a file").eq(1).should("exist");
     cy.get("select.file-select-dropdown").eq(1).select(test_fname);
 
     // Check that the SVG is displayed
@@ -368,7 +368,7 @@ describe("Edit Page", () => {
 
     cy.get('[data-testid="add-block-button-top"]').click();
     cy.get('[data-testid="add-block-dropdown"]').contains("Raman spectroscopy").click();
-    cy.findAllByText("Select a file:").eq(2).should("exist");
+    cy.findAllByText("Select a file").eq(2).should("exist");
     cy.get("select.file-select-dropdown")
       .eq(2)
       .select("example_data_raman_labspec_raman_example.txt");
@@ -431,7 +431,7 @@ describe("Edit Page", () => {
 
     cy.wait(1000);
     cy.get(".data-block").should("exist");
-    cy.findAllByText("Select a file:").should("exist");
+    cy.findAllByText("Select a file").should("exist");
   });
 
   it("Verifies bottom and top 'Add a block' dropdowns work independently", () => {

--- a/webapp/cypress/e2e/editPage.cy.js
+++ b/webapp/cypress/e2e/editPage.cy.js
@@ -226,15 +226,17 @@ describe("Edit Page", () => {
 
     cy.contains("Unsaved changes").should("not.exist");
 
-    cy.get(".datablock-content div").eq(0).type("the first comment box");
+    cy.get(".datablock-content [contenteditable]").eq(0).type("the first comment box");
     cy.contains("Unsaved changes");
 
     // click update block icon and make sure unsaved changes warning goes away
     cy.get('.datablock-header [aria-label="updateBlock"]').eq(0).click();
     cy.contains("Unsaved changes").should("not.exist");
-    cy.get(".datablock-content div").eq(0).contains("the first comment box");
+    cy.get(".datablock-content [contenteditable]").eq(0).contains("the first comment box");
 
-    cy.get(".datablock-content div").eq(0).type("\nThe first comment box; further changes.");
+    cy.get(".datablock-content [contenteditable]")
+      .eq(0)
+      .type("\nThe first comment box; further changes.");
     cy.contains("Unsaved changes");
 
     cy.get('[data-testid="block-description"]').first().find(".ProseMirror").click();

--- a/webapp/cypress/e2e/equipment.cy.js
+++ b/webapp/cypress/e2e/equipment.cy.js
@@ -147,7 +147,7 @@ describe("Equipment edit page", () => {
     cy.get('[data-testid="add-block-button-top"]').click();
     cy.get('[data-testid="add-block-dropdown"]').findByText("Comment").click();
 
-    cy.get(".datablock-content div").first().type("a comment is added here.");
+    cy.get(".datablock-content [contenteditable]").first().type("a comment is added here.");
 
     cy.get(".fa-save").click();
     cy.visit("/equipment");

--- a/webapp/cypress/e2e/sampleTablePage.cy.js
+++ b/webapp/cypress/e2e/sampleTablePage.cy.js
@@ -245,7 +245,7 @@ describe("Advanced sample creation features", () => {
     cy.get('[data-testid="add-block-button-top"]').click();
     cy.get('[data-testid="add-block-dropdown"]').findByText("Comment").click();
 
-    cy.get(".datablock-content div").first().type("a comment is added here.");
+    cy.get(".datablock-content [contenteditable]").first().type("a comment is added here.");
     cy.expandIfCollapsed("[data-testid=synthesis-block]");
     cy.get("#synthesis-information .vs__search").first().type("component3");
     cy.get(".vs__dropdown-menu").contains(".badge", "component3").click();

--- a/webapp/src/components/FileSelectDropdown.vue
+++ b/webapp/src/components/FileSelectDropdown.vue
@@ -1,7 +1,11 @@
 <template>
-  <div class="form-group form-inline">
-    <label class="mr-4"><b>Select a file:</b></label>
-    <select class="form-control file-select-dropdown" :value="localModelValue" @input="handleInput">
+  <div class="block-control">
+    <label class="block-control-label">Select a file</label>
+    <select
+      class="custom-select custom-select-sm file-select-dropdown"
+      :value="localModelValue"
+      @input="handleInput"
+    >
       <option v-if="defaultToAllFiles" value="null">All compatible files</option>
       <option v-for="file_id in available_file_ids" :key="file_id" :value="file_id">
         {{ all_files_name(file_id) }}
@@ -15,7 +19,7 @@
       </option>
     </select>
 
-    <span v-if="all_files[modelValue] && all_files[modelValue].is_live" class="ml-2">
+    <span v-if="all_files[modelValue] && all_files[modelValue].is_live" class="live-badge">
       <b>Live</b> (last updated: {{ lastModified }})
     </span>
   </div>
@@ -116,7 +120,31 @@ export default {
 </script>
 
 <style scoped>
+/* Label above the control rather than inline, so that the block controls line
+   up with one another regardless of how long each label is. */
+.block-control {
+  display: inline-flex;
+  flex-direction: column;
+  vertical-align: top;
+}
+
+.block-control-label {
+  margin-bottom: 0.15rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: #6c757d;
+}
+
 .file-select-dropdown {
   min-width: 20rem;
+  max-width: 100%;
+}
+
+.live-badge {
+  margin-top: 0.15rem;
+  font-size: 0.8rem;
+  color: #6c757d;
 }
 </style>

--- a/webapp/src/components/MetadataViewer.vue
+++ b/webapp/src/components/MetadataViewer.vue
@@ -1,0 +1,78 @@
+<template>
+  <div v-if="displayedMetadata && Object.keys(displayedMetadata).length > 0">
+    <table class="table table-sm">
+      <tbody>
+        <tr v-for="(value, key) in displayedMetadata" :key="key">
+          <th scope="row">{{ formatLabel(key) }}</th>
+          <td>{{ formatValue(key, value) }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    metadata: {
+      type: Object,
+      default: () => ({}),
+    },
+    labels: {
+      type: Object,
+      default: () => ({}),
+    },
+    excludeKeys: {
+      type: Array,
+      default: () => [],
+    },
+  },
+  computed: {
+    displayedMetadata() {
+      if (!this.metadata) return {};
+
+      const filtered = {};
+      for (const [key, value] of Object.entries(this.metadata)) {
+        if (!this.excludeKeys.includes(key) && value !== null && value !== undefined) {
+          filtered[key] = value;
+        }
+      }
+      return filtered;
+    },
+  },
+  methods: {
+    formatLabel(key) {
+      if (this.labels[key]) {
+        return this.labels[key];
+      }
+
+      return key
+        .replace(/_/g, " ")
+        .replace(/([A-Z])/g, " $1")
+        .trim()
+        .replace(/^\w/, (c) => c.toUpperCase());
+    },
+    formatValue(key, value) {
+      if (value === null || value === undefined) {
+        return "";
+      }
+
+      if (typeof value === "object") {
+        if (Array.isArray(value)) {
+          return value.join(", ");
+        }
+        return JSON.stringify(value);
+      }
+
+      return value;
+    },
+  },
+};
+</script>
+
+<style scoped>
+th {
+  color: #454545;
+  font-weight: 500;
+}
+</style>

--- a/webapp/src/components/MetadataViewer.vue
+++ b/webapp/src/components/MetadataViewer.vue
@@ -1,17 +1,38 @@
 <template>
-  <div v-if="displayedMetadata && Object.keys(displayedMetadata).length > 0">
-    <table class="table table-sm">
-      <tbody>
-        <tr v-for="(value, key) in displayedMetadata" :key="key">
-          <th scope="row">{{ formatLabel(key) }}</th>
-          <td>{{ formatValue(key, value) }}</td>
-        </tr>
-      </tbody>
-    </table>
+  <div v-if="hasMetadata" class="metadata-viewer">
+    <div class="metadata-header">
+      <span class="metadata-title">Metadata</span>
+      <button
+        type="button"
+        class="btn btn-sm btn-outline-secondary copy-button"
+        :aria-label="copied ? 'Metadata copied' : 'Copy metadata as JSON'"
+        @click="copyAsJson"
+      >
+        <font-awesome-icon :icon="copied ? 'check' : 'copy'" fixed-width />
+        {{ copied ? "Copied" : "Copy JSON" }}
+      </button>
+    </div>
+
+    <dl class="metadata-list">
+      <template v-for="(value, key) in displayedMetadata" :key="key">
+        <dt :title="String(key)">{{ formatLabel(key) }}</dt>
+        <dd>
+          <details v-if="isExpandable(value)" class="value-details">
+            <summary>{{ summaryFor(value) }}</summary>
+            <pre class="value-json">{{ prettyPrint(value) }}</pre>
+          </details>
+          <span v-else class="value">{{ formatValue(value) }}</span>
+        </dd>
+      </template>
+    </dl>
   </div>
 </template>
 
 <script>
+// Values longer than this are collapsed behind a <details> rather than being
+// allowed to dominate what is usually a narrow column beside a plot.
+const INLINE_LENGTH_LIMIT = 80;
+
 export default {
   props: {
     metadata: {
@@ -27,6 +48,12 @@ export default {
       default: () => [],
     },
   },
+  data() {
+    return {
+      copied: false,
+      copyResetTimeout: null,
+    };
+  },
   computed: {
     displayedMetadata() {
       if (!this.metadata) return {};
@@ -39,6 +66,12 @@ export default {
       }
       return filtered;
     },
+    hasMetadata() {
+      return Object.keys(this.displayedMetadata).length > 0;
+    },
+  },
+  beforeUnmount() {
+    clearTimeout(this.copyResetTimeout);
   },
   methods: {
     formatLabel(key) {
@@ -46,33 +79,144 @@ export default {
         return this.labels[key];
       }
 
-      return key
-        .replace(/_/g, " ")
-        .replace(/([A-Z])/g, " $1")
-        .trim()
-        .replace(/^\w/, (c) => c.toUpperCase());
+      return (
+        key
+          .replace(/_/g, " ")
+          // Split camelCase only at a lowercase/digit -> uppercase boundary, so
+          // that unit acronyms such as `MHz` or `ppm` survive intact.
+          .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+          .trim()
+          .replace(/^\w/, (c) => c.toUpperCase())
+      );
     },
-    formatValue(key, value) {
+    isExpandable(value) {
+      if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+        return true;
+      }
+      return this.formatValue(value).length > INLINE_LENGTH_LIMIT;
+    },
+    summaryFor(value) {
+      if (Array.isArray(value)) {
+        return `${value.length} item${value.length === 1 ? "" : "s"}`;
+      }
+      if (value !== null && typeof value === "object") {
+        const n = Object.keys(value).length;
+        return `${n} field${n === 1 ? "" : "s"}`;
+      }
+      return `${this.formatValue(value).slice(0, INLINE_LENGTH_LIMIT)}…`;
+    },
+    prettyPrint(value) {
+      if (typeof value === "object") {
+        return JSON.stringify(value, null, 2);
+      }
+      return String(value);
+    },
+    formatValue(value) {
       if (value === null || value === undefined) {
         return "";
       }
-
+      if (Array.isArray(value)) {
+        return value.join(", ");
+      }
       if (typeof value === "object") {
-        if (Array.isArray(value)) {
-          return value.join(", ");
-        }
         return JSON.stringify(value);
       }
-
-      return value;
+      return String(value);
+    },
+    async copyAsJson() {
+      try {
+        await navigator.clipboard.writeText(JSON.stringify(this.displayedMetadata, null, 2));
+        this.copied = true;
+        clearTimeout(this.copyResetTimeout);
+        this.copyResetTimeout = setTimeout(() => {
+          this.copied = false;
+        }, 2000);
+      } catch (error) {
+        console.error("Could not copy metadata to the clipboard:", error);
+      }
     },
   },
 };
 </script>
 
 <style scoped>
-th {
+/* A light container so the metadata reads as a distinct panel beside the plot,
+   without competing with it. The inner JSON blocks use a grey fill, so this
+   stays white to keep them legible against it. */
+.metadata-viewer {
+  padding: 0.75rem 1rem;
+  background-color: #fff;
+  border: 1px solid #e9ecef;
+  border-radius: 0.35rem;
+}
+
+.metadata-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.75rem;
+  border-bottom: 1px solid #f1f3f5;
+}
+
+.metadata-title {
+  font-weight: 600;
   color: #454545;
+}
+
+.copy-button {
+  white-space: nowrap;
+}
+
+/* A definition list rather than a table: labels sit above their values, which
+   keeps long values readable in the narrow column beside a plot. */
+.metadata-list {
+  margin-bottom: 0;
+  /* Blocks can expose hundreds of fields (e.g. raw acquisition parameters), so
+     scroll the list rather than letting the panel run far past the plot. The
+     header sits outside this box, keeping the copy button always reachable. */
+  max-height: 30rem;
+  overflow-y: auto;
+  /* Keeps values clear of the scrollbar when one appears. */
+  padding-right: 0.35rem;
+}
+
+.metadata-list dt {
+  font-size: 0.8rem;
   font-weight: 500;
+  color: #6c757d;
+  margin-top: 0.6rem;
+}
+
+.metadata-list dt:first-child {
+  margin-top: 0;
+}
+
+.metadata-list dd {
+  margin-bottom: 0;
+  /* Long unbroken values (paths, encoded strings) must not force the column
+     wider than its container. */
+  overflow-wrap: anywhere;
+}
+
+.value-details summary {
+  cursor: pointer;
+  color: #6c757d;
+}
+
+.value-details summary:hover {
+  color: cornflowerblue;
+}
+
+.value-json {
+  margin: 0.35rem 0 0;
+  padding: 0.5rem;
+  max-height: 16rem;
+  overflow: auto;
+  font-size: 0.78rem;
+  background-color: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 0.25rem;
 }
 </style>

--- a/webapp/src/components/StyledTooltip.vue
+++ b/webapp/src/components/StyledTooltip.vue
@@ -35,11 +35,19 @@ export default {
       type: String,
       default: "",
     },
+    // When set, clicking (or pressing enter on) the anchor pins the tooltip
+    // open so that it survives the pointer leaving, until it is clicked again
+    // or the user clicks elsewhere.
+    pinnable: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {
       tooltipTimeout: null,
       popperInstance: null,
+      pinned: false,
     };
   },
   mounted() {
@@ -64,8 +72,13 @@ export default {
     anchor.addEventListener("focusin", this.delayedShowTooltip);
     anchor.addEventListener("focusout", this.hideTooltip);
 
+    if (this.pinnable) {
+      anchor.addEventListener("click", this.togglePinned);
+      anchor.addEventListener("keyup", this.handleAnchorKeyup);
+    }
+
     document.addEventListener("mousedown", this.handleClickOutside);
-    window.addEventListener("scroll", this.hideTooltip, true);
+    window.addEventListener("scroll", this.forceHideTooltip, true);
   },
   beforeUnmount() {
     const anchor = this.$refs.anchor;
@@ -74,13 +87,15 @@ export default {
       anchor.removeEventListener("mouseleave", this.hideTooltip);
       anchor.removeEventListener("focusin", this.delayedShowTooltip);
       anchor.removeEventListener("focusout", this.hideTooltip);
+      anchor.removeEventListener("click", this.togglePinned);
+      anchor.removeEventListener("keyup", this.handleAnchorKeyup);
     }
     if (this.popperInstance) {
       this.popperInstance.destroy();
     }
 
     document.removeEventListener("mousedown", this.handleClickOutside);
-    window.removeEventListener("scroll", this.hideTooltip, true);
+    window.removeEventListener("scroll", this.forceHideTooltip, true);
   },
   methods: {
     delayedShowTooltip() {
@@ -91,10 +106,37 @@ export default {
         }
       }, this.delay);
     },
+    showTooltip() {
+      clearTimeout(this.tooltipTimeout);
+      if (this.$refs.tooltipContent && this.popperInstance) {
+        this.$refs.tooltipContent.setAttribute("data-show", "");
+        this.popperInstance.update();
+      }
+    },
     hideTooltip() {
+      // A pinned tooltip ignores the pointer leaving; it is dismissed by
+      // clicking the anchor again or clicking outside.
+      if (this.pinned) return;
+      this.forceHideTooltip();
+    },
+    forceHideTooltip() {
+      this.pinned = false;
       clearTimeout(this.tooltipTimeout);
       if (this.$refs.tooltipContent) {
         this.$refs.tooltipContent.removeAttribute("data-show");
+      }
+    },
+    togglePinned() {
+      this.pinned = !this.pinned;
+      if (this.pinned) {
+        this.showTooltip();
+      } else {
+        this.forceHideTooltip();
+      }
+    },
+    handleAnchorKeyup(event) {
+      if (event.key === "Enter" || event.key === " ") {
+        this.togglePinned();
       }
     },
     handleClickOutside(event) {
@@ -104,7 +146,7 @@ export default {
       if (!anchor || !tooltip) return;
 
       if (!anchor.contains(event.target) && !tooltip.contains(event.target)) {
-        this.hideTooltip();
+        this.forceHideTooltip();
       }
     },
   },

--- a/webapp/src/components/TooltipIcon.vue
+++ b/webapp/src/components/TooltipIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <StyledTooltip :delay="500">
+  <StyledTooltip :delay="500" pinnable>
     <template #anchor>
       <font-awesome-icon :icon="['fas', 'info-circle']" class="info-icon" tabindex="0" />
     </template>

--- a/webapp/src/components/datablocks/BokehBlock.vue
+++ b/webapp/src/components/datablocks/BokehBlock.vue
@@ -1,31 +1,33 @@
 <template>
-  <!-- think about elegant two-way binding to DataBlockBase... or, just pass all the block data into
-DataBlockBase as a prop, and save from within DataBlockBase  -->
   <DataBlockBase :item_id="item_id" :block_id="block_id">
-    <div v-if="multiFileBlock">
-      <FileMultiSelect
-        v-model="file_ids"
-        :item_id="item_id"
-        :block_id="block_id"
-        :extensions="blockInfo?.attributes?.accepted_file_extensions"
-        :main-label="'Select and order files'"
-        fallback-to-single-file-id
-        update-block-on-change
-      />
-    </div>
-    <div v-else>
-      <FileSelectDropdown
-        v-model="file_id"
-        :item_id="item_id"
-        :block_id="block_id"
-        :extensions="blockInfo?.attributes?.accepted_file_extensions"
-        update-block-on-change
-      />
-    </div>
+    <template #controls>
+      <div v-if="multiFileBlock">
+        <FileMultiSelect
+          v-model="file_ids"
+          :item_id="item_id"
+          :block_id="block_id"
+          :extensions="blockInfo?.attributes?.accepted_file_extensions"
+          :main-label="'Select and order files'"
+          fallback-to-single-file-id
+          update-block-on-change
+        />
+      </div>
+      <div v-else>
+        <FileSelectDropdown
+          v-model="file_id"
+          :item_id="item_id"
+          :block_id="block_id"
+          :extensions="blockInfo?.attributes?.accepted_file_extensions"
+          update-block-on-change
+        />
+      </div>
+    </template>
 
-    <div id="bokehPlotContainer" class="limited-width">
-      <BokehPlot :bokeh-plot-data="bokehPlotData" />
-    </div>
+    <template #plot>
+      <div id="bokehPlotContainer" class="limited-width">
+        <BokehPlot :bokeh-plot-data="bokehPlotData" />
+      </div>
+    </template>
   </DataBlockBase>
 </template>
 

--- a/webapp/src/components/datablocks/CycleBlock.vue
+++ b/webapp/src/components/datablocks/CycleBlock.vue
@@ -41,7 +41,13 @@
       :show-apply-button="false"
     />
     <div class="form-row mt-2 mb-3">
-      <button class="btn btn-primary btn-sm" @click="applyAllSelections">Apply Changes</button>
+      <button
+        class="btn btn-primary btn-sm"
+        :disabled="!hasPendingChanges"
+        @click="applyAllSelections"
+      >
+        Apply Changes
+      </button>
       <a v-if="bdf_url" :href="api_url + bdf_url" class="btn btn-secondary btn-sm ml-2" download
         >Export CSV (BDF)</a
       >
@@ -67,10 +73,25 @@
             "
           />
           <span id="list-of-cycles" class="pl-3 pt-2">Showing cycles: {{ parsedCycles }}</span>
+          <a
+            type="button"
+            class="btn btn-default btn-sm ml-2"
+            aria-label="Toggle description of cycle selection"
+            @click="showCyclesDescription = !showCyclesDescription"
+          >
+            ?
+          </a>
         </div>
 
         <div v-if="cycle_num_error" class="alert alert-danger mt-2 mx-auto">
           {{ cycle_num_error }}
+        </div>
+
+        <div v-show="showCyclesDescription" class="alert alert-info mt-2 mx-auto">
+          <p>
+            Specify which cycles to plot. Use commas to separate individual cycles and hyphens for
+            ranges. Leave empty or type 'all' to plot all cycles.
+          </p>
         </div>
       </div>
 
@@ -129,13 +150,15 @@
             step="0.2"
             @change="isReplotButtonDisplayed = true"
           />
-          <label
-            for="s_spline"
-            @mouseover="showDescription1 = true"
-            @mouseleave="showDescription1 = false"
+          <label for="s_spline"> <span>Spline fit:</span> {{ -s_spline }} </label>
+          <a
+            type="button"
+            class="btn btn-default btn-sm ml-2"
+            aria-label="Toggle description of spline fit"
+            @click="showDescription1 = !showDescription1"
           >
-            <span>Spline fit:</span> {{ -s_spline }}
-          </label>
+            ?
+          </a>
         </div>
         <div class="col-md slider" style="max-width: 250px">
           <input
@@ -148,13 +171,15 @@
             max="1501"
             @change="isReplotButtonDisplayed = true"
           />
-          <label
-            for="win_size_1"
-            @mouseover="showDescription2 = true"
-            @mouseleave="showDescription2 = false"
+          <label for="win_size_1"> <span>Window Size 1:</span> {{ win_size_1 }} </label>
+          <a
+            type="button"
+            class="btn btn-default btn-sm ml-2"
+            aria-label="Toggle description of window size"
+            @click="showDescription2 = !showDescription2"
           >
-            <span>Window Size 1:</span> {{ win_size_1 }}
-          </label>
+            ?
+          </a>
         </div>
         <button v-show="isReplotButtonDisplayed" class="btn btn-default my-4" @click="updateBlock">
           Recalculate
@@ -231,7 +256,8 @@ export default {
       cycle_num_error: "",
       cyclesString: "",
 
-      // UI state for tooltips and plot display
+      // UI state for tooltips and plot display (toggled by the "?" buttons)
+      showCyclesDescription: false,
       showDescription1: false,
       showDescription2: false,
       bokehPlotLimitedWidth: true,
@@ -281,6 +307,19 @@ export default {
         }
       },
     },
+    /**
+     * True when the staged file/comparison selections differ from what is applied,
+     * used to enable the "Apply Changes" button
+     */
+    hasPendingChanges() {
+      const applied = this.file_ids || [];
+      if (this.mode === FILE_MODE.MULTI) {
+        if (!this.sameIds(this.pending_file_ids, applied)) return true;
+      } else if ((this.pending_single_file_id || null) !== (applied[0] || null)) {
+        return true;
+      }
+      return !this.sameIds(this.pending_comparison_file_ids, this.comparison_file_ids || []);
+    },
     // normalizingMass() {
     //   return this.$store.all_item_data[this.item_id]["characteristic_mass"] || null;
     // },
@@ -310,6 +349,13 @@ export default {
     this.initializeComparisonFiles();
   },
   methods: {
+    /**
+     * Order-sensitive comparison of two lists of file IDs
+     */
+    sameIds(a, b) {
+      return a.length === b.length && a.every((id, index) => id === b[index]);
+    },
+
     /**
      * Initialize mode to default if not set
      */

--- a/webapp/src/components/datablocks/CycleBlock.vue
+++ b/webapp/src/components/datablocks/CycleBlock.vue
@@ -73,25 +73,25 @@
             "
           />
           <span id="list-of-cycles" class="pl-3 pt-2">Showing cycles: {{ parsedCycles }}</span>
-          <a
-            type="button"
-            class="btn btn-default btn-sm ml-2"
-            aria-label="Toggle description of cycle selection"
-            @click="showCyclesDescription = !showCyclesDescription"
-          >
-            ?
-          </a>
+          <StyledTooltip anchor-class="info-anchor" :delay="300" pinnable>
+            <template #anchor>
+              <font-awesome-icon
+                :icon="['fas', 'info-circle']"
+                class="info-icon"
+                role="button"
+                tabindex="0"
+                aria-label="Toggle description of cycle selection"
+              />
+            </template>
+            <template #content>
+              Specify which cycles to plot. Use commas to separate individual cycles and hyphens for
+              ranges. Leave empty or type 'all' to plot all cycles.
+            </template>
+          </StyledTooltip>
         </div>
 
         <div v-if="cycle_num_error" class="alert alert-danger mt-2 mx-auto">
           {{ cycle_num_error }}
-        </div>
-
-        <div v-show="showCyclesDescription" class="alert alert-info mt-2 mx-auto">
-          <p>
-            Specify which cycles to plot. Use commas to separate individual cycles and hyphens for
-            ranges. Leave empty or type 'all' to plot all cycles.
-          </p>
         </div>
       </div>
 
@@ -151,14 +151,21 @@
             @change="isReplotButtonDisplayed = true"
           />
           <label for="s_spline"> <span>Spline fit:</span> {{ -s_spline }} </label>
-          <a
-            type="button"
-            class="btn btn-default btn-sm ml-2"
-            aria-label="Toggle description of spline fit"
-            @click="showDescription1 = !showDescription1"
-          >
-            ?
-          </a>
+          <StyledTooltip anchor-class="info-anchor" :delay="300" pinnable>
+            <template #anchor>
+              <font-awesome-icon
+                :icon="['fas', 'info-circle']"
+                class="info-icon"
+                role="button"
+                tabindex="0"
+                aria-label="Toggle description of spline fit"
+              />
+            </template>
+            <template #content>
+              Smoothing parameter that determines how close the spline fits to the real data. Larger
+              values result in a smoother fit with decreased detail.
+            </template>
+          </StyledTooltip>
         </div>
         <div class="col-md slider" style="max-width: 250px">
           <input
@@ -172,28 +179,24 @@
             @change="isReplotButtonDisplayed = true"
           />
           <label for="win_size_1"> <span>Window Size 1:</span> {{ win_size_1 }} </label>
-          <a
-            type="button"
-            class="btn btn-default btn-sm ml-2"
-            aria-label="Toggle description of window size"
-            @click="showDescription2 = !showDescription2"
-          >
-            ?
-          </a>
+          <StyledTooltip anchor-class="info-anchor" :delay="300" pinnable>
+            <template #anchor>
+              <font-awesome-icon
+                :icon="['fas', 'info-circle']"
+                class="info-icon"
+                role="button"
+                tabindex="0"
+                aria-label="Toggle description of window size"
+              />
+            </template>
+            <template #content>
+              Window size for the Savitzky-Golay filter to apply to the derivatives.
+            </template>
+          </StyledTooltip>
         </div>
         <button v-show="isReplotButtonDisplayed" class="btn btn-default my-4" @click="updateBlock">
           Recalculate
         </button>
-      </div>
-
-      <div v-show="showDescription1" class="alert alert-info">
-        <p>
-          Smoothing parameter that determines how close the spline fits to the real data. Larger
-          values result in a smoother fit with decreased detail.
-        </p>
-      </div>
-      <div v-show="showDescription2" class="alert alert-info">
-        <p>Window size for the Savitzky-Golay filter to apply to the derivatives.</p>
       </div>
 
       <div class="row mt-2">
@@ -214,6 +217,7 @@ import FileSelectDropdown from "@/components/FileSelectDropdown";
 import FileMultiSelect from "@/components/FileMultiSelect";
 import BokehPlot from "@/components/BokehPlot";
 import CollapsibleComparisonFileSelect from "@/components/CollapsibleComparisonFileSelect";
+import StyledTooltip from "@/components/StyledTooltip";
 
 import { updateBlockFromServer } from "@/server_fetch_utils.js";
 import { createComputedSetterForBlockField } from "@/field_utils.js";
@@ -232,6 +236,7 @@ export default {
     FileMultiSelect,
     BokehPlot,
     CollapsibleComparisonFileSelect,
+    StyledTooltip,
   },
   props: {
     item_id: {
@@ -257,9 +262,6 @@ export default {
       cyclesString: "",
 
       // UI state for tooltips and plot display (toggled by the "?" buttons)
-      showCyclesDescription: false,
-      showDescription1: false,
-      showDescription2: false,
       bokehPlotLimitedWidth: true,
       isReplotButtonDisplayed: false,
 
@@ -549,7 +551,24 @@ export default {
 }
 
 .slider span {
-  border-bottom: 2px dotted #0c5460;
   text-decoration: none;
+}
+
+/* Keep the icon centred against the input rather than stretching with the
+   flex row of `.input-group`, which left it sitting high next to the label. */
+::v-deep(.info-anchor) {
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+  margin-left: 0.5rem;
+}
+
+/* Matches the info icon used in the block header (see TooltipIcon.vue) */
+.info-icon {
+  cursor: pointer;
+}
+
+.info-icon:hover {
+  color: cornflowerblue;
 }
 </style>

--- a/webapp/src/components/datablocks/DataBlockBase.vue
+++ b/webapp/src/components/datablocks/DataBlockBase.vue
@@ -172,7 +172,9 @@
         </div>
 
         <div v-if="hasMetadata && metadataShown" class="col-xl-3 col-lg-3 col-md-12">
-          <MetadataViewer :metadata="block.metadata" />
+          <slot name="metadata" :metadata="block.metadata">
+            <MetadataViewer :metadata="block.metadata" />
+          </slot>
         </div>
       </div>
 

--- a/webapp/src/components/datablocks/DataBlockBase.vue
+++ b/webapp/src/components/datablocks/DataBlockBase.vue
@@ -148,6 +148,34 @@
           </div>
         </div>
       </div>
+      <slot name="controls"></slot>
+
+      <div class="mt-2 mb-2">
+        <button
+          class="btn btn-sm btn-outline-secondary"
+          :disabled="!hasMetadata"
+          @click="metadataShown = !metadataShown"
+        >
+          {{ metadataShown ? "Hide metadata" : "Show metadata" }}
+        </button>
+      </div>
+
+      <div v-if="$slots.plot || hasMetadata" class="row mt-2">
+        <div
+          :class="
+            hasMetadata && metadataShown
+              ? 'col-xl-9 col-lg-9 col-md-12'
+              : 'col-xl-9 col-lg-10 col-md-11 mx-auto'
+          "
+        >
+          <slot name="plot"></slot>
+        </div>
+
+        <div v-if="hasMetadata && metadataShown" class="col-xl-3 col-lg-3 col-md-12">
+          <MetadataViewer :metadata="block.metadata" />
+        </div>
+      </div>
+
       <slot></slot>
       <TiptapInline v-model="BlockDescription" data-testid="block-description"></TiptapInline>
     </div>
@@ -167,6 +195,7 @@ import { DialogService } from "@/services/DialogService";
 import { createComputedSetterForBlockField } from "@/field_utils.js";
 import TiptapInline from "@/components/TiptapInline";
 import BlockTooltip from "@/components/BlockTooltip";
+import MetadataViewer from "@/components/MetadataViewer";
 
 import { deleteBlock, updateBlockFromServer } from "@/server_fetch_utils";
 
@@ -174,6 +203,7 @@ export default {
   components: {
     TiptapInline,
     BlockTooltip,
+    MetadataViewer,
   },
   props: {
     item_id: {
@@ -193,6 +223,7 @@ export default {
       isErrorsExpanded: true,
       isWarningsExpanded: true,
       isStagesExpanded: false,
+      metadataShown: false,
     };
   },
   computed: {
@@ -230,6 +261,9 @@ export default {
     latestStageMessage() {
       if (!this.processingStages || this.processingStages.length === 0) return "";
       return this.processingStages[this.processingStages.length - 1].message;
+    },
+    hasMetadata() {
+      return this.block?.metadata && Object.keys(this.block.metadata).length > 0;
     },
   },
   mounted() {

--- a/webapp/src/components/datablocks/DataBlockBase.vue
+++ b/webapp/src/components/datablocks/DataBlockBase.vue
@@ -150,28 +150,37 @@
       </div>
       <slot name="controls"></slot>
 
-      <div class="mt-2 mb-2">
-        <button
-          class="btn btn-sm btn-outline-secondary"
-          :disabled="!hasMetadata"
+      <div v-if="hasMetadata" class="mt-2 mb-2">
+        <span
+          class="metadata-toggle d-inline-flex align-items-center"
+          role="button"
+          tabindex="0"
+          :aria-expanded="metadataShown ? 'true' : 'false'"
           @click="metadataShown = !metadataShown"
+          @keyup.enter="metadataShown = !metadataShown"
         >
-          {{ metadataShown ? "Hide metadata" : "Show metadata" }}
-        </button>
+          <font-awesome-icon
+            :icon="['fas', 'chevron-right']"
+            fixed-width
+            class="collapse-arrow-sm mr-1"
+            :class="{ rotated: metadataShown }"
+          />
+          Metadata
+        </span>
       </div>
 
       <div v-if="$slots.plot || hasMetadata" class="row mt-2">
         <div
           :class="
             hasMetadata && metadataShown
-              ? 'col-xl-9 col-lg-9 col-md-12'
+              ? 'col-xl-8 col-lg-8 col-md-12'
               : 'col-xl-9 col-lg-10 col-md-11 mx-auto'
           "
         >
           <slot name="plot"></slot>
         </div>
 
-        <div v-if="hasMetadata && metadataShown" class="col-xl-3 col-lg-3 col-md-12">
+        <div v-if="hasMetadata && metadataShown" class="col-xl-4 col-lg-4 col-md-12">
           <slot name="metadata" :metadata="block.metadata">
             <MetadataViewer :metadata="block.metadata" />
           </slot>
@@ -225,8 +234,20 @@ export default {
       isErrorsExpanded: true,
       isWarningsExpanded: true,
       isStagesExpanded: false,
-      metadataShown: false,
+      metadataShown: true,
     };
+  },
+  watch: {
+    // Showing or hiding the metadata panel changes the width of the plot
+    // column. Bokeh lays its plots out once and only recomputes on a window
+    // resize, so without this the plot stays at its old width and is clipped
+    // until the user happens to resize the browser.
+    metadataShown() {
+      this.notifyLayoutChange();
+    },
+    hasMetadata() {
+      this.notifyLayoutChange();
+    },
   },
   computed: {
     block() {
@@ -283,6 +304,15 @@ export default {
     document.removeEventListener("block-event", this.handleBokehEvent);
   },
   methods: {
+    notifyLayoutChange() {
+      // Wait for the DOM update and then for the browser to apply the new
+      // column widths, otherwise Bokeh re-measures against the old layout.
+      this.$nextTick(() => {
+        window.requestAnimationFrame(() => {
+          window.dispatchEvent(new Event("resize"));
+        });
+      });
+    },
     formatStageTime(timestamp) {
       const d = new Date(timestamp);
       return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
@@ -467,6 +497,16 @@ ul {
   -webkit-transform: rotate(90deg);
   -moz-transform: rotate(90deg);
   transform: rotate(90deg);
+}
+
+.metadata-toggle {
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: #6c757d;
+}
+
+.metadata-toggle:hover {
+  color: #004175;
 }
 
 .collapse-arrow-sm {

--- a/webapp/src/components/datablocks/NMRBlock.vue
+++ b/webapp/src/components/datablocks/NMRBlock.vue
@@ -2,128 +2,128 @@
   <!-- think about elegant two-way binding to DataBlockBase... or, just pass all the block data into
 DataBlockBase as a prop, and save from within DataBlockBase  -->
   <DataBlockBase :item_id="item_id" :block_id="block_id">
-    <FileSelectDropdown
-      v-model="file_id"
-      :item_id="item_id"
-      :block_id="block_id"
-      :extensions="blockInfo.attributes.accepted_file_extensions"
-      update-block-on-change
-    />
-    <div v-show="file_id">
-      <div class="form-inline mt-2">
-        <div class="form-group">
-          <label class="mr-2"><b>Process number:</b></label>
-          <select v-model="selected_process" class="form-control" @change="updateBlock">
-            <option v-for="process_number in block.available_processes" :key="process_number">
-              {{ process_number }}
-            </option>
-          </select>
+    <template #controls>
+      <FileSelectDropdown
+        v-model="file_id"
+        :item_id="item_id"
+        :block_id="block_id"
+        :extensions="blockInfo.attributes.accepted_file_extensions"
+        update-block-on-change
+      />
+      <div v-show="file_id">
+        <div class="form-inline mt-2">
+          <div class="form-group">
+            <label class="mr-2"><b>Process number:</b></label>
+            <select v-model="selected_process" class="form-control" @change="updateBlock">
+              <option v-for="process_number in block.available_processes" :key="process_number">
+                {{ process_number }}
+              </option>
+            </select>
+          </div>
+        </div>
+        <div class="form-inline mt-2">
+          <div class="form-group">
+            <label class="mr-2"><b>Experiment:</b></label>
+            <select v-model="selected_experiment" class="form-control" @change="updateBlock">
+              <option v-for="experiment in block.available_experiments" :key="experiment">
+                {{ experiment }}
+              </option>
+            </select>
+          </div>
+        </div>
+
+        <div class="mt-4">
+          <span class="mr-2">
+            <Isotope :isotope-string="metadata?.nucleus" /> {{ metadata?.pulse_program_name }}
+          </span>
+          <a type="button" class="btn btn-default btn-sm mb-2" @click="titleShown = !titleShown">{{
+            titleShown ? "hide title" : "show title"
+          }}</a>
+        </div>
+        <div v-if="titleShown" class="card mb-2">
+          <div class="card-body" style="white-space: pre">
+            {{ metadata?.topspin_title }}
+          </div>
         </div>
       </div>
-      <div class="form-inline mt-2">
-        <div class="form-group">
-          <label class="mr-2"><b>Experiment:</b></label>
-          <select v-model="selected_experiment" class="form-control" @change="updateBlock">
-            <option v-for="experiment in block.available_experiments" :key="experiment">
-              {{ experiment }}
-            </option>
-          </select>
-        </div>
+    </template>
+
+    <template #plot>
+      <div v-show="file_id" id="bokehPlotContainer">
+        <BokehPlot v-if="bokehPlotData" :bokeh-plot-data="bokehPlotData" />
       </div>
+    </template>
 
-      <div class="mt-4">
-        <span class="mr-2">
-          <Isotope :isotope-string="metadata?.nucleus" /> {{ metadata?.pulse_program_name }}
-        </span>
-        <a type="button" class="btn btn-default btn-sm mb-2" @click="titleShown = !titleShown">{{
-          titleShown ? "hide title" : "show title"
-        }}</a>
-        <a
-          type="button"
-          class="btn btn-default btn-sm mb-2 ml-2"
-          @click="detailsShown = !detailsShown"
-          >{{ detailsShown ? "hide measurement details" : "show measurement details" }}</a
-        >
-      </div>
-      <div v-if="titleShown" class="card mb-2">
-        <div class="card-body" style="white-space: pre">
-          {{ metadata?.topspin_title }}
-        </div>
-      </div>
-      <div class="row">
-        <div id="bokehPlotContainer" class="col-xl-8 col-lg-8 col-md-11 mx-auto">
-          <BokehPlot v-if="bokehPlotData" :bokeh-plot-data="bokehPlotData" />
-        </div>
-        <div v-if="detailsShown" class="col-xl-4 col-lg-4 ml-0">
-          <table class="table table-sm">
-            <tbody>
-              <tr>
-                <th scope="row">nucleus</th>
-                <td><Isotope :isotope-string="metadata?.nucleus" /></td>
-              </tr>
-              <tr>
-                <th scope="row">pulse program</th>
-                <td>{{ metadata?.pulse_program_name }}</td>
-              </tr>
-              <tr>
-                <th scope="row">Data shape</th>
-                <td>
-                  {{ metadata?.processed_data_shape }} (<i>d</i> =
-                  {{ metadata?.processed_data_shape.length }})
-                </td>
-              </tr>
-              <tr>
-                <th scope="row">probe</th>
-                <td>{{ metadata?.probe_name }} s</td>
-              </tr>
+    <template #metadata="{ metadata: blockMetadata }">
+      <table class="table table-sm">
+        <tbody>
+          <tr>
+            <th scope="row">nucleus</th>
+            <td><Isotope :isotope-string="blockMetadata?.nucleus" /></td>
+          </tr>
+          <tr>
+            <th scope="row">pulse program</th>
+            <td>{{ blockMetadata?.pulse_program_name }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Data shape</th>
+            <td>
+              {{ blockMetadata?.processed_data_shape }} (<i>d</i> =
+              {{ blockMetadata?.processed_data_shape.length }})
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">probe</th>
+            <td>{{ blockMetadata?.probe_name }} s</td>
+          </tr>
 
-              <tr>
-                <th scope="row"># of scans</th>
-                <td>{{ metadata?.nscans }}</td>
-              </tr>
+          <tr>
+            <th scope="row"># of scans</th>
+            <td>{{ blockMetadata?.nscans }}</td>
+          </tr>
 
-              <tr>
-                <th scope="row">recycle delay</th>
-                <td>{{ metadata?.recycle_delay }} s</td>
-              </tr>
+          <tr>
+            <th scope="row">recycle delay</th>
+            <td>{{ blockMetadata?.recycle_delay }} s</td>
+          </tr>
 
-              <tr>
-                <th scope="row">carrier frequency</th>
-                <td>{{ metadata?.carrier_frequency_MHz.toPrecision(4) }} MHz</td>
-              </tr>
+          <tr>
+            <th scope="row">carrier frequency</th>
+            <td>{{ blockMetadata?.carrier_frequency_MHz.toPrecision(4) }} MHz</td>
+          </tr>
 
-              <tr v-if="metadata?.carrier_offset_ppm">
-                <th scope="row">carrier offset</th>
-                <td>
-                  {{ metadata?.carrier_offset_ppm }}
-                  ppm
-                </td>
-              </tr>
+          <tr v-if="blockMetadata?.carrier_offset_ppm">
+            <th scope="row">carrier offset</th>
+            <td>
+              {{ blockMetadata?.carrier_offset_ppm }}
+              ppm
+            </td>
+          </tr>
 
-              <tr v-else>
-                <th scope="row">carrier offset</th>
-                <td>
-                  {{ (metadata?.carrier_offset_Hz / metadata?.carrier_frequency_MHz).toFixed(1) }}
-                  ppm
-                </td>
-              </tr>
+          <tr v-else>
+            <th scope="row">carrier offset</th>
+            <td>
+              {{
+                (blockMetadata?.carrier_offset_Hz / blockMetadata?.carrier_frequency_MHz).toFixed(1)
+              }}
+              ppm
+            </td>
+          </tr>
 
-              <tr v-if="metadata?.spectral_window_Hz">
-                <th scope="row">spectral window</th>
-                <td>
-                  {{ metadata?.spectral_window_Hz.toFixed(1) }}
-                  Hz
-                </td>
-              </tr>
-              <tr>
-                <th scope="row">cnst31</th>
-                <td>{{ metadata?.CNST31 }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
+          <tr v-if="blockMetadata?.spectral_window_Hz">
+            <th scope="row">spectral window</th>
+            <td>
+              {{ blockMetadata?.spectral_window_Hz.toFixed(1) }}
+              Hz
+            </td>
+          </tr>
+          <tr>
+            <th scope="row">cnst31</th>
+            <td>{{ blockMetadata?.CNST31 }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </template>
   </DataBlockBase>
 </template>
 
@@ -156,7 +156,6 @@ export default {
   data() {
     return {
       wavelengthParseError: "",
-      detailsShown: true,
       titleShown: false,
     };
   },

--- a/webapp/src/components/datablocks/NMRBlock.vue
+++ b/webapp/src/components/datablocks/NMRBlock.vue
@@ -11,20 +11,28 @@ DataBlockBase as a prop, and save from within DataBlockBase  -->
         update-block-on-change
       />
       <div v-show="file_id">
-        <div class="form-inline mt-2">
-          <div class="form-group">
-            <label class="mr-2"><b>Process number:</b></label>
-            <select v-model="selected_process" class="form-control" @change="updateBlock">
+        <div class="block-controls mt-2">
+          <div class="block-control">
+            <label class="block-control-label" for="nmr-process">Process number</label>
+            <select
+              id="nmr-process"
+              v-model="selected_process"
+              class="custom-select custom-select-sm"
+              @change="updateBlock"
+            >
               <option v-for="process_number in block.available_processes" :key="process_number">
                 {{ process_number }}
               </option>
             </select>
           </div>
-        </div>
-        <div class="form-inline mt-2">
-          <div class="form-group">
-            <label class="mr-2"><b>Experiment:</b></label>
-            <select v-model="selected_experiment" class="form-control" @change="updateBlock">
+          <div class="block-control">
+            <label class="block-control-label" for="nmr-experiment">Experiment</label>
+            <select
+              id="nmr-experiment"
+              v-model="selected_experiment"
+              class="custom-select custom-select-sm"
+              @change="updateBlock"
+            >
               <option v-for="experiment in block.available_experiments" :key="experiment">
                 {{ experiment }}
               </option>
@@ -32,17 +40,22 @@ DataBlockBase as a prop, and save from within DataBlockBase  -->
           </div>
         </div>
 
-        <div class="mt-4">
-          <span class="mr-2">
-            <Isotope :isotope-string="metadata?.nucleus" /> {{ metadata?.pulse_program_name }}
-          </span>
-          <a type="button" class="btn btn-default btn-sm mb-2" @click="titleShown = !titleShown">{{
-            titleShown ? "hide title" : "show title"
-          }}</a>
-        </div>
-        <div v-if="titleShown" class="card mb-2">
-          <div class="card-body" style="white-space: pre">
-            {{ metadata?.topspin_title }}
+        <div v-if="hasSummary" class="nmr-summary mt-4">
+          <div class="summary-fields">
+            <div v-if="metadata?.nucleus" class="summary-field">
+              <div class="summary-label">Nucleus</div>
+              <div class="summary-value summary-value-lg">
+                <Isotope :isotope-string="metadata.nucleus" />
+              </div>
+            </div>
+            <div v-if="metadata?.pulse_program_name" class="summary-field">
+              <div class="summary-label">Pulse program</div>
+              <div class="summary-value">{{ metadata.pulse_program_name }}</div>
+            </div>
+          </div>
+          <div v-if="metadata?.title" class="summary-field mt-3">
+            <div class="summary-label">Title</div>
+            <div class="summary-value nmr-title">{{ metadata.title }}</div>
           </div>
         </div>
       </div>
@@ -52,77 +65,6 @@ DataBlockBase as a prop, and save from within DataBlockBase  -->
       <div v-show="file_id" id="bokehPlotContainer">
         <BokehPlot v-if="bokehPlotData" :bokeh-plot-data="bokehPlotData" />
       </div>
-    </template>
-
-    <template #metadata="{ metadata: blockMetadata }">
-      <table class="table table-sm">
-        <tbody>
-          <tr>
-            <th scope="row">nucleus</th>
-            <td><Isotope :isotope-string="blockMetadata?.nucleus" /></td>
-          </tr>
-          <tr>
-            <th scope="row">pulse program</th>
-            <td>{{ blockMetadata?.pulse_program_name }}</td>
-          </tr>
-          <tr>
-            <th scope="row">Data shape</th>
-            <td>
-              {{ blockMetadata?.processed_data_shape }} (<i>d</i> =
-              {{ blockMetadata?.processed_data_shape.length }})
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">probe</th>
-            <td>{{ blockMetadata?.probe_name }} s</td>
-          </tr>
-
-          <tr>
-            <th scope="row"># of scans</th>
-            <td>{{ blockMetadata?.nscans }}</td>
-          </tr>
-
-          <tr>
-            <th scope="row">recycle delay</th>
-            <td>{{ blockMetadata?.recycle_delay }} s</td>
-          </tr>
-
-          <tr>
-            <th scope="row">carrier frequency</th>
-            <td>{{ blockMetadata?.carrier_frequency_MHz.toPrecision(4) }} MHz</td>
-          </tr>
-
-          <tr v-if="blockMetadata?.carrier_offset_ppm">
-            <th scope="row">carrier offset</th>
-            <td>
-              {{ blockMetadata?.carrier_offset_ppm }}
-              ppm
-            </td>
-          </tr>
-
-          <tr v-else>
-            <th scope="row">carrier offset</th>
-            <td>
-              {{
-                (blockMetadata?.carrier_offset_Hz / blockMetadata?.carrier_frequency_MHz).toFixed(1)
-              }}
-              ppm
-            </td>
-          </tr>
-
-          <tr v-if="blockMetadata?.spectral_window_Hz">
-            <th scope="row">spectral window</th>
-            <td>
-              {{ blockMetadata?.spectral_window_Hz.toFixed(1) }}
-              Hz
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">cnst31</th>
-            <td>{{ blockMetadata?.CNST31 }}</td>
-          </tr>
-        </tbody>
-      </table>
     </template>
   </DataBlockBase>
 </template>
@@ -156,7 +98,6 @@ export default {
   data() {
     return {
       wavelengthParseError: "",
-      titleShown: false,
     };
   },
   computed: {
@@ -165,6 +106,11 @@ export default {
     },
     metadata() {
       return this.$store.state.all_item_data[this.item_id]["blocks_obj"][this.block_id]?.metadata;
+    },
+    hasSummary() {
+      return Boolean(
+        this.metadata?.nucleus || this.metadata?.pulse_program_name || this.metadata?.title,
+      );
     },
     bokehPlotData() {
       return this.$store.state.all_item_data[this.item_id]["blocks_obj"][this.block_id]
@@ -192,6 +138,67 @@ export default {
 </script>
 
 <style scoped>
+/* Block controls sit in a wrapping row, each with its label above, so they line
+   up with the shared file selector regardless of label length. */
+.block-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.75rem 1.5rem;
+}
+
+.block-control {
+  display: flex;
+  flex-direction: column;
+}
+
+.block-control-label {
+  margin-bottom: 0.15rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: #6c757d;
+}
+
+.block-control select {
+  min-width: 8rem;
+}
+
+/* Headline acquisition parameters, shown above the plot so the fields that
+   identify the experiment are readable at a glance. Laid out as labelled
+   columns rather than a full-width table. */
+.summary-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem 2.5rem;
+}
+
+.summary-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: #6c757d;
+}
+
+.summary-value {
+  margin-top: 0.15rem;
+  color: #212529;
+}
+
+.summary-value-lg {
+  font-size: 1.5rem;
+  line-height: 1.2;
+}
+
+/* TopSpin titles are free text and often span several lines. */
+.nmr-title {
+  max-width: 40rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .attribute-label {
   color: grey;
 }

--- a/webapp/src/components/datablocks/NMRInsituBlock.vue
+++ b/webapp/src/components/datablocks/NMRInsituBlock.vue
@@ -1,104 +1,99 @@
 <template>
   <DataBlockBase :item_id="item_id" :block_id="block_id">
-    <FileSelectDropdown
-      v-model="file_id"
-      :item_id="item_id"
-      :block_id="block_id"
-      :extensions="blockInfo.attributes.accepted_file_extensions"
-      update-block-on-change
-      @change="onFileChange"
-    />
-    <div v-show="file_id">
-      <div class="row">
-        <div class="col-lg-6 col-md-6 col-sm-12 mb-2">
-          <label><b>NMR folder name</b></label>
-          <FolderSelect
-            v-model="nmr_folder_name"
-            :options="availableFolders"
-            @update:model-value="onFolderChanged"
-          />
+    <template #controls>
+      <FileSelectDropdown
+        v-model="file_id"
+        :item_id="item_id"
+        :block_id="block_id"
+        :extensions="blockInfo.attributes.accepted_file_extensions"
+        update-block-on-change
+        @change="onFileChange"
+      />
+      <div v-show="file_id">
+        <div class="row">
+          <div class="col-lg-6 col-md-6 col-sm-12 mb-2">
+            <label><b>NMR folder name</b></label>
+            <FolderSelect
+              v-model="nmr_folder_name"
+              :options="availableFolders"
+              @update:model-value="onFolderChanged"
+            />
+          </div>
+          <div class="col-lg-6 col-md-6 col-sm-12 mb-2">
+            <label><b>Echem folder name</b></label>
+            <FolderSelect
+              v-model="echem_folder_name"
+              :options="availableFolders"
+              @update:model-value="onFolderChanged"
+            />
+          </div>
         </div>
-        <div class="col-lg-6 col-md-6 col-sm-12 mb-2">
-          <label><b>Echem folder name</b></label>
-          <FolderSelect
-            v-model="echem_folder_name"
-            :options="availableFolders"
-            @update:model-value="onFolderChanged"
-          />
+
+        <div v-show="nmr_folder_name && echem_folder_name" class="row mt-2">
+          <div class="col-lg-3 col-md-6 col-sm-12 mb-2">
+            <label><b>Start Exp:</b></label>
+            <input
+              v-model.number="local_start_exp"
+              type="number"
+              class="form-control"
+              min="1"
+              :max="maxExperiments"
+              :placeholder="maxExperiments ? `1-${maxExperiments}` : '1'"
+              @input="onParameterChanged"
+            />
+          </div>
+
+          <div class="col-lg-3 col-md-6 col-sm-12 mb-2">
+            <label><b>End Exp:</b></label>
+            <input
+              v-model.number="local_end_exp"
+              type="number"
+              class="form-control"
+              min="1"
+              :max="maxExperiments"
+              :placeholder="maxExperiments ? `1-${maxExperiments}` : '1'"
+              @input="onParameterChanged"
+            />
+          </div>
+
+          <div class="col-lg-2 col-md-6 col-sm-12 mb-2">
+            <label><b>Step:</b></label>
+            <input
+              v-model.number="local_step_exp"
+              type="number"
+              class="form-control"
+              min="1"
+              @input="onParameterChanged"
+            />
+          </div>
+
+          <div class="col-lg-2 col-md-6 col-sm-12 mb-2">
+            <label><b>Exclude:</b></label>
+            <input
+              v-model="local_exclude_exp"
+              type="text"
+              class="form-control"
+              placeholder="e.g., 1,3,5"
+              @input="onParameterChanged"
+            />
+          </div>
+
+          <div class="col-lg-2 col-md-12 col-sm-12 mb-2 d-flex align-items-end">
+            <button class="btn btn-primary w-100" :disabled="buttonDisabled" @click="applyChanges">
+              {{ isUpdating ? "Updating..." : "Apply" }}
+            </button>
+          </div>
+        </div>
+
+        <div v-if="folderNameError || validationError" class="alert alert-danger mt-2 mx-auto">
+          {{ folderNameError || validationError }}
         </div>
       </div>
+    </template>
 
-      <div v-show="nmr_folder_name && echem_folder_name" class="row mt-2">
-        <div class="col-lg-3 col-md-6 col-sm-12 mb-2">
-          <label><b>Start Exp:</b></label>
-          <input
-            v-model.number="local_start_exp"
-            type="number"
-            class="form-control"
-            min="1"
-            :max="maxExperiments"
-            :placeholder="maxExperiments ? `1-${maxExperiments}` : '1'"
-            @input="onParameterChanged"
-          />
-        </div>
-
-        <div class="col-lg-3 col-md-6 col-sm-12 mb-2">
-          <label><b>End Exp:</b></label>
-          <input
-            v-model.number="local_end_exp"
-            type="number"
-            class="form-control"
-            min="1"
-            :max="maxExperiments"
-            :placeholder="maxExperiments ? `1-${maxExperiments}` : '1'"
-            @input="onParameterChanged"
-          />
-        </div>
-
-        <div class="col-lg-2 col-md-6 col-sm-12 mb-2">
-          <label><b>Step:</b></label>
-          <input
-            v-model.number="local_step_exp"
-            type="number"
-            class="form-control"
-            min="1"
-            @input="onParameterChanged"
-          />
-        </div>
-
-        <div class="col-lg-2 col-md-6 col-sm-12 mb-2">
-          <label><b>Exclude:</b></label>
-          <input
-            v-model="local_exclude_exp"
-            type="text"
-            class="form-control"
-            placeholder="e.g., 1,3,5"
-            @input="onParameterChanged"
-          />
-        </div>
-
-        <div class="col-lg-2 col-md-12 col-sm-12 mb-2 d-flex align-items-end">
-          <button class="btn btn-primary w-100" :disabled="buttonDisabled" @click="applyChanges">
-            {{ isUpdating ? "Updating..." : "Apply" }}
-          </button>
-        </div>
-      </div>
-
-      <div v-if="folderNameError || validationError" class="alert alert-danger mt-2 mx-auto">
-        {{ folderNameError || validationError }}
-      </div>
-    </div>
-    <div
-      v-show="nmr_folder_name && echem_folder_name"
-      class="row mt-2 text-center justify-content-center"
-    >
-      <div
-        id="bokehPlotContainer"
-        class="col-xl-10 col-lg-11 col-md-12 d-flex justify-content-center overflow-auto"
-      >
-        <BokehPlot :bokeh-plot-data="bokehPlotData" class="mw-100" />
-      </div>
-    </div>
+    <template #plot>
+      <BokehPlot :bokeh-plot-data="bokehPlotData" />
+    </template>
   </DataBlockBase>
 </template>
 

--- a/webapp/src/components/datablocks/UVVisInsituBlock.vue
+++ b/webapp/src/components/datablocks/UVVisInsituBlock.vue
@@ -1,86 +1,81 @@
 <template>
   <DataBlockBase :item_id="item_id" :block_id="block_id">
-    <FileSelectDropdown
-      v-model="file_id"
-      :item_id="item_id"
-      :block_id="block_id"
-      :extensions="blockInfo.attributes.accepted_file_extensions"
-      update-block-on-change
-      @change="onFileChange"
-    />
-    <div v-show="file_id">
-      <div class="row">
-        <div class="col-lg-4 col-md-6 col-sm-12 mb-2">
-          <label><b>UV-Vis folder name</b></label>
-          <FolderSelect
-            v-model="uvvis_folder_name"
-            :options="availableFolders"
-            @update:model-value="onFolderSelected"
-          />
+    <template #controls>
+      <FileSelectDropdown
+        v-model="file_id"
+        :item_id="item_id"
+        :block_id="block_id"
+        :extensions="blockInfo.attributes.accepted_file_extensions"
+        update-block-on-change
+        @change="onFileChange"
+      />
+      <div v-show="file_id">
+        <div class="row">
+          <div class="col-lg-4 col-md-6 col-sm-12 mb-2">
+            <label><b>UV-Vis folder name</b></label>
+            <FolderSelect
+              v-model="uvvis_folder_name"
+              :options="availableFolders"
+              @update:model-value="onFolderSelected"
+            />
+          </div>
+          <div class="col-lg-4 col-md-6 col-sm-12 mb-2">
+            <label><b>UV-Vis reference folder name</b></label>
+            <FolderSelect
+              v-model="uvvis_reference_folder_name"
+              :options="availableFolders"
+              @update:model-value="onFolderSelected"
+            />
+          </div>
+          <div class="col-lg-4 col-md-6 col-sm-12 mb-2">
+            <label><b>Echem folder name</b></label>
+            <FolderSelect
+              v-model="echem_folder_name"
+              :options="availableFolders"
+              @update:model-value="onFolderSelected"
+            />
+          </div>
         </div>
-        <div class="col-lg-4 col-md-6 col-sm-12 mb-2">
-          <label><b>UV-Vis reference folder name</b></label>
-          <FolderSelect
-            v-model="uvvis_reference_folder_name"
-            :options="availableFolders"
-            @update:model-value="onFolderSelected"
-          />
-        </div>
-        <div class="col-lg-4 col-md-6 col-sm-12 mb-2">
-          <label><b>Echem folder name</b></label>
-          <FolderSelect
-            v-model="echem_folder_name"
-            :options="availableFolders"
-            @update:model-value="onFolderSelected"
-          />
+        <div v-if="folderNameError" class="alert alert-danger mt-2 mx-auto">
+          {{ folderNameError }}
         </div>
       </div>
-      <div v-if="folderNameError" class="alert alert-danger mt-2 mx-auto">
-        {{ folderNameError }}
+      <div class="form-group mb-2">
+        <label class="mr-2"><b>Scan time (s)</b></label>
+        <input
+          v-model="scan_time_buffer"
+          type="text"
+          class="form-control"
+          placeholder="Enter scan time"
+          style="width: 160px; display: inline-block"
+          inputmode="decimal"
+          @change="onScanTimeSelected"
+        />
       </div>
-    </div>
-    <div class="form-group mb-2">
-      <label class="mr-2"><b>Scan time (s)</b></label>
-      <input
-        v-model="scan_time_buffer"
-        type="text"
-        class="form-control"
-        placeholder="Enter scan time"
-        style="width: 160px; display: inline-block"
-        inputmode="decimal"
-        pattern="[0-9]*[.,]?[0-9]*"
-        @keydown.enter="onScanTimeSelected"
-        @blur="onScanTimeSelected"
-      />
-    </div>
-    <div class="form-inline mb-2">
-      <label class="mr-2"><b>Data granularity</b></label>
-      <input
-        v-model="data_granularity_buffer"
-        type="text"
-        class="form-control mr-3"
-        style="width: 100px; display: inline-block"
-      />
-      <label class="mr-2"><b>Sample granularity</b></label>
-      <input
-        v-model="sample_granularity_buffer"
-        type="text"
-        class="form-control"
-        style="width: 100px; display: inline-block"
-      />
-      <button class="btn btn-primary ml-3" @click="onGranularitySubmit">Apply</button>
-    </div>
-    <div
-      v-show="uvvis_folder_name && uvvis_reference_folder_name && echem_folder_name"
-      class="row mt-2 text-center justify-content-center"
-    >
-      <div
-        id="bokehPlotContainer"
-        class="col-xl-10 col-lg-11 col-md-12 d-flex justify-content-center overflow-auto"
-      >
-        <BokehPlot :bokeh-plot-data="bokehPlotData" class="mw-100" />
+      <div class="form-inline mb-2">
+        <label class="mr-2"><b>Data granularity</b></label>
+        <input
+          v-model="data_granularity_buffer"
+          type="number"
+          class="form-control"
+          min="1"
+          style="width: 100px"
+        />
+        <label class="ml-3 mr-2"><b>Sample granularity</b></label>
+        <input
+          v-model="sample_granularity_buffer"
+          type="number"
+          class="form-control"
+          min="1"
+          style="width: 100px"
+        />
+        <button class="btn btn-primary ml-2" @click="onGranularitySubmit">Apply</button>
       </div>
-    </div>
+    </template>
+
+    <template #plot>
+      <BokehPlot v-if="bokehPlotData" :bokeh-plot-data="bokehPlotData" />
+    </template>
   </DataBlockBase>
 </template>
 


### PR DESCRIPTION
Supersedes #1436

Closes #1396

Mostly cherry-picked from @BenjaminCharmes's work, with a few extras:

- Add metadata viewer popout to base data block and uses it by default on the NMR block
- Use styled input popover for help strings inside blocks
- Update cypress tests for blocks
- Updates the style of the file selection dropdowns and other block controls

NMR block:

<img width="1110" height="1012" alt="image" src="https://github.com/user-attachments/assets/b111ac71-35ce-4d40-8f3e-cd6bbffbfe12" />
