### PR TITLE
Keep track of provenance in the metadata viewer, and allow user to override values

### DIFF
--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -319,6 +319,21 @@
           "description": "The same metadata with its provenance: per field, the value, the source it\ncame from, and what each other source has to offer. Derived on every render, so\na value taken from a file or a sample follows that file or sample when it\nchanges.",
           "title": "Metadata Fields"
         },
+        "metadata_source_labels": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "datalab_exclude_from_load": true,
+          "default": null,
+          "description": "What to call each metadata source when showing it to somebody -- the name of\nthe file it was read from, say, rather than \"file\".",
+          "title": "Metadata Source Labels"
+        },
         "metadata_bindings": {
           "anyOf": [
             {

--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -344,8 +344,9 @@
               "type": "null"
             }
           ],
+          "datalab_exclude_from_load": true,
           "default": null,
-          "description": "Where each metadata field should be taken from, where the user has said.\n\nUnlike the two above this is not derived, it is the choice itself: a field\nbound to the user carries the value they gave, and one bound to a source is\nre-read from it. A field with no binding is left to the block to decide, and is\ndecided again each time it renders.",
+          "description": "Where each metadata field should be taken from, where the user has said.\n\nUnlike the two above this is not derived, it is the choice itself: a field\nbound to the user carries the value they gave, and one bound to a source is\nre-read from it. A field with no binding is left to the block to decide, and is\ndecided again each time it renders.\n\nOnly `set_metadata_source` may write it. It records who made each choice and\nwhen, and a value the web could set directly would be a claim about a person\nthat nobody checked -- which is the one thing this must not be.",
           "title": "Metadata Bindings"
         }
       },

--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -303,6 +303,35 @@
           "default": null,
           "description": "Any structured metadata associated with the block, for example,\nexperimental acquisition parameters.",
           "title": "Metadata"
+        },
+        "metadata_fields": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "datalab_exclude_from_load": true,
+          "default": null,
+          "description": "The same metadata with its provenance: per field, the value, the source it\ncame from, and what each other source has to offer. Derived on every render, so\na value taken from a file or a sample follows that file or sample when it\nchanges.",
+          "title": "Metadata Fields"
+        },
+        "metadata_bindings": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Where each metadata field should be taken from, where the user has said.\n\nUnlike the two above this is not derived, it is the choice itself: a field\nbound to the user carries the value they gave, and one bound to a source is\nre-read from it. A field with no binding is left to the block to decide, and is\ndecided again each time it renders.",
+          "title": "Metadata Bindings"
         }
       },
       "required": [

--- a/pydatalab/schemas/equipment.json
+++ b/pydatalab/schemas/equipment.json
@@ -249,6 +249,21 @@
           "description": "The same metadata with its provenance: per field, the value, the source it\ncame from, and what each other source has to offer. Derived on every render, so\na value taken from a file or a sample follows that file or sample when it\nchanges.",
           "title": "Metadata Fields"
         },
+        "metadata_source_labels": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "datalab_exclude_from_load": true,
+          "default": null,
+          "description": "What to call each metadata source when showing it to somebody -- the name of\nthe file it was read from, say, rather than \"file\".",
+          "title": "Metadata Source Labels"
+        },
         "metadata_bindings": {
           "anyOf": [
             {

--- a/pydatalab/schemas/equipment.json
+++ b/pydatalab/schemas/equipment.json
@@ -233,6 +233,35 @@
           "default": null,
           "description": "Any structured metadata associated with the block, for example,\nexperimental acquisition parameters.",
           "title": "Metadata"
+        },
+        "metadata_fields": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "datalab_exclude_from_load": true,
+          "default": null,
+          "description": "The same metadata with its provenance: per field, the value, the source it\ncame from, and what each other source has to offer. Derived on every render, so\na value taken from a file or a sample follows that file or sample when it\nchanges.",
+          "title": "Metadata Fields"
+        },
+        "metadata_bindings": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Where each metadata field should be taken from, where the user has said.\n\nUnlike the two above this is not derived, it is the choice itself: a field\nbound to the user carries the value they gave, and one bound to a source is\nre-read from it. A field with no binding is left to the block to decide, and is\ndecided again each time it renders.",
+          "title": "Metadata Bindings"
         }
       },
       "required": [

--- a/pydatalab/schemas/equipment.json
+++ b/pydatalab/schemas/equipment.json
@@ -274,8 +274,9 @@
               "type": "null"
             }
           ],
+          "datalab_exclude_from_load": true,
           "default": null,
-          "description": "Where each metadata field should be taken from, where the user has said.\n\nUnlike the two above this is not derived, it is the choice itself: a field\nbound to the user carries the value they gave, and one bound to a source is\nre-read from it. A field with no binding is left to the block to decide, and is\ndecided again each time it renders.",
+          "description": "Where each metadata field should be taken from, where the user has said.\n\nUnlike the two above this is not derived, it is the choice itself: a field\nbound to the user carries the value they gave, and one bound to a source is\nre-read from it. A field with no binding is left to the block to decide, and is\ndecided again each time it renders.\n\nOnly `set_metadata_source` may write it. It records who made each choice and\nwhen, and a value the web could set directly would be a claim about a person\nthat nobody checked -- which is the one thing this must not be.",
           "title": "Metadata Bindings"
         }
       },

--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -316,8 +316,9 @@
               "type": "null"
             }
           ],
+          "datalab_exclude_from_load": true,
           "default": null,
-          "description": "Where each metadata field should be taken from, where the user has said.\n\nUnlike the two above this is not derived, it is the choice itself: a field\nbound to the user carries the value they gave, and one bound to a source is\nre-read from it. A field with no binding is left to the block to decide, and is\ndecided again each time it renders.",
+          "description": "Where each metadata field should be taken from, where the user has said.\n\nUnlike the two above this is not derived, it is the choice itself: a field\nbound to the user carries the value they gave, and one bound to a source is\nre-read from it. A field with no binding is left to the block to decide, and is\ndecided again each time it renders.\n\nOnly `set_metadata_source` may write it. It records who made each choice and\nwhen, and a value the web could set directly would be a claim about a person\nthat nobody checked -- which is the one thing this must not be.",
           "title": "Metadata Bindings"
         }
       },

--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -291,6 +291,21 @@
           "description": "The same metadata with its provenance: per field, the value, the source it\ncame from, and what each other source has to offer. Derived on every render, so\na value taken from a file or a sample follows that file or sample when it\nchanges.",
           "title": "Metadata Fields"
         },
+        "metadata_source_labels": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "datalab_exclude_from_load": true,
+          "default": null,
+          "description": "What to call each metadata source when showing it to somebody -- the name of\nthe file it was read from, say, rather than \"file\".",
+          "title": "Metadata Source Labels"
+        },
         "metadata_bindings": {
           "anyOf": [
             {

--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -275,6 +275,35 @@
           "default": null,
           "description": "Any structured metadata associated with the block, for example,\nexperimental acquisition parameters.",
           "title": "Metadata"
+        },
+        "metadata_fields": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "datalab_exclude_from_load": true,
+          "default": null,
+          "description": "The same metadata with its provenance: per field, the value, the source it\ncame from, and what each other source has to offer. Derived on every render, so\na value taken from a file or a sample follows that file or sample when it\nchanges.",
+          "title": "Metadata Fields"
+        },
+        "metadata_bindings": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Where each metadata field should be taken from, where the user has said.\n\nUnlike the two above this is not derived, it is the choice itself: a field\nbound to the user carries the value they gave, and one bound to a source is\nre-read from it. A field with no binding is left to the block to decide, and is\ndecided again each time it renders.",
+          "title": "Metadata Bindings"
         }
       },
       "required": [

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -316,8 +316,9 @@
               "type": "null"
             }
           ],
+          "datalab_exclude_from_load": true,
           "default": null,
-          "description": "Where each metadata field should be taken from, where the user has said.\n\nUnlike the two above this is not derived, it is the choice itself: a field\nbound to the user carries the value they gave, and one bound to a source is\nre-read from it. A field with no binding is left to the block to decide, and is\ndecided again each time it renders.",
+          "description": "Where each metadata field should be taken from, where the user has said.\n\nUnlike the two above this is not derived, it is the choice itself: a field\nbound to the user carries the value they gave, and one bound to a source is\nre-read from it. A field with no binding is left to the block to decide, and is\ndecided again each time it renders.\n\nOnly `set_metadata_source` may write it. It records who made each choice and\nwhen, and a value the web could set directly would be a claim about a person\nthat nobody checked -- which is the one thing this must not be.",
           "title": "Metadata Bindings"
         }
       },

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -291,6 +291,21 @@
           "description": "The same metadata with its provenance: per field, the value, the source it\ncame from, and what each other source has to offer. Derived on every render, so\na value taken from a file or a sample follows that file or sample when it\nchanges.",
           "title": "Metadata Fields"
         },
+        "metadata_source_labels": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "datalab_exclude_from_load": true,
+          "default": null,
+          "description": "What to call each metadata source when showing it to somebody -- the name of\nthe file it was read from, say, rather than \"file\".",
+          "title": "Metadata Source Labels"
+        },
         "metadata_bindings": {
           "anyOf": [
             {

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -275,6 +275,35 @@
           "default": null,
           "description": "Any structured metadata associated with the block, for example,\nexperimental acquisition parameters.",
           "title": "Metadata"
+        },
+        "metadata_fields": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "datalab_exclude_from_load": true,
+          "default": null,
+          "description": "The same metadata with its provenance: per field, the value, the source it\ncame from, and what each other source has to offer. Derived on every render, so\na value taken from a file or a sample follows that file or sample when it\nchanges.",
+          "title": "Metadata Fields"
+        },
+        "metadata_bindings": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Where each metadata field should be taken from, where the user has said.\n\nUnlike the two above this is not derived, it is the choice itself: a field\nbound to the user carries the value they gave, and one bound to a source is\nre-read from it. A field with no binding is left to the block to decide, and is\ndecided again each time it renders.",
+          "title": "Metadata Bindings"
         }
       },
       "required": [

--- a/pydatalab/src/pydatalab/blocks/base.py
+++ b/pydatalab/src/pydatalab/blocks/base.py
@@ -162,6 +162,10 @@ class DataBlock:
     version: str = __version__
     """The implementation version of this particular block."""
 
+    _event_errors: tuple[str, ...] = ()
+    """Errors from events handled during this request, kept apart from the block's
+    stored errors so that they survive a plot that then succeeds."""
+
     def __init__(
         self,
         item_id: str | None = None,
@@ -232,7 +236,7 @@ class DataBlock:
 
     def to_web(self) -> dict[str, Any]:
         """Returns a JSON serializable dictionary to render the data block on the web."""
-        block_errors = []
+        block_errors = list(self._event_errors)
         block_warnings = []
         if self.plot_functions:
             for plot in self.plot_functions:
@@ -292,10 +296,14 @@ class DataBlock:
     def metadata_sources(self) -> dict[str, dict]:
         """Where this block's metadata can come from, best first.
 
-        A block returns what each source has, e.g. the header it just parsed and
-        the item it is attached to. Every source is read whether or not it wins,
-        so that the interface can show what the others offer and let the user
-        switch between them.
+        A block returns what each source has, e.g. the header of the file it reads
+        and the item it is attached to. Every source is read whether or not it
+        wins, so that the interface can show what the others offer and let the
+        user switch between them.
+
+        This is called whenever a binding is set as well as when the block renders,
+        and an event can arrive before anything has been rendered, so it must not
+        depend on rendering having happened.
         """
         return {}
 
@@ -369,9 +377,12 @@ class DataBlock:
                         self.__class__.__name__,
                         e,
                     )
-                    self.data["errors"] = [
-                        f"{self.__class__.__name__}: Error processing event {event}: {e}"
-                    ]
+                    message = f"{self.__class__.__name__}: Error processing event {event}: {e}"
+                    # Kept on the instance as well: `to_web` rebuilds the stored
+                    # errors from whatever the plots report, and an event that
+                    # failed before a plot that succeeded would otherwise vanish.
+                    self._event_errors = (*self._event_errors, message)
+                    self.data["errors"] = [message]
 
     @event()
     def null_event(self, **kwargs):

--- a/pydatalab/src/pydatalab/blocks/base.py
+++ b/pydatalab/src/pydatalab/blocks/base.py
@@ -276,6 +276,12 @@ class DataBlock:
         """
         return {}
 
+    def metadata_source_labels(self) -> dict[str, str]:
+        """How to name each source to a person: the file it was read from, the item
+        it came off. Falls back to the source's own key where there is nothing
+        better to say."""
+        return {}
+
     def resolve_metadata(self) -> "MetadataResolution":
         """Resolve the metadata, honouring any bindings the user has set."""
         if self.metadata_model is None:
@@ -288,6 +294,7 @@ class DataBlock:
         )
         self.data["metadata"] = resolution.metadata.model_dump()
         self.data["metadata_fields"] = resolution.fields
+        self.data["metadata_source_labels"] = self.metadata_source_labels()
         return resolution
 
     @event()

--- a/pydatalab/src/pydatalab/blocks/base.py
+++ b/pydatalab/src/pydatalab/blocks/base.py
@@ -343,17 +343,28 @@ class DataBlock:
         if self.metadata_model is None or field not in self.metadata_model.model_fields:
             raise ValueError(f"{self.blocktype!r} has no metadata field {field!r}")
 
+        sources = self.metadata_sources()
+        if reserved := {USER, AUTO} & set(sources):
+            raise ValueError(
+                f"{self.blocktype!r} names a metadata source {reserved.pop()!r}, which this "
+                "event answers itself; a source cannot be called either of those."
+            )
+
         bindings = dict(self.data.get("metadata_bindings") or {})
         if source == AUTO:
             bindings.pop(field, None)
         elif source == USER:
             bindings[field] = {"source": USER, "value": value, **_who_and_when()}
-        elif source in self.metadata_sources():
+        elif source in sources:
             bindings[field] = {"source": source, **_who_and_when()}
         else:
             raise ValueError(f"{field!r} cannot be taken from {source!r}")
 
         self.data["metadata_bindings"] = bindings
+        # Nothing else re-resolves before the response is built -- `to_web` only runs
+        # the plot functions -- so without this the field would redraw with the value
+        # and the source it had before the choice was made.
+        self.resolve_metadata()
 
     def process_events(self, events: list[dict] | dict):
         """Handle any supported events passed to the block."""

--- a/pydatalab/src/pydatalab/blocks/base.py
+++ b/pydatalab/src/pydatalab/blocks/base.py
@@ -6,7 +6,10 @@ import warnings
 from collections.abc import Callable, Sequence
 from typing import Any
 
+from pydantic import BaseModel
+
 from pydatalab import __version__
+from pydatalab.blocks.metadata import AUTO, USER, MetadataResolution, resolve_metadata
 from pydatalab.logger import LOGGER
 from pydatalab.models.blocks import DataBlockResponse
 
@@ -255,6 +258,64 @@ class DataBlock:
             self.data.pop("warnings", None)
 
         return self.block_db_model(**self.data).model_dump(exclude_unset=True, exclude_none=True)
+
+    metadata_model: type[BaseModel] | None = None
+    """Describes the metadata this block reads, if it reads any.
+
+    Every field must be optional: a block fills in whatever its sources happen to
+    have, and a field none of them supply is simply empty.
+    """
+
+    def metadata_sources(self) -> dict[str, dict]:
+        """Where this block's metadata can come from, best first.
+
+        A block returns what each source has, e.g. the header it just parsed and
+        the item it is attached to. Every source is read whether or not it wins,
+        so that the interface can show what the others offer and let the user
+        switch between them.
+        """
+        return {}
+
+    def resolve_metadata(self) -> "MetadataResolution":
+        """Resolve the metadata, honouring any bindings the user has set."""
+        if self.metadata_model is None:
+            raise NotImplementedError(f"The {self.blocktype!r} block has no metadata model.")
+
+        resolution = resolve_metadata(
+            self.metadata_model,
+            self.metadata_sources(),
+            self.data.get("metadata_bindings"),
+        )
+        self.data["metadata"] = resolution.metadata.model_dump()
+        self.data["metadata_fields"] = resolution.fields
+        return resolution
+
+    @event()
+    def set_metadata_source(self, field: str, source: str, value: Any = None, **kwargs):
+        """Bind one metadata field to a source, or to a value of the user's own.
+
+        `source` is the name of one of `metadata_sources`, or "user" with a value,
+        or "auto" to drop the binding and let the block choose again.
+
+        Clearing a field is `source="user"` with no value, and is deliberately not
+        the same as "auto": it says there is no good value for this field, which is
+        something worth keeping rather than something to be second-guessed on the
+        next render.
+        """
+        if self.metadata_model is None or field not in self.metadata_model.model_fields:
+            raise ValueError(f"{self.blocktype!r} has no metadata field {field!r}")
+
+        bindings = dict(self.data.get("metadata_bindings") or {})
+        if source == AUTO:
+            bindings.pop(field, None)
+        elif source == USER:
+            bindings[field] = {"source": USER, "value": value}
+        elif source in self.metadata_sources():
+            bindings[field] = {"source": source}
+        else:
+            raise ValueError(f"{field!r} cannot be taken from {source!r}")
+
+        self.data["metadata_bindings"] = bindings
 
     def process_events(self, events: list[dict] | dict):
         """Handle any supported events passed to the block."""

--- a/pydatalab/src/pydatalab/blocks/base.py
+++ b/pydatalab/src/pydatalab/blocks/base.py
@@ -4,8 +4,11 @@ import random
 import traceback
 import warnings
 from collections.abc import Callable, Sequence
+from datetime import datetime, timezone
 from typing import Any
 
+from flask import has_request_context
+from flask_login import current_user
 from pydantic import BaseModel
 
 from pydatalab import __version__
@@ -103,6 +106,26 @@ def generate_random_id():
 ############################################################################################################
 # Resources (base classes to be extended)
 ############################################################################################################
+
+
+def _who_and_when() -> dict[str, str]:
+    """Whose choice this was and when they made it.
+
+    A binding is somebody deciding that a value should not be worked out the usual
+    way, which is worth being able to attribute later. Outside a request there is
+    nobody to name, so only the time is recorded.
+    """
+    stamp = {"set_at": datetime.now(tz=timezone.utc).isoformat()}
+
+    if not has_request_context():
+        return stamp
+
+    person = getattr(current_user, "person", None)
+    if person is not None:
+        stamp["set_by"] = str(person.immutable_id)
+        if person.display_name:
+            stamp["set_by_name"] = person.display_name
+    return stamp
 
 
 class DataBlock:
@@ -316,9 +339,9 @@ class DataBlock:
         if source == AUTO:
             bindings.pop(field, None)
         elif source == USER:
-            bindings[field] = {"source": USER, "value": value}
+            bindings[field] = {"source": USER, "value": value, **_who_and_when()}
         elif source in self.metadata_sources():
-            bindings[field] = {"source": source}
+            bindings[field] = {"source": source, **_who_and_when()}
         else:
             raise ValueError(f"{field!r} cannot be taken from {source!r}")
 

--- a/pydatalab/src/pydatalab/blocks/metadata.py
+++ b/pydatalab/src/pydatalab/blocks/metadata.py
@@ -121,6 +121,13 @@ def resolve_metadata(
             # having filled it in yet.
             "bound": binding is not None,
             "available": available,
+            # Carried through from the binding so that the interface has one place
+            # to look for everything about a field.
+            **{
+                k: binding[k]
+                for k in ("set_by", "set_by_name", "set_at")
+                if binding and k in binding
+            },
         }
 
     return MetadataResolution(metadata=metadata, fields=fields)

--- a/pydatalab/src/pydatalab/blocks/metadata.py
+++ b/pydatalab/src/pydatalab/blocks/metadata.py
@@ -116,6 +116,10 @@ def resolve_metadata(
         fields[field] = {
             "value": _coerce(metadata, field, value),
             "source": source,
+            # Whether the source was chosen or merely landed on, which is the
+            # difference between a decision to leave a field empty and nobody
+            # having filled it in yet.
+            "bound": binding is not None,
             "available": available,
         }
 

--- a/pydatalab/src/pydatalab/blocks/metadata.py
+++ b/pydatalab/src/pydatalab/blocks/metadata.py
@@ -1,0 +1,122 @@
+"""Resolving a block's metadata, and keeping track of where each value came from.
+
+A block's metadata is rarely all from one place. A sample mass might be written
+into a data file by the instrument, a molar mass derived from the sample's
+chemical formula, and either of them corrected by hand. Which of those a value
+came from is worth knowing -- it is the difference between a number the
+instrument measured and one somebody typed -- and it decides what happens to that
+value later.
+
+Each field is *bound* to a source, and it is the binding that persists rather
+than the value:
+
+- Bound to a source, the value is re-read every time the block renders, so it
+  follows the file if the file is replaced, or the sample if the sample is
+  edited.
+- Bound to the user, the value is what the user gave and nothing recomputes it.
+- Bound to nothing, the sources are tried in order until one has a value. This is
+  the block's own guess, so it is made again each time and is free to change its
+  mind when a new file arrives.
+
+The rule that decides between those: the system's choices stay open, and the
+user's choices are kept. Clearing a field by hand is a choice -- it says there is
+no good value for this -- so it is kept too, and is not the same state as a field
+nobody has touched.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel
+
+__all__ = ("USER", "AUTO", "MetadataResolution", "resolve_metadata")
+
+USER = "user"
+"""The binding for a value the user gave, which is stored rather than re-read."""
+
+AUTO = "auto"
+"""Not a binding: asking for this clears one, putting the field back to guessing."""
+
+
+class MetadataResolution(BaseModel):
+    """The outcome of resolving one block's metadata."""
+
+    metadata: BaseModel
+    """The values in force, as the block's own metadata model."""
+
+    fields: dict[str, dict[str, Any]]
+    """Per field, the value, the source it came from, and what the other sources
+    have to offer -- which is what lets the interface say where a number came from
+    and offer the alternatives."""
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+def _coerce(metadata: BaseModel, field: str, value: Any) -> Any:
+    """Put a value through the model, returning what it became, or None.
+
+    A file is free to contain nonsense in a field nobody needs, so a value the
+    model rejects is dropped rather than allowed to fail the whole block.
+    """
+    try:
+        setattr(metadata, field, value)
+    except Exception:  # noqa: S110 -- a bad value is one missing value, not an error
+        return None
+    return getattr(metadata, field)
+
+
+def resolve_metadata(
+    model: type[BaseModel],
+    sources: dict[str, dict],
+    bindings: dict[str, dict] | None = None,
+) -> MetadataResolution:
+    """Work out each field's value, and record where it came from.
+
+    Args:
+        model: The block's metadata model. Every field must be optional, since a
+            block fills in whatever its sources happen to have.
+        sources: What each source offers, best first, e.g.
+            `{"file": {...}, "sample": {...}}`. Every source is read, whether or
+            not it wins, so that the interface can offer them all.
+        bindings: The bindings the user has set, as `{field: {"source": ...}}`,
+            carrying a `"value"` as well when the source is the user.
+
+    """
+    bindings = bindings or {}
+    metadata = model()
+    # A separate instance to try candidate values on, so that reading what a source
+    # offers cannot leave anything behind on the model being built.
+    probe = model()
+    fields: dict[str, dict[str, Any]] = {}
+
+    for field in model.model_fields:
+        # Everything each source has for this field, in the order they were given.
+        available = {
+            name: _coerce(probe, field, values.get(field))
+            for name, values in sources.items()
+            if field in values
+        }
+
+        binding = bindings.get(field)
+        source: str | None
+        value: Any
+        if binding and binding.get("source") == USER:
+            source, value = USER, binding.get("value")
+        elif binding and binding.get("source") in available:
+            source, value = binding["source"], available[binding["source"]]
+        elif binding:
+            # Bound to a source the block no longer has: a file replaced by one
+            # that does not carry this field, say. Left empty rather than quietly
+            # falling back, which would undo a choice somebody made.
+            source, value = binding.get("source"), None
+        else:
+            source, value = next(
+                ((name, v) for name, v in available.items() if v is not None), (None, None)
+            )
+
+        fields[field] = {
+            "value": _coerce(metadata, field, value),
+            "source": source,
+            "available": available,
+        }
+
+    return MetadataResolution(metadata=metadata, fields=fields)

--- a/pydatalab/src/pydatalab/blocks/metadata.py
+++ b/pydatalab/src/pydatalab/blocks/metadata.py
@@ -51,17 +51,18 @@ class MetadataResolution(BaseModel):
     model_config = {"arbitrary_types_allowed": True}
 
 
-def _coerce(metadata: BaseModel, field: str, value: Any) -> Any:
-    """Put a value through the model, returning what it became, or None.
+def _coerce(model: type[BaseModel], field: str, value: Any) -> Any:
+    """What the model makes of a value for one field, or None if it will not have it.
 
-    A file is free to contain nonsense in a field nobody needs, so a value the
-    model rejects is dropped rather than allowed to fail the whole block.
+    Validated rather than assigned: a model only checks assignments if it asks to,
+    and the guarantee here -- that a file is free to contain nonsense in a field
+    nobody needs, and loses only that field by it -- should not depend on whether
+    the block that wrote the model happened to think of that.
     """
     try:
-        setattr(metadata, field, value)
+        return getattr(model.model_validate({field: value}), field)
     except Exception:  # noqa: S110 -- a bad value is one missing value, not an error
         return None
-    return getattr(metadata, field)
 
 
 def resolve_metadata(
@@ -83,20 +84,19 @@ def resolve_metadata(
     """
     bindings = bindings or {}
     metadata = model()
-    # A separate instance to try candidate values on, so that reading what a source
-    # offers cannot leave anything behind on the model being built.
-    probe = model()
     fields: dict[str, dict[str, Any]] = {}
 
     for field in model.model_fields:
         # Everything each source has for this field, in the order they were given.
         available = {
-            name: _coerce(probe, field, values.get(field))
+            name: _coerce(model, field, values.get(field))
             for name, values in sources.items()
             if field in values
         }
 
         binding = bindings.get(field)
+        if not isinstance(binding, dict):
+            binding = None  # nothing readable; treat it as no choice having been made
         source: str | None
         value: Any
         if binding and binding.get("source") == USER:
@@ -113,8 +113,10 @@ def resolve_metadata(
                 ((name, v) for name, v in available.items() if v is not None), (None, None)
             )
 
+        value = _coerce(model, field, value)
+        setattr(metadata, field, value)
         fields[field] = {
-            "value": _coerce(metadata, field, value),
+            "value": value,
             "source": source,
             # Whether the source was chosen or merely landed on, which is the
             # difference between a decision to leave a field empty and nobody

--- a/pydatalab/src/pydatalab/models/blocks.py
+++ b/pydatalab/src/pydatalab/models/blocks.py
@@ -81,6 +81,12 @@ class DataBlockResponse(BaseModel):
     a value taken from a file or a sample follows that file or sample when it
     changes."""
 
+    metadata_source_labels: dict | None = Field(
+        default=None, json_schema_extra={"datalab_exclude_from_load": True}
+    )
+    """What to call each metadata source when showing it to somebody -- the name of
+    the file it was read from, say, rather than "file"."""
+
     metadata_bindings: dict | None = None
     """Where each metadata field should be taken from, where the user has said.
 

--- a/pydatalab/src/pydatalab/models/blocks.py
+++ b/pydatalab/src/pydatalab/models/blocks.py
@@ -87,11 +87,17 @@ class DataBlockResponse(BaseModel):
     """What to call each metadata source when showing it to somebody -- the name of
     the file it was read from, say, rather than "file"."""
 
-    metadata_bindings: dict | None = None
+    metadata_bindings: dict | None = Field(
+        default=None, json_schema_extra={"datalab_exclude_from_load": True}
+    )
     """Where each metadata field should be taken from, where the user has said.
 
     Unlike the two above this is not derived, it is the choice itself: a field
     bound to the user carries the value they gave, and one bound to a source is
     re-read from it. A field with no binding is left to the block to decide, and is
     decided again each time it renders.
+
+    Only `set_metadata_source` may write it. It records who made each choice and
+    when, and a value the web could set directly would be a claim about a person
+    that nobody checked -- which is the one thing this must not be.
     """

--- a/pydatalab/src/pydatalab/models/blocks.py
+++ b/pydatalab/src/pydatalab/models/blocks.py
@@ -72,3 +72,20 @@ class DataBlockResponse(BaseModel):
     )
     """Any structured metadata associated with the block, for example,
     experimental acquisition parameters."""
+
+    metadata_fields: dict | None = Field(
+        default=None, json_schema_extra={"datalab_exclude_from_load": True}
+    )
+    """The same metadata with its provenance: per field, the value, the source it
+    came from, and what each other source has to offer. Derived on every render, so
+    a value taken from a file or a sample follows that file or sample when it
+    changes."""
+
+    metadata_bindings: dict | None = None
+    """Where each metadata field should be taken from, where the user has said.
+
+    Unlike the two above this is not derived, it is the choice itself: a field
+    bound to the user carries the value they gave, and one bound to a source is
+    re-read from it. A field with no binding is left to the block to decide, and is
+    decided again each time it renders.
+    """

--- a/pydatalab/tests/server/test_block_metadata.py
+++ b/pydatalab/tests/server/test_block_metadata.py
@@ -284,6 +284,26 @@ def test_a_block_may_say_what_its_sources_should_be_called():
     assert block.data["metadata_source_labels"] == {"file": "measurement.dat"}
 
 
+def test_an_event_that_failed_is_still_reported_after_a_plot_that_did_not():
+    """`to_web` rebuilds the block's errors from what the plots say, so an event
+    that failed on the way there used to disappear -- leaving a control that did
+    nothing and said nothing about why."""
+
+    class Plotting(_Block):
+        blocktype = "_metadata_test_plotting"
+
+        @property
+        def plot_functions(self):
+            return (lambda: None,)
+
+    block = Plotting(item_id="test")
+    block.process_events(
+        {"event_name": "set_metadata_source", "field": "nope", "source": "user", "value": 1}
+    )
+
+    assert block.to_web()["errors"]
+
+
 def test_resolving_writes_both_the_values_and_their_provenance():
     block = _Block(item_id="test")
     block.resolve_metadata()

--- a/pydatalab/tests/server/test_block_metadata.py
+++ b/pydatalab/tests/server/test_block_metadata.py
@@ -59,6 +59,7 @@ def test_every_source_is_reported_not_only_the_winner():
     assert resolution.fields["sample_mass_mg"] == {
         "value": pytest.approx(14.32),
         "source": "file",
+        "bound": False,
         "available": {"file": pytest.approx(14.32), "sample": pytest.approx(21.0)},
     }
 
@@ -82,7 +83,13 @@ def test_a_user_may_say_a_field_has_no_good_value():
 
 
 def test_which_is_not_the_same_as_never_having_chosen():
-    assert resolve({}).fields["sample_mass_mg"]["source"] == "file"
+    """Both end up on the file's value; only one of them is a decision."""
+    cleared = resolve({"sample_mass_mg": {"source": "user", "value": None}})
+    untouched = resolve({})
+
+    assert cleared.fields["sample_mass_mg"]["bound"] is True
+    assert untouched.fields["sample_mass_mg"]["bound"] is False
+    assert untouched.fields["sample_mass_mg"]["source"] == "file"
 
 
 def test_a_zero_a_user_typed_is_kept_as_their_choice_even_where_it_is_no_value():

--- a/pydatalab/tests/server/test_block_metadata.py
+++ b/pydatalab/tests/server/test_block_metadata.py
@@ -5,6 +5,9 @@ again on every render, so a value follows the file or the sample it came from;
 the user's choices are kept, including the choice that a field should be empty.
 """
 
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
 import pytest
 from pydantic import BaseModel, ConfigDict, field_validator
 
@@ -163,8 +166,81 @@ def test_the_event_records_a_binding_and_resolution_honours_it():
         }
     )
 
-    assert block.data["metadata_bindings"] == {"sample_mass_mg": {"source": "user", "value": "99"}}
+    binding = block.data["metadata_bindings"]["sample_mass_mg"]
+    assert binding["source"] == "user"
+    assert binding["value"] == "99"
     assert block.resolve_metadata().metadata.sample_mass_mg == pytest.approx(99.0)
+
+
+def test_a_binding_records_when_it_was_made():
+    """Somebody deciding a value should not be worked out the usual way is worth
+    being able to attribute afterwards."""
+    block = _Block(item_id="test")
+    block.process_events(
+        {
+            "event_name": "set_metadata_source",
+            "field": "sample_mass_mg",
+            "source": "user",
+            "value": "99",
+        }
+    )
+
+    stamped = datetime.fromisoformat(block.data["metadata_bindings"]["sample_mass_mg"]["set_at"])
+    assert stamped.tzinfo is not None
+    assert abs((datetime.now(tz=timezone.utc) - stamped).total_seconds()) < 60
+
+    # and it reaches the interface alongside the value it belongs to
+    assert block.resolve_metadata().fields["sample_mass_mg"]["set_at"]
+
+
+def test_a_binding_records_who_made_it(monkeypatch):
+    from bson import ObjectId
+
+    from pydatalab.blocks import base
+
+    person = SimpleNamespace(immutable_id=ObjectId("1" * 24), display_name="Ada Lovelace")
+    monkeypatch.setattr(base, "has_request_context", lambda: True)
+    monkeypatch.setattr(base, "current_user", SimpleNamespace(person=person))
+
+    block = _Block(item_id="test")
+    block.process_events(
+        {
+            "event_name": "set_metadata_source",
+            "field": "sample_mass_mg",
+            "source": "user",
+            "value": "99",
+        }
+    )
+
+    binding = block.data["metadata_bindings"]["sample_mass_mg"]
+    assert binding["set_by"] == "1" * 24
+    assert binding["set_by_name"] == "Ada Lovelace"
+
+    # Choosing which source to take a value from is a decision too, so it is
+    # attributed the same way.
+    block.process_events(
+        {"event_name": "set_metadata_source", "field": "sample_mass_mg", "source": "file"}
+    )
+    assert block.data["metadata_bindings"]["sample_mass_mg"]["set_by_name"] == "Ada Lovelace"
+
+    assert block.resolve_metadata().fields["sample_mass_mg"]["set_by_name"] == "Ada Lovelace"
+
+
+def test_there_is_nobody_to_name_outside_a_request():
+    """Which must not be an error: the tests, and any script, resolve blocks with
+    no user logged in."""
+    block = _Block(item_id="test")
+    block.process_events(
+        {
+            "event_name": "set_metadata_source",
+            "field": "sample_mass_mg",
+            "source": "user",
+            "value": "99",
+        }
+    )
+
+    assert not block.data.get("errors")
+    assert "set_by" not in block.data["metadata_bindings"]["sample_mass_mg"]
 
 
 def test_asking_for_auto_drops_the_binding():

--- a/pydatalab/tests/server/test_block_metadata.py
+++ b/pydatalab/tests/server/test_block_metadata.py
@@ -304,6 +304,73 @@ def test_an_event_that_failed_is_still_reported_after_a_plot_that_did_not():
     assert block.to_web()["errors"]
 
 
+def test_a_model_that_does_not_validate_assignments_is_still_protected():
+    """The guarantee that a file may contain nonsense and lose only that field must
+    not depend on the block having thought to enable assignment validation."""
+
+    class Unguarded(BaseModel):
+        sample_mass_mg: float | None = None
+
+    resolution = resolve_metadata(Unguarded, {"file": {"sample_mass_mg": "heavy"}}, None)
+    assert resolution.fields["sample_mass_mg"]["value"] is None
+
+    # and a value still arrives as the type the model asks for
+    typed = resolve_metadata(Unguarded, {}, {"sample_mass_mg": {"source": "user", "value": "99"}})
+    assert typed.metadata.sample_mass_mg == pytest.approx(99.0)
+
+
+def test_a_binding_that_is_not_a_binding_costs_that_field_and_nothing_else():
+    """Bindings come from the database, which has held other shapes before now."""
+    resolution = resolve(bindings={"sample_mass_mg": "nonsense"})
+
+    assert resolution.metadata.sample_mass_mg == pytest.approx(14.32)
+    assert resolution.fields["sample_mass_mg"]["bound"] is False
+
+
+def test_the_web_cannot_write_a_binding_directly():
+    """A binding says who chose a value and when. Letting the web set one would be
+    letting it make a claim about a person that nobody checked."""
+    schema = DataBlock.block_db_model.model_json_schema()["properties"]
+    assert schema["metadata_bindings"]["datalab_exclude_from_load"]
+
+
+def test_a_source_may_not_be_called_user_or_auto():
+    """Those are the two answers the event gives itself, so a source of either name
+    could never be bound to -- and asking for it would blank the field instead."""
+
+    class Colliding(_Block):
+        blocktype = "_metadata_test_colliding"
+
+        def metadata_sources(self):
+            return {"user": {"sample_mass_mg": 1.0}}
+
+    block = Colliding(item_id="test")
+    block.process_events(
+        {"event_name": "set_metadata_source", "field": "sample_mass_mg", "source": "user"}
+    )
+
+    assert block.data["errors"]
+    assert not block.data.get("metadata_bindings")
+
+
+def test_setting_a_source_resolves_there_and_then():
+    """`to_web` only runs the plot functions, so a block whose plots do not resolve
+    would answer the request with the value the field had before the choice."""
+    block = _Block(item_id="test")
+    block.resolve_metadata()
+    block.process_events(
+        {
+            "event_name": "set_metadata_source",
+            "field": "sample_mass_mg",
+            "source": "user",
+            "value": 99,
+        }
+    )
+
+    assert block.data["metadata"]["sample_mass_mg"] == pytest.approx(99.0)
+    assert block.data["metadata_fields"]["sample_mass_mg"]["source"] == "user"
+
+
 def test_resolving_writes_both_the_values_and_their_provenance():
     block = _Block(item_id="test")
     block.resolve_metadata()

--- a/pydatalab/tests/server/test_block_metadata.py
+++ b/pydatalab/tests/server/test_block_metadata.py
@@ -193,6 +193,21 @@ def test_an_impossible_binding_becomes_a_block_error(event):
     assert not block.data.get("metadata_bindings")
 
 
+def test_a_block_may_say_what_its_sources_should_be_called():
+    """ "file" is not much use on its own; which file is the useful half."""
+
+    class Named(_Block):
+        blocktype = "_metadata_test_named"
+
+        def metadata_source_labels(self):
+            return {"file": "measurement.dat"}
+
+    block = Named(item_id="test")
+    block.resolve_metadata()
+
+    assert block.data["metadata_source_labels"] == {"file": "measurement.dat"}
+
+
 def test_resolving_writes_both_the_values_and_their_provenance():
     block = _Block(item_id="test")
     block.resolve_metadata()

--- a/pydatalab/tests/server/test_block_metadata.py
+++ b/pydatalab/tests/server/test_block_metadata.py
@@ -1,0 +1,194 @@
+"""Tests for metadata resolution and the bindings that decide it.
+
+The rule these are all circling: the block's own choices stay open and are made
+again on every render, so a value follows the file or the sample it came from;
+the user's choices are kept, including the choice that a field should be empty.
+"""
+
+import pytest
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from pydatalab.blocks.base import DataBlock
+from pydatalab.blocks.metadata import resolve_metadata
+
+
+class Metadata(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
+    sample_mass_mg: float | None = None
+    molar_mass_g_mol: float | None = None
+    comment: str | None = None
+
+    @field_validator("sample_mass_mg", mode="after")
+    @classmethod
+    def _a_non_positive_mass_is_no_mass(cls, value):
+        return None if value is not None and value <= 0 else value
+
+
+FILE = {"sample_mass_mg": 14.32, "comment": "eicosane"}
+SAMPLE = {"molar_mass_g_mol": 192.7}
+
+
+def resolve(bindings=None, file=None, sample=None):
+    return resolve_metadata(
+        Metadata,
+        {"file": FILE if file is None else file, "sample": SAMPLE if sample is None else sample},
+        bindings,
+    )
+
+
+def test_the_first_source_with_a_value_wins():
+    resolution = resolve()
+
+    assert resolution.metadata.sample_mass_mg == pytest.approx(14.32)
+    assert resolution.fields["sample_mass_mg"]["source"] == "file"
+    assert resolution.fields["molar_mass_g_mol"]["source"] == "sample"
+
+
+def test_a_field_no_source_has_is_empty_and_came_from_nowhere():
+    resolution = resolve(file={}, sample={})
+
+    assert resolution.metadata.comment is None
+    assert resolution.fields["comment"]["source"] is None
+
+
+def test_every_source_is_reported_not_only_the_winner():
+    """The interface needs the alternatives to be able to offer them."""
+    resolution = resolve(sample={"sample_mass_mg": 21.0})
+
+    assert resolution.fields["sample_mass_mg"] == {
+        "value": pytest.approx(14.32),
+        "source": "file",
+        "available": {"file": pytest.approx(14.32), "sample": pytest.approx(21.0)},
+    }
+
+
+def test_a_user_value_beats_every_source():
+    resolution = resolve({"sample_mass_mg": {"source": "user", "value": 99.0}})
+
+    assert resolution.metadata.sample_mass_mg == pytest.approx(99.0)
+    assert resolution.fields["sample_mass_mg"]["source"] == "user"
+    # and the file is still there to go back to
+    assert resolution.fields["sample_mass_mg"]["available"]["file"] == pytest.approx(14.32)
+
+
+def test_a_user_may_say_a_field_has_no_good_value():
+    """Clearing a field is a decision, not the absence of one: the file is not
+    consulted again on the next render."""
+    resolution = resolve({"sample_mass_mg": {"source": "user", "value": None}})
+
+    assert resolution.metadata.sample_mass_mg is None
+    assert resolution.fields["sample_mass_mg"]["source"] == "user"
+
+
+def test_which_is_not_the_same_as_never_having_chosen():
+    assert resolve({}).fields["sample_mass_mg"]["source"] == "file"
+
+
+def test_a_zero_a_user_typed_is_kept_as_their_choice_even_where_it_is_no_value():
+    """The model has nothing to do with a mass of zero, but the decision that this
+    field is not to be filled from the file survives."""
+    resolution = resolve({"sample_mass_mg": {"source": "user", "value": 0}})
+
+    assert resolution.metadata.sample_mass_mg is None
+    assert resolution.fields["sample_mass_mg"]["source"] == "user"
+
+
+def test_a_bound_field_follows_its_source():
+    """The point of binding rather than storing: re-uploading the file moves the
+    value with it."""
+    bindings = {"sample_mass_mg": {"source": "file"}}
+
+    assert resolve(bindings).metadata.sample_mass_mg == pytest.approx(14.32)
+    assert resolve(bindings, file={"sample_mass_mg": 21.4}).metadata.sample_mass_mg == (
+        pytest.approx(21.4)
+    )
+
+
+def test_a_binding_can_pick_a_source_that_would_not_have_won():
+    resolution = resolve({"sample_mass_mg": {"source": "sample"}}, sample={"sample_mass_mg": 21.0})
+
+    assert resolution.metadata.sample_mass_mg == pytest.approx(21.0)
+    assert resolution.fields["sample_mass_mg"]["source"] == "sample"
+
+
+def test_a_binding_whose_source_no_longer_has_the_value_leaves_it_empty():
+    """Falling back would undo a choice somebody made, and do it silently."""
+    resolution = resolve({"sample_mass_mg": {"source": "sample"}})
+
+    assert resolution.metadata.sample_mass_mg is None
+    assert resolution.fields["sample_mass_mg"]["source"] == "sample"
+
+
+def test_an_unbound_field_changes_its_mind_when_a_better_source_appears():
+    """The block guessed; a guess is made again rather than kept."""
+    assert (
+        resolve(sample={"comment": "from the sample"}, file={}).fields["comment"]["source"]
+        == "sample"
+    )
+    assert resolve(sample={"comment": "from the sample"}).fields["comment"]["source"] == "file"
+
+
+def test_a_source_holding_nonsense_costs_that_field_and_nothing_else():
+    """A file is free to contain rubbish in a field nobody needs."""
+    resolution = resolve(file={"sample_mass_mg": "heavy", "comment": "fine"})
+
+    assert resolution.fields["sample_mass_mg"]["value"] is None
+    assert resolution.metadata.comment == "fine"
+
+
+class _Block(DataBlock):
+    blocktype = "_metadata_test"
+    metadata_model = Metadata
+
+    def metadata_sources(self):
+        return {"file": FILE, "sample": SAMPLE}
+
+
+def test_the_event_records_a_binding_and_resolution_honours_it():
+    block = _Block(item_id="test")
+    block.process_events(
+        {
+            "event_name": "set_metadata_source",
+            "field": "sample_mass_mg",
+            "source": "user",
+            "value": "99",
+        }
+    )
+
+    assert block.data["metadata_bindings"] == {"sample_mass_mg": {"source": "user", "value": "99"}}
+    assert block.resolve_metadata().metadata.sample_mass_mg == pytest.approx(99.0)
+
+
+def test_asking_for_auto_drops_the_binding():
+    block = _Block(item_id="test")
+    block.data["metadata_bindings"] = {"sample_mass_mg": {"source": "user", "value": 99.0}}
+    block.process_events(
+        {"event_name": "set_metadata_source", "field": "sample_mass_mg", "source": "auto"}
+    )
+
+    assert block.data["metadata_bindings"] == {}
+    assert block.resolve_metadata().fields["sample_mass_mg"]["source"] == "file"
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"field": "not_a_field", "source": "user", "value": 1},
+        {"field": "sample_mass_mg", "source": "not_a_source"},
+    ],
+)
+def test_an_impossible_binding_becomes_a_block_error(event):
+    block = _Block(item_id="test")
+    block.process_events({"event_name": "set_metadata_source", **event})
+
+    assert block.data["errors"]
+    assert not block.data.get("metadata_bindings")
+
+
+def test_resolving_writes_both_the_values_and_their_provenance():
+    block = _Block(item_id="test")
+    block.resolve_metadata()
+
+    assert block.data["metadata"]["sample_mass_mg"] == pytest.approx(14.32)
+    assert block.data["metadata_fields"]["sample_mass_mg"]["source"] == "file"

--- a/webapp/cypress/component/MetadataFieldTest.cy.jsx
+++ b/webapp/cypress/component/MetadataFieldTest.cy.jsx
@@ -5,7 +5,13 @@ import MetadataField from "@/components/MetadataField.vue";
 describe("MetadataField", () => {
   const mount = (entry) =>
     cy.mount(MetadataField, {
-      propsData: { item_id: "test", block_id: "block", field: "sample_mass_mg", entry },
+      propsData: {
+        item_id: "test",
+        block_id: "block",
+        field: "sample_mass_mg",
+        entry,
+        sourceLabels: { file: "NiCl2btd_MT.rso.dat", sample: "NiCl2btd-01" },
+      },
     });
 
   const fromFile = {
@@ -15,18 +21,33 @@ describe("MetadataField", () => {
     available: { file: 14.32, sample: null },
   };
 
-  it("shows the value and where it came from", () => {
+  it("names the file a value was read out of, not just that it was read from one", () => {
     mount(fromFile);
 
     cy.contains("14.32").should("be.visible");
-    cy.get(".source").should("have.text", "file").and("have.attr", "title").and("include", "file");
+    cy.get(".source").should("have.text", "file");
+    cy.get(".source").should("have.attr", "title", "Supplied by NiCl2btd_MT.rso.dat");
+  });
+
+  it("falls back to the source's own name where there is nothing better", () => {
+    cy.mount(MetadataField, {
+      propsData: { item_id: "test", block_id: "block", field: "sample_mass_mg", entry: fromFile },
+    });
+
+    cy.get(".source").should("have.attr", "title", "Supplied by file");
   });
 
   it("marks a value somebody typed as theirs", () => {
     mount({ value: 99, source: "user", bound: true, available: { file: 14.32 } });
 
     cy.get(".source").should("have.text", "user supplied");
-    cy.get(".source").should("have.attr", "title").and("include", "nothing will overwrite it");
+    cy.get(".source").should("have.attr", "title", "Value overwritten by user");
+  });
+
+  it("says so when somebody has decided there is no value", () => {
+    mount({ value: null, source: "user", bound: true, available: { file: 14.32 } });
+
+    cy.get(".source").should("have.attr", "title", "Value set to blank by user");
   });
 
   it("shows an empty field rather than hiding it", () => {

--- a/webapp/cypress/component/MetadataFieldTest.cy.jsx
+++ b/webapp/cypress/component/MetadataFieldTest.cy.jsx
@@ -1,0 +1,75 @@
+import MetadataField from "@/components/MetadataField.vue";
+
+// Where a value came from decides what may be done to it, so these check that
+// the menu offers what the block says it can and nothing else.
+describe("MetadataField", () => {
+  const mount = (entry) =>
+    cy.mount(MetadataField, {
+      propsData: { item_id: "test", block_id: "block", field: "sample_mass_mg", entry },
+    });
+
+  const fromFile = {
+    value: 14.32,
+    source: "file",
+    bound: false,
+    available: { file: 14.32, sample: null },
+  };
+
+  it("shows the value and where it came from", () => {
+    mount(fromFile);
+
+    cy.contains("14.32").should("be.visible");
+    cy.get(".source").should("have.text", "file").and("have.attr", "title").and("include", "file");
+  });
+
+  it("marks a value somebody typed as theirs", () => {
+    mount({ value: 99, source: "user", bound: true, available: { file: 14.32 } });
+
+    cy.get(".source").should("have.text", "edited");
+    cy.get(".source").should("have.attr", "title").and("include", "nothing will overwrite it");
+  });
+
+  it("shows an empty field rather than hiding it", () => {
+    mount({ value: null, source: null, bound: false, available: { file: null } });
+
+    cy.get(".value").should("have.text", "—").and("have.class", "empty");
+  });
+
+  it("offers only the sources that have something to offer", () => {
+    mount(fromFile);
+    cy.get(".metadata-field").rightclick();
+
+    // `sample` has nothing, and `file` is already in use.
+    cy.get(".dropdown-item").should("not.contain", "sample");
+    cy.get(".dropdown-item").should("not.contain", "Use file value");
+    cy.contains(".dropdown-item", "Override…").should("be.visible");
+    cy.contains(".dropdown-item", "Set to empty").should("be.visible");
+  });
+
+  it("offers a source that did not win, with its value", () => {
+    mount({ ...fromFile, available: { file: 14.32, sample: 21.4 } });
+    cy.get(".metadata-field").rightclick();
+
+    cy.contains(".dropdown-item", "Use sample value").should("contain", "21.4");
+  });
+
+  it("only offers to choose automatically once something has been chosen", () => {
+    mount(fromFile);
+    cy.get(".metadata-field").rightclick();
+    cy.get(".dropdown-item").should("not.contain", "Choose automatically");
+
+    mount({ ...fromFile, bound: true });
+    cy.get(".metadata-field").rightclick();
+    cy.contains(".dropdown-item", "Choose automatically").should("be.visible");
+  });
+
+  it("edits in place, starting from the value on show", () => {
+    mount(fromFile);
+    cy.get(".metadata-field").rightclick();
+    cy.contains(".dropdown-item", "Override…").click();
+
+    cy.get("input").should("be.focused").and("have.value", "14.32");
+    cy.get("input").type("{esc}");
+    cy.get(".value").should("have.text", "14.32");
+  });
+});

--- a/webapp/cypress/component/MetadataFieldTest.cy.jsx
+++ b/webapp/cypress/component/MetadataFieldTest.cy.jsx
@@ -44,6 +44,42 @@ describe("MetadataField", () => {
     cy.get(".source").should("have.attr", "title", "Value overwritten by user");
   });
 
+  it("names who made a choice, and when", () => {
+    mount({
+      value: 99,
+      source: "user",
+      bound: true,
+      available: { file: 14.32 },
+      set_by_name: "Ada Lovelace",
+      set_at: "2026-09-05T18:30:00+00:00",
+    });
+
+    cy.get(".source")
+      .should("have.attr", "title")
+      .and("match", /^Value overwritten by Ada Lovelace on /);
+  });
+
+  it("attributes the choice of a source too, not only a typed value", () => {
+    mount({
+      value: 14.32,
+      source: "file",
+      bound: true,
+      available: { file: 14.32, sample: 21.4 },
+      set_by_name: "Ada Lovelace",
+      set_at: "2026-09-05T18:30:00+00:00",
+    });
+
+    cy.get(".source")
+      .should("have.attr", "title")
+      .and("match", /^Supplied by NiCl2btd_MT\.rso\.dat, chosen by Ada Lovelace on /);
+  });
+
+  it("says only what it knows about a binding nobody is recorded for", () => {
+    mount({ value: 99, source: "user", bound: true, available: {} });
+
+    cy.get(".source").should("have.attr", "title", "Value overwritten by user");
+  });
+
   it("says so when somebody has decided there is no value", () => {
     mount({ value: null, source: "user", bound: true, available: { file: 14.32 } });
 

--- a/webapp/cypress/component/MetadataFieldTest.cy.jsx
+++ b/webapp/cypress/component/MetadataFieldTest.cy.jsx
@@ -1,3 +1,5 @@
+import { h } from "vue";
+
 import MetadataField from "@/components/MetadataField.vue";
 
 // Where a value came from decides what may be done to it, so these check that
@@ -78,6 +80,40 @@ describe("MetadataField", () => {
     mount({ value: 99, source: "user", bound: true, available: {} });
 
     cy.get(".source").should("have.attr", "title", "Value overwritten by user");
+  });
+
+  it("names nobody rather than half of somebody when only the time is known", () => {
+    // A binding made by a script, or by a user with no display name: there is a
+    // timestamp but no actor, and "overwritten on Tuesday" credits no one.
+    mount({
+      value: 99,
+      source: "user",
+      bound: true,
+      available: {},
+      set_at: "2026-09-05T18:30:00+00:00",
+    });
+
+    cy.get(".source").should("have.attr", "title", "Value overwritten by user");
+  });
+
+  it("closes its menu when another field is clicked", () => {
+    // Each field listens on the document for clicks elsewhere, so a field that
+    // swallowed its own clicks would leave every menu ever opened still open.
+    const entry = { value: 1, source: "file", bound: false, available: {} };
+    const props = { item_id: "i", block_id: "b", entry };
+
+    cy.mount(() =>
+      h("div", [
+        h(MetadataField, { ...props, field: "first" }),
+        h(MetadataField, { ...props, field: "second" }),
+      ]),
+    );
+
+    cy.get(".metadata-field").first().click();
+    cy.get(".dropdown-menu").should("have.length", 1);
+
+    cy.get(".metadata-field").last().click();
+    cy.get(".dropdown-menu").should("have.length", 1);
   });
 
   it("says so when somebody has decided there is no value", () => {

--- a/webapp/cypress/component/MetadataFieldTest.cy.jsx
+++ b/webapp/cypress/component/MetadataFieldTest.cy.jsx
@@ -37,7 +37,7 @@ describe("MetadataField", () => {
 
   it("offers only the sources that have something to offer", () => {
     mount(fromFile);
-    cy.get(".metadata-field").rightclick();
+    cy.get(".metadata-field").click();
 
     // `sample` has nothing, and `file` is already in use.
     cy.get(".dropdown-item").should("not.contain", "sample");
@@ -48,28 +48,68 @@ describe("MetadataField", () => {
 
   it("offers a source that did not win, with its value", () => {
     mount({ ...fromFile, available: { file: 14.32, sample: 21.4 } });
-    cy.get(".metadata-field").rightclick();
+    cy.get(".metadata-field").click();
 
     cy.contains(".dropdown-item", "Use sample value").should("contain", "21.4");
   });
 
   it("only offers to choose automatically once something has been chosen", () => {
     mount(fromFile);
-    cy.get(".metadata-field").rightclick();
+    cy.get(".metadata-field").click();
     cy.get(".dropdown-item").should("not.contain", "Choose automatically");
 
     mount({ ...fromFile, bound: true });
-    cy.get(".metadata-field").rightclick();
+    cy.get(".metadata-field").click();
     cy.contains(".dropdown-item", "Choose automatically").should("be.visible");
   });
 
   it("edits in place, starting from the value on show", () => {
     mount(fromFile);
-    cy.get(".metadata-field").rightclick();
+    cy.get(".metadata-field").click();
     cy.contains(".dropdown-item", "Override…").click();
 
     cy.get("input").should("be.focused").and("have.value", "14.32");
-    cy.get("input").type("{esc}");
+  });
+
+  it("can be backed out of, by the button or by the keyboard", () => {
+    mount(fromFile);
+
+    for (const abandon of [
+      () => cy.get(".editor .cancel").click(),
+      () => cy.get("input").type("{esc}"),
+    ]) {
+      cy.get(".metadata-field").click();
+      cy.contains(".dropdown-item", "Override…").click();
+      cy.get("input").clear();
+      cy.get("input").type("999");
+      abandon();
+      cy.get("input").should("not.exist");
+      cy.get(".value").should("have.text", "14.32");
+    }
+  });
+
+  it("still opens on a right-click, for anyone who tries one", () => {
+    mount(fromFile);
+    cy.get(".value").rightclick();
+
+    cy.contains(".dropdown-item", "Override…").should("be.visible");
+  });
+
+  it("does not leave the menu open behind an edit that was saved or abandoned", () => {
+    mount(fromFile);
+    cy.get(".metadata-field").click();
+    cy.contains(".dropdown-item", "Override…").click();
+    cy.get(".editor .cancel").click();
+
+    cy.get(".dropdown-menu").should("not.exist");
+  });
+
+  it("closes the menu without changing anything", () => {
+    mount(fromFile);
+    cy.get(".metadata-field").click();
+    cy.contains(".dropdown-item", "Cancel").click();
+
+    cy.get(".dropdown-menu").should("not.exist");
     cy.get(".value").should("have.text", "14.32");
   });
 });

--- a/webapp/cypress/component/MetadataFieldTest.cy.jsx
+++ b/webapp/cypress/component/MetadataFieldTest.cy.jsx
@@ -25,7 +25,7 @@ describe("MetadataField", () => {
   it("marks a value somebody typed as theirs", () => {
     mount({ value: 99, source: "user", bound: true, available: { file: 14.32 } });
 
-    cy.get(".source").should("have.text", "edited");
+    cy.get(".source").should("have.text", "user supplied");
     cy.get(".source").should("have.attr", "title").and("include", "nothing will overwrite it");
   });
 

--- a/webapp/cypress/component/MetadataViewerTest.cy.jsx
+++ b/webapp/cypress/component/MetadataViewerTest.cy.jsx
@@ -1,0 +1,52 @@
+import MetadataViewer from "@/components/MetadataViewer.vue";
+
+describe("MetadataViewer", () => {
+  const fields = (mass) => ({
+    sample_mass_mg: {
+      value: mass,
+      source: mass === null ? "user" : "file",
+      bound: mass === null,
+      available: {},
+    },
+    molar_mass_g_mol: { value: 192.7, source: "sample", bound: false, available: {} },
+    comment: { value: "eicosane", source: "file", bound: false, available: {} },
+  });
+
+  const labels = () =>
+    cy.get(".metadata-list dt").then(($dt) => [...$dt].map((el) => el.textContent.trim()));
+
+  it("keeps a field in its place when it is emptied", () => {
+    // The order a block declares its metadata in, not the order of whatever
+    // happens to have a value: a field that moves when you clear it, and moves
+    // back when you fill it in, is impossible to work with.
+    cy.mount(MetadataViewer, {
+      propsData: {
+        metadata: { sample_mass_mg: 14.32, molar_mass_g_mol: 192.7, comment: "eicosane" },
+        fields: fields(14.32),
+        item_id: "i",
+        block_id: "b",
+      },
+    });
+    labels().should("deep.equal", ["Sample mass mg", "Molar mass g mol", "Comment"]);
+
+    // The server drops empty values from `metadata` entirely, so this is what
+    // arrives once the mass is cleared.
+    cy.mount(MetadataViewer, {
+      propsData: {
+        metadata: { molar_mass_g_mol: 192.7, comment: "eicosane" },
+        fields: fields(null),
+        item_id: "i",
+        block_id: "b",
+      },
+    });
+    labels().should("deep.equal", ["Sample mass mg", "Molar mass g mol", "Comment"]);
+  });
+
+  it("still leaves out an empty value nothing is tracking", () => {
+    cy.mount(MetadataViewer, {
+      propsData: { metadata: { kept: 1, dropped: null } },
+    });
+
+    labels().should("deep.equal", ["Kept"]);
+  });
+});

--- a/webapp/src/components/MetadataField.vue
+++ b/webapp/src/components/MetadataField.vue
@@ -1,22 +1,36 @@
 <template>
-  <span class="metadata-field" @contextmenu.prevent="openMenu">
-    <input
-      v-if="editing"
-      ref="input"
-      v-model="draft"
-      class="form-control form-control-sm"
-      @keyup.enter="commit"
-      @keyup.esc="editing = false"
-      @blur="commit"
-    />
+  <!-- A div rather than a span: the menu is a `ul`, which a span cannot contain. -->
+  <div class="metadata-field" @click.stop="toggleMenu" @contextmenu.prevent.stop="openMenu">
+    <!-- `click.stop` for the same reason as on the menu: saving or abandoning an
+         edit must not fall through and open the menu behind it. -->
+    <span v-if="editing" class="editor" @click.stop>
+      <input
+        ref="input"
+        v-model="draft"
+        class="form-control form-control-sm"
+        @keyup.enter="commit"
+        @keyup.esc="cancel"
+        @blur="cancel"
+      />
+      <!-- `mousedown.prevent` so the input never loses focus, which would cancel
+           the edit out from under the button being pressed. -->
+      <button class="btn btn-sm btn-link" title="Save" @mousedown.prevent="commit">
+        <font-awesome-icon icon="check" fixed-width />
+      </button>
+      <button class="btn btn-sm btn-link cancel" title="Cancel" @mousedown.prevent="cancel">
+        <font-awesome-icon icon="times" fixed-width />
+      </button>
+    </span>
     <template v-else>
       <span class="value" :class="{ empty: isEmpty }">{{ shown }}</span>
       <span class="source" :class="entry.source" :title="explanation">{{ badge }}</span>
     </template>
 
-    <!-- Right-click menu. The options are whatever the block says it can offer,
-         so a source with nothing to give never appears. -->
-    <ul v-if="menuOpen" ref="menu" class="dropdown-menu show" :style="menuPosition">
+    <!-- The options are whatever the block says it can offer, so a source with
+         nothing to give never appears. -->
+    <!-- `click.stop` so choosing an option does not bubble back to the field and
+         reopen the menu that the option just closed. -->
+    <ul v-if="menuOpen" class="dropdown-menu show" @click.stop>
       <li>
         <button class="dropdown-item" @click="startEditing">Override…</button>
       </li>
@@ -32,8 +46,11 @@
       <li v-if="entry.bound">
         <button class="dropdown-item" @click="bind('auto')">Choose automatically</button>
       </li>
+      <li>
+        <button class="dropdown-item text-muted" @click="closeMenu">Cancel</button>
+      </li>
     </ul>
-  </span>
+  </div>
 </template>
 
 <script>
@@ -50,7 +67,7 @@ export default {
     entry: { type: Object, required: true },
   },
   data() {
-    return { menuOpen: false, menuPosition: {}, editing: false, draft: "" };
+    return { menuOpen: false, editing: false, draft: "" };
   },
   computed: {
     isEmpty() {
@@ -95,9 +112,14 @@ export default {
     format(value) {
       return Array.isArray(value) ? value.join(", ") : String(value);
     },
-    openMenu(event) {
-      this.menuPosition = { top: `${event.offsetY}px`, left: `${event.offsetX}px` };
-      this.menuOpen = true;
+    openMenu() {
+      if (!this.editing) this.menuOpen = true;
+    },
+    toggleMenu() {
+      // Nothing to choose while a value is being typed; the editor has its own
+      // save and cancel.
+      if (this.editing) return;
+      this.menuOpen = !this.menuOpen;
     },
     closeMenu() {
       this.menuOpen = false;
@@ -107,6 +129,9 @@ export default {
       this.editing = true;
       this.menuOpen = false;
       this.$nextTick(() => this.$refs.input?.focus());
+    },
+    cancel() {
+      this.editing = false;
     },
     commit() {
       if (!this.editing) return;
@@ -143,7 +168,26 @@ export default {
   display: inline-flex;
   align-items: baseline;
   gap: 0.4rem;
-  cursor: context-menu;
+  cursor: pointer;
+}
+
+.editor {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+}
+
+.editor .btn-link {
+  padding: 0 0.2rem;
+  color: #6c757d;
+}
+
+.editor .btn-link:hover {
+  color: cornflowerblue;
+}
+
+.editor .cancel:hover {
+  color: #c92a2a;
 }
 
 .value.empty {
@@ -168,8 +212,12 @@ export default {
   font-style: italic;
 }
 
+/* Below the value rather than at the pointer, so it lands in the same place
+   however the menu was opened. */
 .dropdown-menu {
   position: absolute;
+  top: 100%;
+  left: 0;
   z-index: 1000;
 }
 </style>

--- a/webapp/src/components/MetadataField.vue
+++ b/webapp/src/components/MetadataField.vue
@@ -1,0 +1,173 @@
+<template>
+  <span class="metadata-field" @contextmenu.prevent="openMenu">
+    <input
+      v-if="editing"
+      ref="input"
+      v-model="draft"
+      class="form-control form-control-sm"
+      @keyup.enter="commit"
+      @keyup.esc="editing = false"
+      @blur="commit"
+    />
+    <template v-else>
+      <span class="value" :class="{ empty: isEmpty }">{{ shown }}</span>
+      <span class="source" :class="entry.source" :title="explanation">{{ badge }}</span>
+    </template>
+
+    <!-- Right-click menu. The options are whatever the block says it can offer,
+         so a source with nothing to give never appears. -->
+    <ul v-if="menuOpen" ref="menu" class="dropdown-menu show" :style="menuPosition">
+      <li>
+        <button class="dropdown-item" @click="startEditing">Override…</button>
+      </li>
+      <li v-for="(value, source) in offers" :key="source">
+        <button class="dropdown-item" @click="bind(source)">
+          Use {{ source }} value <span class="text-muted">({{ format(value) }})</span>
+        </button>
+      </li>
+      <li><hr class="dropdown-divider" /></li>
+      <li>
+        <button class="dropdown-item" @click="clear">Set to empty</button>
+      </li>
+      <li v-if="entry.bound">
+        <button class="dropdown-item" @click="bind('auto')">Choose automatically</button>
+      </li>
+    </ul>
+  </span>
+</template>
+
+<script>
+import { updateBlockFromServer } from "@/server_fetch_utils.js";
+import store from "@/store/index.js";
+
+export default {
+  props: {
+    item_id: { type: String, required: true },
+    block_id: { type: String, required: true },
+    field: { type: String, required: true },
+    // As served in `metadata_fields`: the value, where it came from, whether that
+    // was chosen or merely landed on, and what the other sources have to offer.
+    entry: { type: Object, required: true },
+  },
+  data() {
+    return { menuOpen: false, menuPosition: {}, editing: false, draft: "" };
+  },
+  computed: {
+    isEmpty() {
+      return this.entry.value === null || this.entry.value === undefined;
+    },
+    shown() {
+      return this.isEmpty ? "—" : this.format(this.entry.value);
+    },
+    badge() {
+      if (this.entry.source === "user") return this.entry.bound ? "edited" : "";
+      return this.entry.source ?? "";
+    },
+    explanation() {
+      if (this.entry.source === "user") {
+        return this.isEmpty
+          ? "Set to empty by hand; it will not be filled in from a file again"
+          : "Entered by hand; nothing will overwrite it";
+      }
+      if (!this.entry.source) return "No source has a value for this";
+      const how = this.entry.bound ? "Taken from" : "Read from";
+      return `${how} the ${this.entry.source}, and follows it if it changes`;
+    },
+    // A source is only worth offering if it has something to offer and is not
+    // already the one in use.
+    offers() {
+      const available = this.entry.available ?? {};
+      return Object.fromEntries(
+        Object.entries(available).filter(
+          ([source, value]) =>
+            value !== null && value !== undefined && source !== this.entry.source,
+        ),
+      );
+    },
+  },
+  mounted() {
+    document.addEventListener("click", this.closeMenu);
+  },
+  beforeUnmount() {
+    document.removeEventListener("click", this.closeMenu);
+  },
+  methods: {
+    format(value) {
+      return Array.isArray(value) ? value.join(", ") : String(value);
+    },
+    openMenu(event) {
+      this.menuPosition = { top: `${event.offsetY}px`, left: `${event.offsetX}px` };
+      this.menuOpen = true;
+    },
+    closeMenu() {
+      this.menuOpen = false;
+    },
+    startEditing() {
+      this.draft = this.isEmpty ? "" : this.format(this.entry.value);
+      this.editing = true;
+      this.menuOpen = false;
+      this.$nextTick(() => this.$refs.input?.focus());
+    },
+    commit() {
+      if (!this.editing) return;
+      this.editing = false;
+      const value = this.draft.trim();
+      // An emptied box is a decision that this field has no good value, which is
+      // why it is sent as a value of the user's rather than as no binding at all.
+      this.send("user", value === "" ? null : value);
+    },
+    clear() {
+      this.menuOpen = false;
+      this.send("user", null);
+    },
+    bind(source) {
+      this.menuOpen = false;
+      this.send(source, null);
+    },
+    send(source, value) {
+      const block = store.state.all_item_data[this.item_id]?.blocks_obj?.[this.block_id];
+      updateBlockFromServer(this.item_id, this.block_id, block, {
+        event_name: "set_metadata_source",
+        field: this.field,
+        source,
+        value,
+      }).catch((error) => console.error("Could not set the metadata source:", error));
+    },
+  },
+};
+</script>
+
+<style scoped>
+.metadata-field {
+  position: relative;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  cursor: context-menu;
+}
+
+.value.empty {
+  color: #adb5bd;
+}
+
+/* The provenance sits beside the value rather than replacing it: quiet enough to
+   ignore while reading the numbers, there when you look for it. */
+.source {
+  font-size: 0.7rem;
+  text-transform: lowercase;
+  color: #adb5bd;
+  border-bottom: 1px dotted currentColor;
+  cursor: help;
+}
+
+/* A value somebody typed is the one worth being able to pick out. */
+.source.user {
+  color: #b8860b;
+  font-style: italic;
+}
+
+.dropdown-menu {
+  position: absolute;
+  z-index: 1000;
+}
+</style>

--- a/webapp/src/components/MetadataField.vue
+++ b/webapp/src/components/MetadataField.vue
@@ -83,12 +83,26 @@ export default {
       if (this.entry.source === "user") return this.entry.bound ? "user supplied" : "";
       return this.entry.source ?? "";
     },
+    // Who made a choice and when, where anyone is recorded. A binding made outside
+    // a request -- by a script, or before this was tracked -- has neither.
+    attribution() {
+      const who = this.entry.set_by_name ? ` by ${this.entry.set_by_name}` : "";
+      const when = this.entry.set_at ? ` on ${new Date(this.entry.set_at).toLocaleString()}` : "";
+      return who + when;
+    },
     explanation() {
       if (this.entry.source === "user") {
-        return this.isEmpty ? "Value set to blank by user" : "Value overwritten by user";
+        const what = this.isEmpty ? "Value set to blank" : "Value overwritten";
+        return `${what}${this.attribution || " by user"}`;
       }
       if (!this.entry.source) return "No source has a value for this";
-      return `Supplied by ${this.sourceLabels[this.entry.source] ?? this.entry.source}`;
+
+      const supplied = `Supplied by ${this.sourceLabels[this.entry.source] ?? this.entry.source}`;
+      // Only worth saying who chose it where somebody did; otherwise the block
+      // worked it out and there is nobody to name.
+      return this.entry.bound && this.attribution
+        ? `${supplied}, chosen${this.attribution}`
+        : supplied;
     },
     // A source is only worth offering if it has something to offer and is not
     // already the one in use.

--- a/webapp/src/components/MetadataField.vue
+++ b/webapp/src/components/MetadataField.vue
@@ -60,7 +60,7 @@ export default {
       return this.isEmpty ? "—" : this.format(this.entry.value);
     },
     badge() {
-      if (this.entry.source === "user") return this.entry.bound ? "edited" : "";
+      if (this.entry.source === "user") return this.entry.bound ? "user supplied" : "";
       return this.entry.source ?? "";
     },
     explanation() {
@@ -160,9 +160,11 @@ export default {
   cursor: help;
 }
 
-/* A value somebody typed is the one worth being able to pick out. */
+/* A value somebody typed is the one worth being able to pick out. Deliberately
+   not in the yellow the rest of datalab uses for unsaved changes: this says where
+   a value came from, not that anything needs doing about it. */
 .source.user {
-  color: #b8860b;
+  color: #4a6fa5;
   font-style: italic;
 }
 

--- a/webapp/src/components/MetadataField.vue
+++ b/webapp/src/components/MetadataField.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- A div rather than a span: the menu is a `ul`, which a span cannot contain. -->
-  <div class="metadata-field" @click.stop="toggleMenu" @contextmenu.prevent.stop="openMenu">
+  <div ref="root" class="metadata-field" @click="toggleMenu" @contextmenu.prevent.stop="openMenu">
     <!-- `click.stop` for the same reason as on the menu: saving or abandoning an
          edit must not fall through and open the menu behind it. -->
     <span v-if="editing" class="editor" @click.stop>
@@ -47,7 +47,7 @@
         <button class="dropdown-item" @click="bind('auto')">Choose automatically</button>
       </li>
       <li>
-        <button class="dropdown-item text-muted" @click="closeMenu">Cancel</button>
+        <button class="dropdown-item text-muted" @click="menuOpen = false">Cancel</button>
       </li>
     </ul>
   </div>
@@ -85,10 +85,13 @@ export default {
     },
     // Who made a choice and when, where anyone is recorded. A binding made outside
     // a request -- by a script, or before this was tracked -- has neither.
+    // Who made a choice and when. A binding made outside a request -- by a script,
+    // or by a user with no display name -- has a time but nobody to name, and a
+    // time on its own credits no one, so it is not an attribution at all.
     attribution() {
-      const who = this.entry.set_by_name ? ` by ${this.entry.set_by_name}` : "";
+      if (!this.entry.set_by_name) return "";
       const when = this.entry.set_at ? ` on ${new Date(this.entry.set_at).toLocaleString()}` : "";
-      return who + when;
+      return ` by ${this.entry.set_by_name}${when}`;
     },
     explanation() {
       if (this.entry.source === "user") {
@@ -98,8 +101,8 @@ export default {
       if (!this.entry.source) return "No source has a value for this";
 
       const supplied = `Supplied by ${this.sourceLabels[this.entry.source] ?? this.entry.source}`;
-      // Only worth saying who chose it where somebody did; otherwise the block
-      // worked it out and there is nobody to name.
+      // Only worth saying who chose it where somebody is recorded; otherwise the
+      // block worked it out, or nobody was named, and there is no one to credit.
       return this.entry.bound && this.attribution
         ? `${supplied}, chosen${this.attribution}`
         : supplied;
@@ -135,7 +138,13 @@ export default {
       if (this.editing) return;
       this.menuOpen = !this.menuOpen;
     },
-    closeMenu() {
+    closeMenu(event) {
+      // Clicks inside this field are its own business -- opening the menu, or
+      // choosing from it. Anything else closes it, including a click on another
+      // field, which is how only one menu is ever open at a time.
+      // `$refs` rather than `$el`: the comment above makes this a fragment, so
+      // `$el` is that comment rather than the element, and contains nothing.
+      if (event && this.$refs.root?.contains(event.target)) return;
       this.menuOpen = false;
     },
     startEditing() {

--- a/webapp/src/components/MetadataField.vue
+++ b/webapp/src/components/MetadataField.vue
@@ -65,6 +65,9 @@ export default {
     // As served in `metadata_fields`: the value, where it came from, whether that
     // was chosen or merely landed on, and what the other sources have to offer.
     entry: { type: Object, required: true },
+    // What to call each source when explaining where a value came from: the name
+    // of the file rather than "file".
+    sourceLabels: { type: Object, default: () => ({}) },
   },
   data() {
     return { menuOpen: false, editing: false, draft: "" };
@@ -82,13 +85,10 @@ export default {
     },
     explanation() {
       if (this.entry.source === "user") {
-        return this.isEmpty
-          ? "Set to empty by hand; it will not be filled in from a file again"
-          : "Entered by hand; nothing will overwrite it";
+        return this.isEmpty ? "Value set to blank by user" : "Value overwritten by user";
       }
       if (!this.entry.source) return "No source has a value for this";
-      const how = this.entry.bound ? "Taken from" : "Read from";
-      return `${how} the ${this.entry.source}, and follows it if it changes`;
+      return `Supplied by ${this.sourceLabels[this.entry.source] ?? this.entry.source}`;
     },
     // A source is only worth offering if it has something to offer and is not
     // already the one in use.
@@ -201,7 +201,6 @@ export default {
   text-transform: lowercase;
   color: #adb5bd;
   border-bottom: 1px dotted currentColor;
-  cursor: help;
 }
 
 /* A value somebody typed is the one worth being able to pick out. Deliberately

--- a/webapp/src/components/MetadataViewer.vue
+++ b/webapp/src/components/MetadataViewer.vue
@@ -89,20 +89,25 @@ export default {
   },
   computed: {
     displayedMetadata() {
-      if (!this.metadata) return {};
+      const values = this.metadata || {};
+
+      // `fields` names every tracked field in the order the block declares them,
+      // empty ones included, while `metadata` carries only those with a value.
+      // Taking the order from `fields` is what stops a field moving down the list
+      // the moment it is emptied and back up again when it is filled in.
+      const keys = [...new Set([...Object.keys(this.fields), ...Object.keys(values)])];
 
       const filtered = {};
-      for (const [key, value] of Object.entries(this.metadata)) {
-        if (!this.excludeKeys.includes(key) && value !== null && value !== undefined) {
-          filtered[key] = value;
-        }
-      }
-      // A tracked field is shown even when it is empty: an empty one is exactly
-      // the one somebody needs to be able to right-click and fill in.
-      for (const key of Object.keys(this.fields)) {
-        if (!this.excludeKeys.includes(key) && !(key in filtered)) {
-          filtered[key] = this.metadata?.[key] ?? null;
-        }
+      for (const key of keys) {
+        if (this.excludeKeys.includes(key)) continue;
+
+        const value = values[key] ?? null;
+        // An empty tracked field stays: it is exactly the one somebody needs to
+        // reach in order to give it a value. An empty untracked one has nothing
+        // to offer and is left out, as it always was.
+        if (value === null && !(key in this.fields)) continue;
+
+        filtered[key] = value;
       }
       return filtered;
     },

--- a/webapp/src/components/MetadataViewer.vue
+++ b/webapp/src/components/MetadataViewer.vue
@@ -25,6 +25,7 @@
             :block_id="block_id"
             :field="String(key)"
             :entry="fields[key]"
+            :source-labels="sourceLabels"
           />
           <details v-else-if="isExpandable(value)" class="value-details">
             <summary>{{ summaryFor(value) }}</summary>
@@ -56,6 +57,10 @@ export default {
     // `metadata_fields` as the block serves it: the entries whose provenance is
     // known, keyed the same as `metadata`. Anything not in here renders as before.
     fields: {
+      type: Object,
+      default: () => ({}),
+    },
+    sourceLabels: {
       type: Object,
       default: () => ({}),
     },

--- a/webapp/src/components/MetadataViewer.vue
+++ b/webapp/src/components/MetadataViewer.vue
@@ -17,7 +17,16 @@
       <template v-for="(value, key) in displayedMetadata" :key="key">
         <dt :title="String(key)">{{ formatLabel(key) }}</dt>
         <dd>
-          <details v-if="isExpandable(value)" class="value-details">
+          <!-- A field the block tracks the provenance of is editable in place and
+               says where it came from; the rest are plain values. -->
+          <MetadataField
+            v-if="fields[key]"
+            :item_id="item_id"
+            :block_id="block_id"
+            :field="String(key)"
+            :entry="fields[key]"
+          />
+          <details v-else-if="isExpandable(value)" class="value-details">
             <summary>{{ summaryFor(value) }}</summary>
             <pre class="value-json">{{ prettyPrint(value) }}</pre>
           </details>
@@ -29,15 +38,34 @@
 </template>
 
 <script>
+import MetadataField from "@/components/MetadataField";
+
 // Values longer than this are collapsed behind a <details> rather than being
 // allowed to dominate what is usually a narrow column beside a plot.
 const INLINE_LENGTH_LIMIT = 80;
 
 export default {
+  components: {
+    MetadataField,
+  },
   props: {
     metadata: {
       type: Object,
       default: () => ({}),
+    },
+    // `metadata_fields` as the block serves it: the entries whose provenance is
+    // known, keyed the same as `metadata`. Anything not in here renders as before.
+    fields: {
+      type: Object,
+      default: () => ({}),
+    },
+    item_id: {
+      type: String,
+      default: null,
+    },
+    block_id: {
+      type: String,
+      default: null,
     },
     labels: {
       type: Object,
@@ -62,6 +90,13 @@ export default {
       for (const [key, value] of Object.entries(this.metadata)) {
         if (!this.excludeKeys.includes(key) && value !== null && value !== undefined) {
           filtered[key] = value;
+        }
+      }
+      // A tracked field is shown even when it is empty: an empty one is exactly
+      // the one somebody needs to be able to right-click and fill in.
+      for (const key of Object.keys(this.fields)) {
+        if (!this.excludeKeys.includes(key) && !(key in filtered)) {
+          filtered[key] = this.metadata?.[key] ?? null;
         }
       }
       return filtered;

--- a/webapp/src/components/datablocks/DataBlockBase.vue
+++ b/webapp/src/components/datablocks/DataBlockBase.vue
@@ -182,7 +182,12 @@
 
         <div v-if="hasMetadata && metadataShown" class="col-xl-4 col-lg-4 col-md-12">
           <slot name="metadata" :metadata="block.metadata">
-            <MetadataViewer :metadata="block.metadata" />
+            <MetadataViewer
+              :metadata="block.metadata"
+              :fields="block.metadata_fields || {}"
+              :item_id="item_id"
+              :block_id="block_id"
+            />
           </slot>
         </div>
       </div>
@@ -286,7 +291,12 @@ export default {
       return this.processingStages[this.processingStages.length - 1].message;
     },
     hasMetadata() {
-      return this.block?.metadata && Object.keys(this.block.metadata).length > 0;
+      // A tracked field counts even when it is empty: an empty one is exactly the
+      // one somebody needs to reach in order to give it a value.
+      return (
+        Object.keys(this.block?.metadata || {}).length > 0 ||
+        Object.keys(this.block?.metadata_fields || {}).length > 0
+      );
     },
   },
   mounted() {

--- a/webapp/src/components/datablocks/DataBlockBase.vue
+++ b/webapp/src/components/datablocks/DataBlockBase.vue
@@ -185,6 +185,7 @@
             <MetadataViewer
               :metadata="block.metadata"
               :fields="block.metadata_fields || {}"
+              :source-labels="block.metadata_source_labels || {}"
               :item_id="item_id"
               :block_id="block_id"
             />

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -842,6 +842,10 @@ export async function updateBlockFromServer(item_id, block_id, block_data, event
   delete block_data.b64_encoded_image;
   delete block_data.computed;
   delete block_data.metadata;
+  // Derived from the metadata and larger than it: every source's value for every
+  // field. The server rebuilds it and refuses to load it, so sending it is waste.
+  delete block_data.metadata_fields;
+  delete block_data.metadata_source_labels;
 
   store.commit("setBlockUpdating", block_id);
   return fetch_post(`${API_URL}/update-block/`, {


### PR DESCRIPTION
The metadata viewer currently nicely displays the metadata available on a block, which is generally set during file read. This PR adds the ability for the block developer to set how the metadata should be determined (e.g., from the data file vs. inherited from the sample vs. supplied by the user). The user can also override any values by clicking on it in the metadata viewer, and that metadata is tracked. 

This PR will also probably hide metadata by default, and fix an issue where hiding/showing the metadata causes the screen to jump positions (not complete yet).

Some screenshots of the new behavior (demonstrated with the private SQUID block):
<img width="2033" height="910" alt="temp" src="https://github.com/user-attachments/assets/678a71e5-178f-45c8-b765-a6ff47b65d9c" />
