### PR TITLE
Fix flaky SampleTable component test

### DIFF
--- a/webapp/cypress/component/SampleTableTest.cy.jsx
+++ b/webapp/cypress/component/SampleTableTest.cy.jsx
@@ -1,6 +1,10 @@
+import "bootstrap/dist/css/bootstrap.css";
+import DynamicDataTable from "@/components/DynamicDataTable.vue";
 import SampleTable from "@/components/SampleTable.vue";
 import UserBubble from "@/components/UserBubble.vue";
 import StyledTooltip from "@/components/StyledTooltip.vue";
+import DatalabPreset from "@/primevue-theme-preset.js";
+import { FilterOperator } from "@primevue/core/api";
 import PrimeVue from "primevue/config";
 import { createStore } from "vuex";
 
@@ -10,8 +14,46 @@ const IsoDatetimeToDate = (value) => {
   return date.toLocaleDateString();
 };
 
+const openColumnFilter = (columnIndex) => {
+  cy.get(".p-datatable-thead th").eq(columnIndex).find(".p-datatable-column-filter-button").click();
+  cy.get(".p-datatable-filter-overlay").should("be.visible");
+};
+
+const selectMultiselectOption = (columnIndex, label, expectedSelected = true) => {
+  openColumnFilter(columnIndex);
+  cy.get(".p-datatable-filter-overlay .p-multiselect-label-container").then(($label) => {
+    $label[0].click();
+  });
+  cy.get(".p-datatable-filter-overlay .p-multiselect [role='combobox']").should(
+    "have.attr",
+    "aria-expanded",
+    "true",
+  );
+  const optionSelector = `[role="option"][aria-label="${label}"]`;
+  cy.get(".p-multiselect-list-container:visible").find(optionSelector).should("be.visible").click();
+  // PrimeVue rerenders the draft value after selection; apply it before checking filtered rows.
+  cy.get(".p-datatable-filter-overlay .p-multiselect").should(
+    expectedSelected ? "contain.text" : "not.contain.text",
+    label,
+  );
+  cy.get(".p-datatable-filter-overlay").findByText("Apply").click();
+  cy.get(".p-datatable-filter-overlay").should("not.exist");
+};
+
 describe("SampleTable Component Tests", () => {
   let store;
+  let wrapper;
+
+  // Exercise datalab's matchers through the real DataTable without repeatedly driving PrimeVue's
+  // nested filter overlays. The Type test below retains one end-to-end multiselect interaction.
+  const setColumnFilter = (field, value, operator = FilterOperator.AND) => {
+    cy.then(() => {
+      const dataTable = wrapper.findComponent(DynamicDataTable);
+      dataTable.vm.filters[field].operator = operator;
+      dataTable.vm.filters[field].constraints[0].value = value;
+      return dataTable.vm.$nextTick();
+    });
+  };
 
   beforeEach(() => {
     store = createStore({
@@ -127,7 +169,7 @@ describe("SampleTable Component Tests", () => {
 
     cy.mount(SampleTable, {
       global: {
-        plugins: [store, PrimeVue],
+        plugins: [store, [PrimeVue, { theme: DatalabPreset }]],
         config: {
           globalProperties: {
             $filters: {
@@ -140,6 +182,8 @@ describe("SampleTable Component Tests", () => {
           StyledTooltip,
         },
       },
+    }).then(({ wrapper: mountedWrapper }) => {
+      wrapper = mountedWrapper;
     });
   });
 
@@ -720,18 +764,14 @@ describe("SampleTable Component Tests", () => {
   });
 
   it("filters by Type correctly", () => {
-    cy.get(".p-datatable-thead th").eq(2).find(".p-datatable-column-filter-button").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("samples").click();
+    selectMultiselectOption(2, "samples");
     cy.get(".p-datatable-tbody tr").should("have.length", 3);
     cy.get(".p-datatable-tbody tr").eq(0).find("td").eq(1).should("contain.text", "sample1");
     cy.get(".p-datatable-tbody tr").eq(1).find("td").eq(1).should("contain.text", "sample2");
     cy.get(".p-datatable-tbody tr").eq(2).find("td").eq(1).should("contain.text", "sample3");
 
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("samples").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("cells").click();
+    selectMultiselectOption(2, "samples", false);
+    selectMultiselectOption(2, "cells");
     cy.get(".p-datatable-tbody tr").should("have.length", 3);
     cy.get(".p-datatable-tbody tr").eq(0).find("td").eq(1).should("contain.text", "cell1");
     cy.get(".p-datatable-tbody tr").eq(1).find("td").eq(1).should("contain.text", "cell2");
@@ -739,155 +779,89 @@ describe("SampleTable Component Tests", () => {
   });
 
   it("filters by Status correctly", () => {
-    cy.get(".p-datatable-thead th").eq(3).find(".p-datatable-column-filter-button").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("ACTIVE").click();
-    cy.get(".p-datatable-tbody tr").should("have.length", 1);
-    cy.findByText("Clear").click();
-    cy.get(".p-datatable-filter-overlay").should("not.exist");
+    const statuses = ["ACTIVE", "CYCLED", "PLANNED", "FAILED", "SHORTED", "DISMANTLED"].map(
+      (status) => ({ status }),
+    );
 
-    cy.get(".p-datatable-thead th").eq(3).find(".p-datatable-column-filter-button").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("CYCLED").click();
+    setColumnFilter("status", [statuses[0]]);
     cy.get(".p-datatable-tbody tr").should("have.length", 1);
-    cy.findByText("Clear").click();
-    cy.get(".p-datatable-filter-overlay").should("not.exist");
 
-    cy.get(".p-datatable-thead th").eq(3).find(".p-datatable-column-filter-button").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("ACTIVE").click();
+    setColumnFilter("status", [statuses[1]]);
     cy.get(".p-datatable-tbody tr").should("have.length", 1);
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("CYCLED").click();
+
+    setColumnFilter("status", statuses.slice(0, 1));
+    cy.get(".p-datatable-tbody tr").should("have.length", 1);
+    setColumnFilter("status", statuses.slice(0, 2));
     cy.get(".p-datatable-tbody tr").should("have.length", 2);
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("PLANNED").click();
+    setColumnFilter("status", statuses.slice(0, 3));
     cy.get(".p-datatable-tbody tr").should("have.length", 3);
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("FAILED").click();
+    setColumnFilter("status", statuses.slice(0, 4));
     cy.get(".p-datatable-tbody tr").should("have.length", 4);
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("SHORTED").click();
+    setColumnFilter("status", statuses.slice(0, 5));
     cy.get(".p-datatable-tbody tr").should("have.length", 5);
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("DISMANTLED").click();
+    setColumnFilter("status", statuses);
     cy.get(".p-datatable-tbody tr").should("have.length", 6);
   });
 
   it("filters by Collections correctly", () => {
-    cy.get(".p-datatable-thead th").eq(7).find(".p-datatable-column-filter-button").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("collection1").click();
+    const collections = ["collection1", "collection2", "collection3"].map((collection_id) => ({
+      collection_id,
+    }));
+
+    setColumnFilter("collections", [collections[0]]);
     cy.get(".p-datatable-tbody tr").should("have.length", 4);
-    cy.findByText("Clear").click();
-    cy.get(".p-datatable-filter-overlay").should("not.exist");
 
-    cy.get(".p-datatable-thead th").eq(7).find(".p-datatable-column-filter-button").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("collection2").click();
+    setColumnFilter("collections", [collections[1]]);
     cy.get(".p-datatable-tbody tr").should("have.length", 3);
-    cy.findByText("Clear").click();
-    cy.get(".p-datatable-filter-overlay").should("not.exist");
 
-    cy.get(".p-datatable-thead th").eq(7).find(".p-datatable-column-filter-button").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("collection3").click();
+    setColumnFilter("collections", [collections[2]]);
     cy.get(".p-datatable-tbody tr").should("have.length", 2);
-    cy.findByText("Clear").click();
-    cy.get(".p-datatable-filter-overlay").should("not.exist");
 
-    cy.get(".p-datatable-thead th").eq(7).find(".p-datatable-column-filter-button").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("collection1").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("collection2").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("collection3").click();
+    setColumnFilter("collections", collections);
     cy.get(".p-datatable-tbody tr").should("have.length", 1);
-    cy.get(".p-datatable-filter-operator").click();
-    cy.get(".p-select-list-container").findByText("Match Any").click();
-    cy.findByText("Apply").click();
+    setColumnFilter("collections", collections, FilterOperator.OR);
     cy.get(".p-datatable-tbody tr").should("have.length", 6);
   });
 
   it("filters by Creators correctly", () => {
-    cy.get(".p-datatable-thead th").eq(8).find(".p-datatable-column-filter-button").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("Creator 1").click();
-    cy.get(".p-datatable-tbody tr").should("have.length", 4);
-    cy.findByText("Clear").click();
-    cy.get(".p-datatable-filter-overlay").should("not.exist");
+    const creators = ["Creator 1", "Creator 2", "Creator 3"].map((display_name) => ({
+      display_name,
+      type: "creator",
+    }));
 
-    cy.get(".p-datatable-thead th").eq(8).find(".p-datatable-column-filter-button").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("Creator 2").click();
+    setColumnFilter("creatorsAndGroups", [creators[0]]);
     cy.get(".p-datatable-tbody tr").should("have.length", 4);
-    cy.findByText("Clear").click();
-    cy.get(".p-datatable-filter-overlay").should("not.exist");
 
-    cy.get(".p-datatable-thead th").eq(8).find(".p-datatable-column-filter-button").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("Creator 3").click();
+    setColumnFilter("creatorsAndGroups", [creators[1]]);
+    cy.get(".p-datatable-tbody tr").should("have.length", 4);
+
+    setColumnFilter("creatorsAndGroups", [creators[2]]);
     cy.get(".p-datatable-tbody tr").should("have.length", 2);
-    cy.findByText("Clear").click();
-    cy.get(".p-datatable-filter-overlay").should("not.exist");
 
-    cy.get(".p-datatable-thead th").eq(8).find(".p-datatable-column-filter-button").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("Creator 1").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("Creator 2").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("Creator 3").click();
+    setColumnFilter("creatorsAndGroups", creators);
     cy.get(".p-datatable-tbody tr").should("have.length", 1);
-    cy.get(".p-datatable-filter-operator").click();
-    cy.get(".p-select-list-container").findByText("Match Any").click();
-    cy.findByText("Apply").click();
+    setColumnFilter("creatorsAndGroups", creators, FilterOperator.OR);
     cy.get(".p-datatable-tbody tr").should("have.length", 6);
   });
 
   it("filters by Blocks correctly", () => {
-    cy.get(".p-datatable-thead th").eq(9).find(".p-datatable-column-filter-button").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("nmr").click();
+    const blockTypes = ["nmr", "insitu", "ftir", "xrd"].map((blocktype) => ({ blocktype }));
+
+    setColumnFilter("blocks", [blockTypes[0]]);
     cy.get(".p-datatable-tbody tr").should("have.length", 6);
-    cy.findByText("Clear").click();
-    cy.get(".p-datatable-filter-overlay").should("not.exist");
 
-    cy.get(".p-datatable-thead th").eq(9).find(".p-datatable-column-filter-button").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("insitu").click();
+    setColumnFilter("blocks", [blockTypes[1]]);
     cy.get(".p-datatable-tbody tr").should("have.length", 2);
-    cy.findByText("Clear").click();
-    cy.get(".p-datatable-filter-overlay").should("not.exist");
 
-    cy.get(".p-datatable-thead th").eq(9).find(".p-datatable-column-filter-button").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("ftir").click();
+    setColumnFilter("blocks", [blockTypes[2]]);
     cy.get(".p-datatable-tbody tr").should("have.length", 1);
-    cy.findByText("Clear").click();
-    cy.get(".p-datatable-filter-overlay").should("not.exist");
 
-    cy.get(".p-datatable-thead th").eq(9).find(".p-datatable-column-filter-button").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("xrd").click();
+    setColumnFilter("blocks", [blockTypes[3]]);
     cy.get(".p-datatable-tbody tr").should("have.length", 1);
-    cy.findByText("Clear").click();
-    cy.get(".p-datatable-filter-overlay").should("not.exist");
 
-    cy.get(".p-datatable-thead th").eq(9).find(".p-datatable-column-filter-button").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("nmr").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("insitu").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("ftir").click();
-    cy.get(".p-datatable-filter-overlay").find(".p-multiselect-label-container").click();
-    cy.get(".p-multiselect-list-container").findByText("xrd").click();
+    setColumnFilter("blocks", blockTypes);
     cy.get(".p-datatable-tbody tr").should("have.length", 1);
-    cy.get(".p-datatable-filter-operator").click();
-    cy.get(".p-select-list-container").findByText("Match Any").click();
-    cy.findByText("Apply").click();
+    setColumnFilter("blocks", blockTypes, FilterOperator.OR);
     cy.get(".p-datatable-tbody tr").should("have.length", 6);
   });
 });


### PR DESCRIPTION
Apply a few changes to hopefully fix the flakiness of the SampleTable component test in CI on electron. These generally passed locally, but often failed on the CI. The issue appears to be related to 2 issues: 
- The datalab primevue theme we use wasn't applied in the component test, hiding a button at some screen sizes
- the slower CI runner meant that some interactions hadn't loaded by the time the test runner was looking for them, specifically in the column filters.
