### PR TITLE
Passwordless test login

### DIFF
--- a/pydatalab/docs/INSTALL.md
+++ b/pydatalab/docs/INSTALL.md
@@ -215,7 +215,7 @@ uv lock
 ```
 ### Test server authentication/authorisation
 
-There are two approaches to authentication when developing *datalab* features locally.
+There are three approaches to authentication when developing *datalab* features locally.
 
 1. Disable authentication entirely with the `PYDATALAB_TESTING=true` environment
    variable (or corresponding config file option `TESTING`). This will perform
@@ -224,7 +224,7 @@ There are two approaches to authentication when developing *datalab* features lo
    - This mode of development is fine for e.g., developing new blocks, but in
      cases where new API functionality is being added, it is recommended to set
      up authentication locally (see below).
-1. Local OAuth setup. This requires registering an OAuth app with one of the
+2. Local OAuth setup. This requires registering an OAuth app with one of the
    implemented providers (e.g., GitHub, ORCID), configuring the credentials
    locally (see the [configuration documentation](https://docs.datalab-org.io/en/latest/config/) for more details) and then logging into *datalab* normally.
    - In this case, the user will also need to be activated when it is created.
@@ -233,6 +233,20 @@ There are two approaches to authentication when developing *datalab* features lo
      invoke task.
    - For testing admin functionality, the user can also be promoted with
      the `admin.change-user-role` invoke task.
+3. Enable the explicitly unsafe passwordless test login with
+   `PYDATALAB_ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN=true`. This keeps any existing email and
+   OAuth options and adds a modal for selecting configured test users. Create one with:
+
+   ```shell
+   uv run invoke dev.create-test-user \
+     --username alice \
+     --display-name "Alice Test User" \
+     --role user
+   ```
+
+   This mode is useful for switching between users when testing roles, groups, and permissions.
+   It performs no authentication and allows user impersonation, so it must never be enabled in
+   production or used with sensitive data.
 
 Finally, all API tests can be run with variable authentication.
 There are [pytest fixtures](https://docs.pytest.org/en/7.1.x/how-to/fixtures.html) that provide

--- a/pydatalab/docs/config.md
+++ b/pydatalab/docs/config.md
@@ -52,6 +52,30 @@ mechanisms:
 Each is configured differently.
 If left unconfigured, then the corresponding registration mechanism will not be available to the user.
 
+### Unsafe passwordless test login
+
+For local development and disposable test deployments, setting
+`ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN` to `true` adds a passwordless test-login option
+alongside the configured email and OAuth options. The equivalent environment variable is
+`PYDATALAB_ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN=true`.
+
+> [!WARNING]
+> This option lets anyone who can access the instance impersonate configured test users without
+> authentication. Never enable it in production or on an instance containing sensitive data.
+
+With the option enabled, create or update a test user from the `pydatalab` directory:
+
+```shell
+uv run invoke dev.create-test-user \
+  --username alice \
+  --display-name "Alice Test User" \
+  --role user
+```
+
+The command stores a `testing_passwordless` identity on the normal user document. It does not
+create or store a password. Only active users with that identity appear in the test-login modal;
+their normal roles, groups, and permissions still apply.
+
 ### Email magic links
 
 To support sign-in via email magic-links, you must currently provide additional configuration for authorized SMTP server.

--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -907,7 +907,8 @@
         "orcid",
         "github",
         "google",
-        "microsoft"
+        "microsoft",
+        "testing_passwordless"
       ],
       "title": "IdentityType",
       "type": "string"

--- a/pydatalab/schemas/equipment.json
+++ b/pydatalab/schemas/equipment.json
@@ -768,7 +768,8 @@
         "orcid",
         "github",
         "google",
-        "microsoft"
+        "microsoft",
+        "testing_passwordless"
       ],
       "title": "IdentityType",
       "type": "string"

--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -879,7 +879,8 @@
         "orcid",
         "github",
         "google",
-        "microsoft"
+        "microsoft",
+        "testing_passwordless"
       ],
       "title": "IdentityType",
       "type": "string"

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -879,7 +879,8 @@
         "orcid",
         "github",
         "google",
-        "microsoft"
+        "microsoft",
+        "testing_passwordless"
       ],
       "title": "IdentityType",
       "type": "string"

--- a/pydatalab/src/pydatalab/config.py
+++ b/pydatalab/src/pydatalab/config.py
@@ -145,6 +145,14 @@ class ServerConfig(BaseSettings):
         False, description="Whether to run the server in testing mode, i.e., without user auth."
     )
 
+    ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN: bool = Field(
+        False,
+        description=(
+            "Enable an unsafe testing-only login that lets anyone impersonate configured test "
+            "users without authentication. This must never be enabled in production."
+        ),
+    )
+
     SECRET_KEY: str | None = Field(
         None,
         description="The secret key to use for Flask. This value should be changed and/or loaded from an environment variable for production deployments.",

--- a/pydatalab/src/pydatalab/feature_flags.py
+++ b/pydatalab/src/pydatalab/feature_flags.py
@@ -2,7 +2,7 @@ import math
 import os
 from collections import Counter
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from pydatalab.config import CONFIG
 from pydatalab.logger import LOGGER
@@ -16,6 +16,13 @@ class AuthMechanisms(BaseModel):
     email: bool = False
     google: bool = False
     microsoft: bool = False
+    unsafe_testing_passwordless_login: bool = Field(
+        False,
+        description=(
+            "Unsafe testing-only login that permits impersonation without authentication. "
+            "Do not enable this mechanism in production."
+        ),
+    )
 
 
 class AIIntegrations(BaseModel):
@@ -58,6 +65,16 @@ def check_feature_flags(app):
     object reported by the API for use in UIs.
 
     """
+
+    FEATURE_FLAGS.auth_mechanisms.unsafe_testing_passwordless_login = (
+        CONFIG.ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN
+    )
+    if CONFIG.ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN:
+        LOGGER.critical(
+            "ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN is enabled. Anyone who can reach this "
+            "datalab instance can impersonate any configured passwordless test user without "
+            "authentication. This must never be enabled in production."
+        )
 
     if CONFIG.EMAIL_AUTH_SMTP_SETTINGS is None:
         LOGGER.warning(

--- a/pydatalab/src/pydatalab/main.py
+++ b/pydatalab/src/pydatalab/main.py
@@ -332,5 +332,13 @@ def register_endpoints(app: Flask):
     for bp in OAUTH:  # type: ignore
         app.register_blueprint(OAUTH[bp], url_prefix=f"{CONFIG.ROOT_PATH}login")  # type: ignore
 
+    if CONFIG.ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN:
+        from pydatalab.routes.v0_1.auth import TESTING_PASSWORDLESS_BLUEPRINT
+
+        app.register_blueprint(
+            TESTING_PASSWORDLESS_BLUEPRINT,
+            url_prefix=f"{CONFIG.ROOT_PATH}login",
+        )
+
     for exception_type, handler in ERROR_HANDLERS:
         app.register_error_handler(exception_type, handler)

--- a/pydatalab/src/pydatalab/models/people.py
+++ b/pydatalab/src/pydatalab/models/people.py
@@ -22,6 +22,7 @@ class IdentityType(str, Enum):
     GITHUB = "github"
     GOOGLE = "google"
     MICROSOFT = "microsoft"
+    TESTING_PASSWORDLESS = "testing_passwordless"
 
 
 class Identity(BaseModel):

--- a/pydatalab/src/pydatalab/routes/v0_1/auth.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/auth.py
@@ -16,7 +16,8 @@ from flask import Blueprint, Response, g, jsonify, redirect, request
 from flask_dance.consumer import OAuth2ConsumerBlueprint, oauth_authorized
 from flask_login import current_user, login_user
 from flask_login.utils import LocalProxy
-from werkzeug.exceptions import BadRequest, Forbidden, NotFound
+from pydantic import TypeAdapter, ValidationError
+from werkzeug.exceptions import BadRequest, Forbidden, NotFound, Unauthorized
 
 from pydatalab.config import CONFIG
 from pydatalab.errors import UserRegistrationForbidden
@@ -24,6 +25,7 @@ from pydatalab.feature_flags import FEATURE_FLAGS
 from pydatalab.logger import LOGGER
 from pydatalab.login import get_by_id
 from pydatalab.models.people import AccountStatus, Identity, IdentityType, Person
+from pydatalab.models.utils import HumanReadableIdentifier
 from pydatalab.mongo import flask_mongo, insert_pydantic_model_fork_safe
 from pydatalab.permissions import ApiKey, authenticate, exclude_api_key
 from pydatalab.send_email import send_mail
@@ -400,6 +402,7 @@ def wrapped_login_user(*args, **kwargs):
 
 
 EMAIL_BLUEPRINT = Blueprint("email", __name__)
+TESTING_PASSWORDLESS_BLUEPRINT = Blueprint("testing_passwordless", __name__)
 
 AUTH = Blueprint("auth", __name__)
 
@@ -866,6 +869,64 @@ def email_logged_in():
         return redirect(CONFIG.APP_URL, 307)
     referer = request.headers.get("Referer", CONFIG.ROOT_PATH or "/")
     return redirect(referer, 307)
+
+
+@TESTING_PASSWORDLESS_BLUEPRINT.route("/testing-passwordless/users", methods=["GET"])
+def list_testing_passwordless_users():
+    """List only active users explicitly configured for unsafe test login."""
+
+    if not CONFIG.ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN:
+        raise NotFound()
+    documents = flask_mongo.db.users.find(
+        {
+            "account_status": AccountStatus.ACTIVE.value,
+            "identities.identity_type": IdentityType.TESTING_PASSWORDLESS.value,
+        }
+    )
+    users: list[dict[str, str | None]] = []
+    for document in documents:
+        login_user_model = get_by_id(document["_id"])
+        if login_user_model is None:
+            continue
+        for identity in login_user_model.identities:
+            if identity.identity_type is IdentityType.TESTING_PASSWORDLESS:
+                users.append(
+                    {
+                        "username": identity.identifier,
+                        "display_name": login_user_model.display_name,
+                        "role": login_user_model.role.value,
+                        "account_status": login_user_model.account_status.value,
+                    }
+                )
+    users.sort(key=lambda user: (user["display_name"] or user["username"] or "").casefold())
+    return jsonify({"users": users}), 200
+
+
+@TESTING_PASSWORDLESS_BLUEPRINT.route("/testing-passwordless", methods=["POST"])
+def testing_passwordless_login():
+    """Impersonate a configured test user without authentication or a password."""
+
+    if not CONFIG.ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN:
+        raise NotFound()
+    request_json = request.get_json(silent=True)
+    try:
+        if not isinstance(request_json, dict):
+            raise ValueError
+        username = TypeAdapter(HumanReadableIdentifier).validate_python(
+            request_json.get("username")
+        )
+    except (TypeError, ValueError, ValidationError):
+        raise Unauthorized("Unknown passwordless test user.") from None
+
+    person = find_user_with_identity(username, IdentityType.TESTING_PASSWORDLESS)
+    if person is None or person.account_status is not AccountStatus.ACTIVE:
+        raise Unauthorized("Unknown passwordless test user.")
+
+    login_user_model = get_by_id(person.immutable_id)
+    if login_user_model is None:
+        raise Unauthorized("Unknown passwordless test user.")
+    wrapped_login_user(login_user_model)
+    return jsonify({"status": "success"}), 200
 
 
 @oauth_authorized.connect_via(OAUTH[IdentityType.GITHUB])

--- a/pydatalab/tasks.py
+++ b/pydatalab/tasks.py
@@ -169,6 +169,96 @@ def serve(
 dev.add_task(serve)
 
 
+@task(
+    help={
+        "username": "Case-sensitive username for unsafe passwordless testing login",
+        "display_name": "Display name for the test user (defaults to the username)",
+        "role": "User role: user, manager, or admin",
+    }
+)
+def create_test_user(
+    _,
+    username: str,
+    display_name: str | None = None,
+    role: str = "user",
+):
+    """Create or update a user for unsafe passwordless testing login."""
+
+    from pydantic import TypeAdapter, ValidationError
+
+    from pydatalab.config import CONFIG
+    from pydatalab.models.people import AccountStatus, DisplayName, Identity, IdentityType, Person
+    from pydatalab.models.utils import HumanReadableIdentifier, UserRole
+    from pydatalab.mongo import get_database, insert_pydantic_model_fork_safe
+
+    if not CONFIG.ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN:
+        raise SystemExit(
+            "Unsafe passwordless test users require "
+            "PYDATALAB_ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN=true. "
+            "Never enable this option in production."
+        )
+
+    try:
+        username = TypeAdapter(HumanReadableIdentifier).validate_python(username)
+    except ValidationError as exc:
+        raise SystemExit(f"Invalid test username {username!r}: {exc}") from None
+
+    try:
+        role_value = UserRole(role.lower())
+    except ValueError:
+        allowed_roles = ", ".join(value.value for value in UserRole)
+        raise SystemExit(f"Invalid role {role!r}; expected one of: {allowed_roles}.") from None
+
+    if display_name is not None:
+        try:
+            display_name = TypeAdapter(DisplayName).validate_python(display_name)
+        except ValidationError as exc:
+            raise SystemExit(f"Invalid display name {display_name!r}: {exc}") from None
+
+    database = get_database()
+    identity_query = {
+        "identities": {
+            "$elemMatch": {
+                "identity_type": IdentityType.TESTING_PASSWORDLESS.value,
+                "identifier": username,
+            }
+        }
+    }
+    existing_user = database.users.find_one(identity_query)
+
+    if existing_user is None:
+        identity = Identity(
+            identity_type=IdentityType.TESTING_PASSWORDLESS,
+            identifier=username,
+            name=username,
+            display_name=display_name or username,
+            verified=False,
+        )
+        user = Person.new_user_from_identity(
+            identity,
+            account_status=AccountStatus.ACTIVE,
+        )
+        user_id = insert_pydantic_model_fork_safe(user, "users")
+        action = "Created"
+    else:
+        user_id = existing_user["_id"]
+        user_updates = {"account_status": AccountStatus.ACTIVE.value}
+        if display_name is not None:
+            user_updates["display_name"] = display_name
+        database.users.update_one({"_id": user_id}, {"$set": user_updates})
+        action = "Updated"
+
+    database.roles.update_one(
+        {"_id": user_id},
+        {"$set": {"role": role_value.value}},
+        upsert=True,
+    )
+    print(f"{action} unsafe passwordless test user {username!r} with role {role_value.value!r}.")
+
+
+dev.add_task(create_test_user)
+
+
 @task
 def install(_, dev=True):
     """This task looks for a plugins.toml and attempts to

--- a/pydatalab/tests/server/test_auth.py
+++ b/pydatalab/tests/server/test_auth.py
@@ -1,9 +1,69 @@
 import datetime
 from unittest.mock import MagicMock
 
+import pytest
 from bson import ObjectId
 
 from pydatalab.routes.v0_1.auth import _check_email_domain
+
+
+@pytest.fixture()
+def unsafe_testing_passwordless_app(app_config):
+    from pydatalab.config import CONFIG
+    from pydatalab.feature_flags import FEATURE_FLAGS
+    from pydatalab.main import create_app
+    from pydatalab.routes.v0_1.info import _get_deployment_metadata_once
+
+    old_config_value = CONFIG.ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN
+    old_feature_value = FEATURE_FLAGS.auth_mechanisms.unsafe_testing_passwordless_login
+    app = create_app(
+        {**app_config, "ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN": True},
+        env_file=False,
+    )
+    _get_deployment_metadata_once.cache_clear()
+    try:
+        yield app
+    finally:
+        CONFIG.ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN = old_config_value
+        FEATURE_FLAGS.auth_mechanisms.unsafe_testing_passwordless_login = old_feature_value
+        _get_deployment_metadata_once.cache_clear()
+
+
+@pytest.fixture()
+def unsafe_testing_passwordless_client(unsafe_testing_passwordless_app):
+    with unsafe_testing_passwordless_app.test_client() as client:
+        yield client
+
+
+@pytest.fixture()
+def testing_passwordless_users(
+    database,
+    user_id,
+    unverified_user_id,
+    deactivated_user_id,
+):
+    configured_users = (
+        (user_id, "active-user"),
+        (unverified_user_id, "unverified-user"),
+        (deactivated_user_id, "deactivated-user"),
+    )
+    for configured_user_id, username in configured_users:
+        database.users.update_one(
+            {"_id": configured_user_id},
+            {
+                "$set": {
+                    "identities": [
+                        {
+                            "identity_type": "testing_passwordless",
+                            "identifier": username,
+                            "name": username,
+                            "verified": False,
+                        }
+                    ]
+                },
+            },
+        )
+    yield
 
 
 def test_allow_emails():
@@ -91,6 +151,71 @@ def test_magic_link_auth_can_be_disabled(unauthenticated_client, app, database, 
             == "Magic-link authentication is disabled for this datalab instance."
         )
         assert len(outbox) == 0
+
+
+def test_testing_passwordless_routes_are_absent_when_disabled(unauthenticated_client):
+    assert unauthenticated_client.get("/login/testing-passwordless/users").status_code == 404
+    assert (
+        unauthenticated_client.post(
+            "/login/testing-passwordless", json={"username": "active-user"}
+        ).status_code
+        == 404
+    )
+
+
+def test_testing_passwordless_user_list_is_restricted(
+    unsafe_testing_passwordless_client,
+    testing_passwordless_users,
+):
+    info = unsafe_testing_passwordless_client.get("/info")
+    assert (
+        info.json["data"]["attributes"]["features"]["auth_mechanisms"][
+            "unsafe_testing_passwordless_login"
+        ]
+        is True
+    )
+
+    response = unsafe_testing_passwordless_client.get("/login/testing-passwordless/users")
+    assert response.status_code == 200
+    users = response.json["users"]
+    assert [user["username"] for user in users] == ["active-user"]
+    assert users[0]["account_status"] == "active"
+    assert users[0]["role"] == "user"
+
+
+def test_testing_passwordless_login_preserves_user_access(
+    unsafe_testing_passwordless_client,
+    testing_passwordless_users,
+    user_id,
+):
+    response = unsafe_testing_passwordless_client.post(
+        "/login/testing-passwordless", json={"username": "active-user"}
+    )
+    assert response.status_code == 200
+
+    current_user = unsafe_testing_passwordless_client.get("/get-current-user/")
+    assert current_user.status_code == 200
+    assert current_user.json["immutable_id"] == str(user_id)
+    assert current_user.json["role"] == "user"
+    assert current_user.json["groups"]
+
+
+def test_testing_passwordless_login_rejects_unavailable_users(
+    unsafe_testing_passwordless_client,
+    testing_passwordless_users,
+):
+    unknown = unsafe_testing_passwordless_client.post(
+        "/login/testing-passwordless", json={"username": "unknown-user"}
+    )
+    deactivated = unsafe_testing_passwordless_client.post(
+        "/login/testing-passwordless", json={"username": "deactivated-user"}
+    )
+    unverified = unsafe_testing_passwordless_client.post(
+        "/login/testing-passwordless", json={"username": "unverified-user"}
+    )
+    assert unknown.status_code == 401
+    assert deactivated.status_code == 401
+    assert unverified.status_code == 401
 
 
 # ──────────────────────────────────────────────

--- a/pydatalab/tests/test_config.py
+++ b/pydatalab/tests/test_config.py
@@ -10,6 +10,14 @@ def test_default_settings():
     assert config.MONGO_URI == "mongodb://localhost:27017/datalabvue"
     assert config.SECRET_KEY
     assert Path(config.FILE_DIRECTORY).name == "files"
+    assert config.ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN is False
+
+
+def test_unsafe_testing_passwordless_login_environment_setting(monkeypatch):
+    from pydatalab.config import ServerConfig
+
+    monkeypatch.setenv("PYDATALAB_ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN", "true")
+    assert ServerConfig().ENABLE_UNSAFE_TESTING_PASSWORDLESS_LOGIN is True
 
 
 def test_update_settings():

--- a/webapp/cypress/component/LoginDropdownTest.cy.jsx
+++ b/webapp/cypress/component/LoginDropdownTest.cy.jsx
@@ -1,0 +1,50 @@
+import { createStore } from "vuex";
+import "bootstrap/dist/css/bootstrap.css";
+
+import LoginDropdown from "@/components/LoginDropdown.vue";
+
+function mountLoginDropdown({ enabled = true } = {}) {
+  const store = createStore({
+    state: {
+      serverInfo: {
+        features: {
+          auth_mechanisms: {
+            email: true,
+            github: true,
+            unsafe_testing_passwordless_login: enabled,
+          },
+        },
+      },
+    },
+  });
+  cy.mount(LoginDropdown, {
+    global: { plugins: [store] },
+  });
+}
+
+describe("LoginDropdown unsafe passwordless test login", () => {
+  it("does not expose test users when disabled", () => {
+    mountLoginDropdown({ enabled: false });
+
+    cy.get('[data-testid="testing-passwordless-open"]').should("not.exist");
+    cy.contains("Alice Test User").should("not.exist");
+  });
+
+  it("lists configured test users when enabled", () => {
+    cy.intercept("GET", "**/login/testing-passwordless/users", {
+      users: [
+        {
+          username: "alice",
+          display_name: "Alice Test User",
+          role: "manager",
+          account_status: "active",
+        },
+      ],
+    }).as("testUsers");
+    mountLoginDropdown();
+
+    cy.get('[data-testid="testing-passwordless-open"]').click();
+    cy.wait("@testUsers");
+    cy.contains("Alice Test User").should("be.visible");
+  });
+});

--- a/webapp/cypress/component/LoginDropdownTest.cy.jsx
+++ b/webapp/cypress/component/LoginDropdownTest.cy.jsx
@@ -47,4 +47,40 @@ describe("LoginDropdown unsafe passwordless test login", () => {
     cy.wait("@testUsers");
     cy.contains("Alice Test User").should("be.visible");
   });
+
+  it("keeps the user list available after a failed login", () => {
+    cy.intercept("GET", "**/login/testing-passwordless/users", {
+      users: [
+        {
+          username: "alice",
+          display_name: "Alice Test User",
+          role: "manager",
+          account_status: "active",
+        },
+        {
+          username: "bob",
+          display_name: "Bob Test User",
+          role: "user",
+          account_status: "active",
+        },
+      ],
+    });
+    cy.intercept("POST", "**/login/testing-passwordless", {
+      statusCode: 500,
+      delay: 100,
+    }).as("login");
+    mountLoginDropdown();
+
+    cy.get('[data-testid="testing-passwordless-open"]').click();
+    cy.contains("button", "Alice Test User").click();
+    cy.get('[data-testid="testing-passwordless-users"] button').should("be.disabled");
+    cy.wait("@login").its("request.body.username").should("equal", "alice");
+
+    cy.get('[data-testid="testing-passwordless-error"]')
+      .should("be.visible")
+      .and("contain", "Unable to log in as that test user");
+    cy.contains("Alice Test User").should("be.visible");
+    cy.contains("button", "Bob Test User").should("be.enabled").click();
+    cy.wait("@login").its("request.body.username").should("equal", "bob");
+  });
 });

--- a/webapp/src/components/LoginDropdown.vue
+++ b/webapp/src/components/LoginDropdown.vue
@@ -44,15 +44,18 @@
   >
     <font-awesome-icon :icon="['fa', 'envelope']" /> Login via email
   </button>
+  <UnsafeTestingPasswordlessLogin v-if="showUnsafeTestingPasswordlessLogin" />
 </template>
 
 <script>
 import GetEmailModal from "@/components/GetEmailModal.vue";
+import UnsafeTestingPasswordlessLogin from "@/components/UnsafeTestingPasswordlessLogin.vue";
 import { API_URL } from "@/resources.js";
 
 export default {
   components: {
     GetEmailModal,
+    UnsafeTestingPasswordlessLogin,
   },
   props: {
     modelValue: Boolean,
@@ -81,6 +84,12 @@ export default {
     },
     showEmail() {
       return this.$store.state.serverInfo?.features?.auth_mechanisms?.email ?? false;
+    },
+    showUnsafeTestingPasswordlessLogin() {
+      return (
+        this.$store.state.serverInfo?.features?.auth_mechanisms
+          ?.unsafe_testing_passwordless_login ?? false
+      );
     },
   },
 };

--- a/webapp/src/components/UnsafeTestingPasswordlessLogin.vue
+++ b/webapp/src/components/UnsafeTestingPasswordlessLogin.vue
@@ -1,0 +1,117 @@
+<template>
+  <Modal v-model="isOpen" :is-large="false">
+    <template #header>
+      <font-awesome-icon icon="exclamation-triangle" class="text-danger" />
+      Unsafe passwordless test login
+    </template>
+    <template #body>
+      <div class="alert alert-danger" data-testid="testing-passwordless-warning">
+        No authentication is performed. Anyone with access to this instance can impersonate any user
+        listed below. Never enable this login mechanism in production.
+      </div>
+      <div v-if="error" class="alert alert-warning" data-testid="testing-passwordless-error">
+        {{ error }}
+      </div>
+      <div v-else-if="users === null" class="text-center text-muted py-3">
+        <font-awesome-icon icon="spinner" spin /> Loading test users…
+      </div>
+      <div
+        v-else-if="users.length === 0"
+        class="text-muted"
+        data-testid="testing-passwordless-empty"
+      >
+        No passwordless test users are configured.
+      </div>
+      <div v-else class="list-group" data-testid="testing-passwordless-users">
+        <button
+          v-for="user in users"
+          :key="user.username"
+          type="button"
+          class="list-group-item list-group-item-action"
+          @click="login(user.username)"
+        >
+          <span class="d-flex justify-content-between align-items-center">
+            <span class="text-left">
+              <strong>{{ user.display_name || user.username }}</strong>
+              <small class="d-block text-muted">{{ user.username }}</small>
+            </span>
+            <span class="d-flex align-items-center">
+              <RoleBadge :role="user.role" class="mr-2" />
+              <span
+                class="d-flex align-items-center"
+                :title="`Account status: ${user.account_status}`"
+                :aria-label="`Account status: ${user.account_status}`"
+              >
+                <UserStatusCell :status="user.account_status" />
+              </span>
+            </span>
+          </span>
+        </button>
+      </div>
+    </template>
+    <template #footer>
+      <button
+        type="button"
+        class="btn btn-secondary"
+        data-testid="testing-passwordless-close"
+        @click="isOpen = false"
+      >
+        Close
+      </button>
+    </template>
+  </Modal>
+  <button
+    type="button"
+    class="dropdown-item btn login btn-link unsafe-testing-login"
+    aria-label="Open unsafe passwordless test login"
+    data-testid="testing-passwordless-open"
+    @click="open"
+  >
+    <font-awesome-icon icon="exclamation-triangle" /> Unsafe passwordless test login
+  </button>
+</template>
+
+<script>
+import Modal from "@/components/Modal.vue";
+import RoleBadge from "@/components/RoleBadge.vue";
+import UserStatusCell from "@/components/UserStatusCell.vue";
+import { getTestingPasswordlessUsers, loginTestingPasswordless } from "@/server_fetch_utils.js";
+
+export default {
+  components: { Modal, RoleBadge, UserStatusCell },
+  data() {
+    return {
+      isOpen: false,
+      users: null,
+      error: "",
+    };
+  },
+  methods: {
+    async open() {
+      this.isOpen = true;
+      this.users = null;
+      this.error = "";
+      try {
+        this.users = await getTestingPasswordlessUsers();
+      } catch {
+        this.error = "Unable to load passwordless test users.";
+      }
+    },
+    async login(username) {
+      try {
+        await loginTestingPasswordless(username);
+        window.location.reload();
+      } catch {
+        this.error = "Unable to log in as that test user.";
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.unsafe-testing-login {
+  color: #b00020;
+  white-space: normal;
+}
+</style>

--- a/webapp/src/components/UnsafeTestingPasswordlessLogin.vue
+++ b/webapp/src/components/UnsafeTestingPasswordlessLogin.vue
@@ -12,22 +12,23 @@
       <div v-if="error" class="alert alert-warning" data-testid="testing-passwordless-error">
         {{ error }}
       </div>
-      <div v-else-if="users === null" class="text-center text-muted py-3">
+      <div v-if="users === null && !error" class="text-center text-muted py-3">
         <font-awesome-icon icon="spinner" spin /> Loading test users…
       </div>
       <div
-        v-else-if="users.length === 0"
+        v-else-if="users !== null && users.length === 0"
         class="text-muted"
         data-testid="testing-passwordless-empty"
       >
         No passwordless test users are configured.
       </div>
-      <div v-else class="list-group" data-testid="testing-passwordless-users">
+      <div v-else-if="users !== null" class="list-group" data-testid="testing-passwordless-users">
         <button
           v-for="user in users"
           :key="user.username"
           type="button"
           class="list-group-item list-group-item-action"
+          :disabled="isLoggingIn"
           @click="login(user.username)"
         >
           <span class="d-flex justify-content-between align-items-center">
@@ -84,6 +85,7 @@ export default {
       isOpen: false,
       users: null,
       error: "",
+      isLoggingIn: false,
     };
   },
   methods: {
@@ -98,11 +100,17 @@ export default {
       }
     },
     async login(username) {
+      if (this.isLoggingIn) return;
+
+      this.isLoggingIn = true;
+      this.error = "";
       try {
         await loginTestingPasswordless(username);
         window.location.reload();
       } catch {
         this.error = "Unable to log in as that test user.";
+      } finally {
+        this.isLoggingIn = false;
       }
     },
   },

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -643,6 +643,16 @@ export async function requestMagicLink(email_address) {
     });
 }
 
+export function getTestingPasswordlessUsers() {
+  return fetch_get(`${API_URL}/login/testing-passwordless/users`).then(
+    (response_json) => response_json.users,
+  );
+}
+
+export function loginTestingPasswordless(username) {
+  return fetch_post(`${API_URL}/login/testing-passwordless`, { username });
+}
+
 export function searchUsers(query, nresults = 100) {
   // construct a url with parameters:
   var url = new URL(`${API_URL}/search-users/`);


### PR DESCRIPTION
Added an additional login procedure for dev/tests. This is purposedly simplistic, just a username, and to login, you just click on the user in the list. The goal is to be able to test various access features / groups etc ... without the need to have multiple OAuth logins.

Adapted from the previous PR here: https://github.com/Matgenix/datalab/pull/5
In this previous PR, a password credentials existed. Given the actual purpose of this, i.e. just be able to have different authenticated users easily in a purely test/dev environments, the password credentials added unnecessary code.

Logic in datalab for access to items/anything is:
1/ Authentication (who am I)
2/ Tenant access (do i have access to to this datalab instance)
3/ resource-level access control (can I access this specific "object")

This PR allow to kind of "bypass" 1/ and 2/ (not really bypass, just make it super easy for testing/development).