### PR TITLE
Move component test runner port to fix for macOS

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -3,31 +3,40 @@
 More detailed instructions can be found in the top-level [README](../README.md).
 
 ## Project setup
+
 ```
 yarn install
 ```
 
 ### Compiles and hot-reloads for development
+
 ```
 yarn serve
 ```
 
 ### Compiles and minifies for production
+
 ```
 yarn build
 ```
 
 ### Run component tests
+
+Component tests use port 8082 for the Cypress webpack development server so they can run alongside
+the local development frontend on port 8081.
+
 ```
 yarn test:component
 ```
 
 ### Run end-to-end tests
+
 ```
 yarn test:e2e
 ```
 
 ### Lints and fixes files
+
 ```
 yarn lint
 ```

--- a/webapp/cypress.config.ts
+++ b/webapp/cypress.config.ts
@@ -8,6 +8,8 @@ export default defineConfig({
     defaultCommandTimeout: 10000,
   },
   component: {
+    // Avoid port 8080's macOS WebSocket issue and the usual local dev-server port, 8081.
+    port: 8082,
     devServer: {
       framework: "vue-cli",
       bundler: "webpack",


### PR DESCRIPTION
I noticed that `yarn test:component` wasn't working on my machine. This may be a MacOS issue, or may be a more general issue. 

The issue turns out to be that Cypress runs a server for these tests that defaults to port 8080, and there is some issue with communicating with it on that port. By forcing it to port 8082, it works on my machine. It would be good to verify that this doesn't break anything for others! 

