### PR TITLE
Add routes and event handling for hot-loading data into bokeh

### DIFF
--- a/pydatalab/src/pydatalab/blocks/base.py
+++ b/pydatalab/src/pydatalab/blocks/base.py
@@ -18,6 +18,21 @@ from pydatalab.logger import LOGGER
 from pydatalab.models.blocks import DataBlockResponse
 
 
+class UnknownColumn(BadRequest):
+    """The block has no such data column.
+
+    Distinct from asking for a column in units it does not have: this one names
+    nothing the block holds, so listing the units of anything would be noise.
+    """
+
+    def __init__(self, column: str, available: Iterable[str]):
+        self.column = column
+        super().__init__(
+            f"This block has no column {column!r}. "
+            f"It holds: {', '.join(repr(c) for c in available) or 'nothing'}."
+        )
+
+
 class UnsupportedUnits(BadRequest):
     """The requested units are not among those the block declares for that column.
 
@@ -52,6 +67,7 @@ __all__ = (
     "generate_random_id",
     "DataBlock",
     "generate_js_callback_single_float_parameter",
+    "UnknownColumn",
     "UnsupportedUnits",
     "MissingMetadataForUnits",
 )
@@ -421,6 +437,7 @@ class DataBlock:
             what the axis showing that column should be called.
 
         Raises:
+            UnknownColumn: If the block holds no such column.
             UnsupportedUnits: If a column cannot be expressed in the units asked for.
             MissingMetadataForUnits: If it could be, but a metadata value is missing.
 

--- a/pydatalab/src/pydatalab/blocks/base.py
+++ b/pydatalab/src/pydatalab/blocks/base.py
@@ -3,20 +3,58 @@ import pprint
 import random
 import traceback
 import warnings
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from datetime import datetime, timezone
 from typing import Any
 
 from flask import has_request_context
 from flask_login import current_user
 from pydantic import BaseModel
+from werkzeug.exceptions import BadRequest, UnprocessableEntity
 
 from pydatalab import __version__
 from pydatalab.blocks.metadata import AUTO, USER, MetadataResolution, resolve_metadata
 from pydatalab.logger import LOGGER
 from pydatalab.models.blocks import DataBlockResponse
 
-__all__ = ("generate_random_id", "DataBlock", "generate_js_callback_single_float_parameter")
+
+class UnsupportedUnits(BadRequest):
+    """The requested units are not among those the block declares for that column.
+
+    A client error: no state of the block could satisfy this request.
+    """
+
+    def __init__(self, column: str, units: str, supported: Iterable[str]):
+        self.column, self.units = column, units
+        super().__init__(
+            f"Column {column!r} cannot be given in {units!r}. "
+            f"Supported units are: {', '.join(repr(u) for u in supported)}."
+        )
+
+
+class MissingMetadataForUnits(UnprocessableEntity):
+    """The requested units are declared, but converting to them needs a metadata
+    value this block does not have -- a mass, a molar mass, a wavelength.
+
+    Not a client error: the request names a real unit, and it will succeed once
+    the missing value is supplied.
+    """
+
+    def __init__(self, column: str, units: str, field: str):
+        self.column, self.units, self.field = column, units, field
+        super().__init__(
+            f"Column {column!r} cannot be given in {units!r} because {field!r} is not "
+            f"set for this block. Supply it and the conversion becomes available."
+        )
+
+
+__all__ = (
+    "generate_random_id",
+    "DataBlock",
+    "generate_js_callback_single_float_parameter",
+    "UnsupportedUnits",
+    "MissingMetadataForUnits",
+)
 
 
 def generate_js_callback_single_float_parameter(
@@ -365,6 +403,31 @@ class DataBlock:
         # the plot functions -- so without this the field would redraw with the value
         # and the source it had before the choice was made.
         self.resolve_metadata()
+
+    def get_data(self, columns: dict[str, str | None]) -> dict[str, dict]:
+        """Return the named data columns, each converted to the units asked for.
+
+        This is a read: it must not alter the block, regenerate a plot or write
+        anything back, so that the client can call it as often as the user moves
+        a widget. It is what lets a plot change what it displays without the
+        block, and the whole Bokeh document with it, being rebuilt.
+
+        Args:
+            columns: The canonical name of each column wanted, mapped to the units
+                it should be given in. `None` means the column's own units.
+
+        Returns:
+            `{"data": {name: [...]}, "labels": {name: "..."}}`, where each label is
+            what the axis showing that column should be called.
+
+        Raises:
+            UnsupportedUnits: If a column cannot be expressed in the units asked for.
+            MissingMetadataForUnits: If it could be, but a metadata value is missing.
+
+        """
+        raise NotImplementedError(
+            f"The {self.blocktype!r} block cannot serve individual data columns."
+        )
 
     def process_events(self, events: list[dict] | dict):
         """Handle any supported events passed to the block."""

--- a/pydatalab/src/pydatalab/routes/v0_1/blocks.py
+++ b/pydatalab/src/pydatalab/routes/v0_1/blocks.py
@@ -457,6 +457,62 @@ def delete_block():
     )  # could try to switch to http 204 is "No Content" success with no json
 
 
+@BLOCKS.route("/blocks/<string:item_id>/<string:block_id>/data", methods=["GET"])
+def get_block_data(item_id: str, block_id: str):
+    """Serve individual data columns from a block, in the units asked for.
+
+    Each `column` query parameter names one column and, after a colon, the units
+    to give it in; omitting the units gives the column as it is stored:
+
+        ?column=moment:emu%2Fg&column=temperature
+
+    This exists so that a plot can change what it shows without the block being
+    reprocessed and its whole Bokeh document rebuilt. It is deliberately a GET
+    that takes no block data: the block is read from the database, so there is no
+    way for a request to alter it, and no large payload to upload.
+
+    The units on offer are fixed by the block's own declaration -- the client
+    names a unit, never a conversion to apply -- so this cannot be used to make a
+    block evaluate anything of the caller's choosing.
+
+    """
+    requested: dict[str, str | None] = {}
+    for parameter in request.args.getlist("column"):
+        column, _, units = parameter.partition(":")
+        if not column:
+            raise BadRequest(f"Malformed column parameter: {parameter!r}")
+        requested[column] = units or None
+
+    if not requested:
+        raise BadRequest("No columns requested; pass at least one `column` parameter.")
+
+    item = flask_mongo.db.items.find_one(
+        {"item_id": item_id, **get_default_permissions(user_only=False)},
+        projection={f"blocks_obj.{block_id}": 1},
+    )
+    if not item:
+        raise NotFound(f"Item with item_id {item_id} not found or not accessible")
+
+    block_data = item.get("blocks_obj", {}).get(block_id)
+    if not block_data:
+        raise NotFound(f"Item {item_id} has no block with block_id {block_id}")
+
+    block_type = block_data["blocktype"]
+    if block_type not in BLOCK_TYPES:
+        raise NotImplemented(  # noqa: F901
+            f"Invalid block type {block_type!r}, must be one of {BLOCK_TYPES.keys()}"
+        )
+
+    block = BLOCK_TYPES[block_type](item_id=item_id, init_data=block_data, unique_id=block_id)
+
+    try:
+        payload = block.get_data(requested)
+    except NotImplementedError as exc:
+        raise NotImplemented(str(exc))  # noqa: F901
+
+    return jsonify({"status": "success", **payload}), 200
+
+
 @BLOCKS.route("/blocks/<string:task_id>/status", methods=["GET"])
 def get_block_task_status(task_id: str):
     task = flask_mongo.db.tasks.find_one({"task_id": task_id, "type": TaskType.BLOCK_PROCESSING})

--- a/pydatalab/tests/server/test_blocks.py
+++ b/pydatalab/tests/server/test_blocks.py
@@ -911,7 +911,12 @@ def test_large_fake_xrd_data_block_serialization(
 @pytest.fixture
 def block_with_columns(admin_client, default_sample_dict, monkeypatch, request):
     """A real block on a real item, standing in for one that serves columns."""
-    from pydatalab.blocks.base import DataBlock, MissingMetadataForUnits, UnsupportedUnits
+    from pydatalab.blocks.base import (
+        DataBlock,
+        MissingMetadataForUnits,
+        UnknownColumn,
+        UnsupportedUnits,
+    )
 
     # The test database is not reset between tests, so each needs its own item.
     # Item ids are capped at 40 characters, hence the digest rather than the name.
@@ -932,7 +937,7 @@ def block_with_columns(admin_client, default_sample_dict, monkeypatch, request):
         def get_data(self, columns):
             for column, units in columns.items():
                 if column != "moment":
-                    raise UnsupportedUnits(column, units, ["emu", "emu/g"])
+                    raise UnknownColumn(column, ["moment"])
                 if units not in (None, "emu", "emu/g"):
                     raise UnsupportedUnits(column, units, ["emu", "emu/g"])
                 if units == "emu/g":
@@ -974,6 +979,18 @@ def test_an_unsupported_unit_and_a_missing_metadata_value_are_told_apart(
     assert unavailable.status_code == 422
     assert unavailable.json["title"] == "MissingMetadataForUnits"
     assert "sample_mass_mg" in unavailable.json["message"]
+
+
+def test_a_column_the_block_does_not_have_is_a_different_answer_again(
+    admin_client, block_with_columns
+):
+    """Listing the units of something it does not hold would be noise."""
+    sample_id, block_id = block_with_columns
+    response = admin_client.get(f"/blocks/{sample_id}/{block_id}/data?column=nonsense")
+
+    assert response.status_code == 400
+    assert response.json["title"] == "UnknownColumn"
+    assert "'moment'" in response.json["message"]
 
 
 def test_get_block_data_needs_at_least_one_column(admin_client, block_with_columns):

--- a/pydatalab/tests/server/test_blocks.py
+++ b/pydatalab/tests/server/test_blocks.py
@@ -1,4 +1,5 @@
 import datetime
+from hashlib import blake2s
 from pathlib import Path
 
 import pytest
@@ -905,3 +906,98 @@ def test_large_fake_xrd_data_block_serialization(
     assert response.json["new_block_data"]["bokeh_plot_data"]
 
     gc.collect()
+
+
+@pytest.fixture
+def block_with_columns(admin_client, default_sample_dict, monkeypatch, request):
+    """A real block on a real item, standing in for one that serves columns."""
+    from pydatalab.blocks.base import DataBlock, MissingMetadataForUnits, UnsupportedUnits
+
+    # The test database is not reset between tests, so each needs its own item.
+    # Item ids are capped at 40 characters, hence the digest rather than the name.
+    sample_id = f"test_columns_{blake2s(request.node.name.encode(), digest_size=4).hexdigest()}"
+    sample_data = {**default_sample_dict, "item_id": sample_id}
+    assert admin_client.post("/new-sample/", json=sample_data).status_code == 201
+
+    block_type = next(iter(BLOCK_TYPES))
+    response = admin_client.post(
+        "/add-data-block/", json={"block_type": block_type, "item_id": sample_id, "index": 0}
+    )
+    assert response.status_code == 200
+    block_id = response.json["new_block_obj"]["block_id"]
+
+    class ColumnServingBlock(DataBlock):
+        blocktype = block_type
+
+        def get_data(self, columns):
+            for column, units in columns.items():
+                if column != "moment":
+                    raise UnsupportedUnits(column, units, ["emu", "emu/g"])
+                if units not in (None, "emu", "emu/g"):
+                    raise UnsupportedUnits(column, units, ["emu", "emu/g"])
+                if units == "emu/g":
+                    raise MissingMetadataForUnits(column, units, "sample_mass_mg")
+            return {"data": {"moment": [1.0, 2.0]}, "labels": {"moment": "Moment (emu)"}}
+
+    monkeypatch.setitem(BLOCK_TYPES, block_type, ColumnServingBlock)
+    return sample_id, block_id
+
+
+def test_get_block_data_returns_the_requested_columns(admin_client, block_with_columns):
+    sample_id, block_id = block_with_columns
+    response = admin_client.get(f"/blocks/{sample_id}/{block_id}/data?column=moment:emu")
+
+    assert response.status_code == 200
+    assert response.json["data"] == {"moment": [1.0, 2.0]}
+    assert response.json["labels"] == {"moment": "Moment (emu)"}
+
+
+def test_get_block_data_takes_a_column_without_units(admin_client, block_with_columns):
+    sample_id, block_id = block_with_columns
+    response = admin_client.get(f"/blocks/{sample_id}/{block_id}/data?column=moment")
+    assert response.status_code == 200
+
+
+def test_an_unsupported_unit_and_a_missing_metadata_value_are_told_apart(
+    admin_client, block_with_columns
+):
+    """Both refuse the request, but only one of them is the client's fault, and
+    only one of them tells the user what to do about it."""
+    sample_id, block_id = block_with_columns
+
+    unsupported = admin_client.get(f"/blocks/{sample_id}/{block_id}/data?column=moment:furlongs")
+    assert unsupported.status_code == 400
+    assert unsupported.json["title"] == "UnsupportedUnits"
+    assert "'emu'" in unsupported.json["message"]
+
+    unavailable = admin_client.get(f"/blocks/{sample_id}/{block_id}/data?column=moment:emu%2Fg")
+    assert unavailable.status_code == 422
+    assert unavailable.json["title"] == "MissingMetadataForUnits"
+    assert "sample_mass_mg" in unavailable.json["message"]
+
+
+def test_get_block_data_needs_at_least_one_column(admin_client, block_with_columns):
+    sample_id, block_id = block_with_columns
+    assert admin_client.get(f"/blocks/{sample_id}/{block_id}/data").status_code == 400
+
+
+def test_a_block_that_does_not_serve_columns_says_so(admin_client, default_sample_dict, request):
+    sample_id = f"test_columns_{blake2s(request.node.name.encode(), digest_size=4).hexdigest()}"
+    admin_client.post("/new-sample/", json={**default_sample_dict, "item_id": sample_id})
+    block_type = next(iter(BLOCK_TYPES))
+    response = admin_client.post(
+        "/add-data-block/", json={"block_type": block_type, "item_id": sample_id, "index": 0}
+    )
+    block_id = response.json["new_block_obj"]["block_id"]
+
+    response = admin_client.get(f"/blocks/{sample_id}/{block_id}/data?column=moment")
+    assert response.status_code == 501
+
+
+def test_get_block_data_on_a_missing_item_or_block(admin_client, block_with_columns):
+    sample_id, block_id = block_with_columns
+
+    assert admin_client.get(f"/blocks/nonexistent/{block_id}/data?column=moment").status_code == 404
+    assert (
+        admin_client.get(f"/blocks/{sample_id}/nonexistent/data?column=moment").status_code == 404
+    )

--- a/webapp/src/components/BokehPlot.vue
+++ b/webapp/src/components/BokehPlot.vue
@@ -6,6 +6,9 @@
 
 <script>
 import * as Bokeh from "bokeh";
+
+import store from "@/store/index.js";
+import { updateBlockFromServer } from "@/server_fetch_utils.js";
 // var BokehDoc = null
 
 export default {
@@ -13,6 +16,16 @@ export default {
     bokehPlotData: {
       type: Object,
       required: true,
+    },
+    // Widgets inside the plot dispatch `block-event` to ask the server for
+    // something, and the event has to say which block it came from.
+    item_id: {
+      type: String,
+      default: null,
+    },
+    block_id: {
+      type: String,
+      default: null,
     },
   },
   data: function () {
@@ -38,15 +51,34 @@ export default {
   },
   mounted() {
     this.unique_id = this.guidGenerator();
+    document.addEventListener("block-event", this.handleBokehEvent);
     this.$nextTick(() => {
       this.startBokehPlot();
     });
   },
   unmounted() {
+    document.removeEventListener("block-event", this.handleBokehEvent);
     this.cleanupBokehPlot();
   },
   // BokehDoc: null, // this is a non-reactive property. We don't put this is in Data so Vue doesn't wrap it in a Proxy, which breaks its document.clear() functionality (for some reason)
   methods: {
+    async handleBokehEvent(event) {
+      // Only handle events for this specific block
+      if (event.detail.block_id !== this.block_id) {
+        return;
+      }
+
+      console.log("handlingBokehEvent", event.detail, "for block", this.block_id);
+
+      updateBlockFromServer(
+        this.item_id,
+        this.block_id,
+        store.state.all_item_data[this.item_id]["blocks_obj"][this.block_id],
+        event.detail,
+      ).catch((error) => {
+        console.error("Error updating block:", error);
+      });
+    },
     async startBokehPlot() {
       if (this.bokehPlotData) {
         this.cleanupBokehPlot();

--- a/webapp/src/components/BokehPlot.vue
+++ b/webapp/src/components/BokehPlot.vue
@@ -145,7 +145,7 @@ export default {
           // add some bootrap styles to bokeh widgets. This is not very elegants
           var bokehSelectElements = document.querySelectorAll("div.bk-input-group>select");
           bokehSelectElements.forEach((element) => {
-            element.classList.add("form-control", "ml-4");
+            element.classList.add("form-control", "form-control-sm", "ml-2");
             element.classList.remove("bk-input", "bk");
           });
           var bokehSelectLabelElements = document.querySelectorAll("div.bk-input-group>label");
@@ -154,7 +154,10 @@ export default {
           });
           var bokehInputGroups = document.querySelectorAll("div.bk-input-group");
           bokehInputGroups.forEach((element) => {
-            element.classList.add("input-group", "form-inline", "col-sm-6");
+            // No width class here: a widget's width is set by whatever the plot put
+            // it in. Pinning every input group to half a row overrode that, so a
+            // control laid out to fill its column only ever filled half of it.
+            element.classList.add("input-group", "form-inline");
             element.classList.remove("bk-input-group", "bk");
           });
         } catch (error) {

--- a/webapp/src/components/BokehPlot.vue
+++ b/webapp/src/components/BokehPlot.vue
@@ -8,7 +8,7 @@
 import * as Bokeh from "bokeh";
 
 import store from "@/store/index.js";
-import { updateBlockFromServer } from "@/server_fetch_utils.js";
+import { getBlockData, updateBlockFromServer } from "@/server_fetch_utils.js";
 // var BokehDoc = null
 
 export default {
@@ -70,6 +70,13 @@ export default {
 
       console.log("handlingBokehEvent", event.detail, "for block", this.block_id);
 
+      // A request for data is a read, so it does not go anywhere near the block
+      // update path: the arrays are patched into the plot that is already on
+      // screen, which keeps its zoom, its selection and its widget state.
+      if (event.detail.event_name === "get_data") {
+        return this.patchColumns(event.detail);
+      }
+
       updateBlockFromServer(
         this.item_id,
         this.block_id,
@@ -78,6 +85,38 @@ export default {
       ).catch((error) => {
         console.error("Error updating block:", error);
       });
+    },
+    async patchColumns({ columns, source, keys }) {
+      // `columns` says which columns to fetch and in what units; `keys` says what
+      // to call each one in the data source. The plot decides both -- everything
+      // here knows is how to put an array where it was asked to.
+      const target = this.BokehDoc && this.BokehDoc.get_model_by_name(source);
+      if (!target) {
+        console.warn(`No data source named ${source} in this plot`);
+        return;
+      }
+
+      try {
+        const response = await getBlockData(this.item_id, this.block_id, columns);
+        if (!response) {
+          return;
+        }
+
+        const data = { ...target.data };
+        for (const [column, values] of Object.entries(response.data)) {
+          data[keys[column] ?? column] = values;
+        }
+        target.data = data;
+
+        store.commit("setBlockError", { block_id: this.block_id, error: "" });
+      } catch (error) {
+        // The server explains refusals in terms the user can act on, e.g. which
+        // metadata field a unit needs, so show it rather than only logging it.
+        store.commit("setBlockError", {
+          block_id: this.block_id,
+          error: error?.message || String(error),
+        });
+      }
     },
     async startBokehPlot() {
       if (this.bokehPlotData) {

--- a/webapp/src/components/datablocks/BokehBlock.vue
+++ b/webapp/src/components/datablocks/BokehBlock.vue
@@ -25,7 +25,7 @@
 
     <template #plot>
       <div id="bokehPlotContainer" class="limited-width">
-        <BokehPlot :bokeh-plot-data="bokehPlotData" />
+        <BokehPlot :item_id="item_id" :block_id="block_id" :bokeh-plot-data="bokehPlotData" />
       </div>
     </template>
   </DataBlockBase>

--- a/webapp/src/components/datablocks/CycleBlock.vue
+++ b/webapp/src/components/datablocks/CycleBlock.vue
@@ -204,7 +204,12 @@
           class="col mx-auto"
           :class="{ 'limited-width': bokehPlotLimitedWidth, blurry: isUpdating }"
         >
-          <BokehPlot v-if="bokehPlotData" :bokeh-plot-data="bokehPlotData" />
+          <BokehPlot
+            v-if="bokehPlotData"
+            :item_id="item_id"
+            :block_id="block_id"
+            :bokeh-plot-data="bokehPlotData"
+          />
         </div>
       </div>
     </div>

--- a/webapp/src/components/datablocks/DataBlockBase.vue
+++ b/webapp/src/components/datablocks/DataBlockBase.vue
@@ -309,10 +309,6 @@ export default {
         this.contentMaxHeight = "none";
       }
     });
-    document.addEventListener("block-event", this.handleBokehEvent);
-  },
-  beforeUnmount() {
-    document.removeEventListener("block-event", this.handleBokehEvent);
   },
   methods: {
     notifyLayoutChange() {
@@ -330,23 +326,6 @@ export default {
     },
     async updateBlock() {
       await updateBlockFromServer(this.item_id, this.block_id, this.block).catch((error) => {
-        console.error("Error updating block:", error);
-      });
-    },
-    async handleBokehEvent(event) {
-      // Only handle events for this specific block
-      if (event.detail.block_id !== this.block_id) {
-        return;
-      }
-
-      console.log("handlingBokehEvent", event.detail, "for block", this.block_id);
-
-      updateBlockFromServer(
-        this.item_id,
-        this.block_id,
-        this.$store.state.all_item_data[this.item_id]["blocks_obj"][this.block_id],
-        event.detail,
-      ).catch((error) => {
         console.error("Error updating block:", error);
       });
     },

--- a/webapp/src/components/datablocks/NMRBlock.vue
+++ b/webapp/src/components/datablocks/NMRBlock.vue
@@ -63,7 +63,12 @@ DataBlockBase as a prop, and save from within DataBlockBase  -->
 
     <template #plot>
       <div v-show="file_id" id="bokehPlotContainer">
-        <BokehPlot v-if="bokehPlotData" :bokeh-plot-data="bokehPlotData" />
+        <BokehPlot
+          v-if="bokehPlotData"
+          :item_id="item_id"
+          :block_id="block_id"
+          :bokeh-plot-data="bokehPlotData"
+        />
       </div>
     </template>
   </DataBlockBase>

--- a/webapp/src/components/datablocks/NMRInsituBlock.vue
+++ b/webapp/src/components/datablocks/NMRInsituBlock.vue
@@ -92,7 +92,7 @@
     </template>
 
     <template #plot>
-      <BokehPlot :bokeh-plot-data="bokehPlotData" />
+      <BokehPlot :item_id="item_id" :block_id="block_id" :bokeh-plot-data="bokehPlotData" />
     </template>
   </DataBlockBase>
 </template>

--- a/webapp/src/components/datablocks/UVVisBlock.vue
+++ b/webapp/src/components/datablocks/UVVisBlock.vue
@@ -11,7 +11,7 @@
       />
     </div>
     <div id="bokehPlotContainer">
-      <BokehPlot :bokeh-plot-data="bokehPlotData" />
+      <BokehPlot :item_id="item_id" :block_id="block_id" :bokeh-plot-data="bokehPlotData" />
     </div>
   </DataBlockBase>
 </template>

--- a/webapp/src/components/datablocks/UVVisInsituBlock.vue
+++ b/webapp/src/components/datablocks/UVVisInsituBlock.vue
@@ -74,7 +74,12 @@
     </template>
 
     <template #plot>
-      <BokehPlot v-if="bokehPlotData" :bokeh-plot-data="bokehPlotData" />
+      <BokehPlot
+        v-if="bokehPlotData"
+        :item_id="item_id"
+        :block_id="block_id"
+        :bokeh-plot-data="bokehPlotData"
+      />
     </template>
   </DataBlockBase>
 </template>

--- a/webapp/src/components/datablocks/XRDInsituBlock.vue
+++ b/webapp/src/components/datablocks/XRDInsituBlock.vue
@@ -109,7 +109,12 @@
         id="bokehPlotContainer"
         class="col-xl-10 col-lg-11 col-md-12 d-flex justify-content-center overflow-auto"
       >
-        <BokehPlot :bokeh-plot-data="bokehPlotData" class="mw-100" />
+        <BokehPlot
+          :item_id="item_id"
+          :block_id="block_id"
+          :bokeh-plot-data="bokehPlotData"
+          class="mw-100"
+        />
       </div>
     </div>
   </DataBlockBase>

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -829,6 +829,23 @@ export async function getCollectionData(collection_id) {
     });
 }
 
+export async function getBlockData(item_id, block_id, columns) {
+  // Ask the server for individual data columns from a block, each in the units
+  // wanted, e.g. `{moment: "emu/g", temperature: null}` for the stored units.
+  //
+  // This is a read: it cannot change the block, and the response carries only the
+  // columns asked for, so a plot can use it to change what it shows without being
+  // rebuilt.
+  if (!(await waitForUserAuth())) return;
+
+  const query = Object.entries(columns)
+    .map(([column, units]) => (units ? `${column}:${units}` : column))
+    .map((parameter) => `column=${encodeURIComponent(parameter)}`)
+    .join("&");
+
+  return fetch_get(`${API_URL}/blocks/${item_id}/${block_id}/data?${query}`);
+}
+
 export async function updateBlockFromServer(item_id, block_id, block_data, event_data = null) {
   // Send the current block state to the API and receive an updated version
   // of the block in return, including any event data.


### PR DESCRIPTION
I am currently playing with adding a data schema to the private magnetometry block, with the goal of contributing a clean version of the block updates back to datalab once we are happy it. The goal is to have parsed data validated with a  pydantic schema, and stored in the db. The API will then be able to serve data directly. 

As part of this, I am working on the ability to request data in different units (e.g., temperature in K vs °C or diffraction data in 2θ or Q). This requires a new route and changes to the bokeh event handling in the frontend, so it can't live in the magnetometry plugin alone. These core changes are being made in this branch, which will co-develop with the plugin.

Note: besides the new changes, this also migrates the existing bokeh event handling from DataBlockBase.vue to BokehPlot.vue