### PR TITLE
Fix typos in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 </div>
 
 <!-- --8<-- [start:intro] -->
-_datalab_ is a user-friendly, open-source platform that can capture all the experimental data and metadata produced in a scientific lab, targeted (broadly) at materials chemistry but with customisability and extensability in mind.
+_datalab_ is a user-friendly, open-source platform that can capture all the experimental data and metadata produced in a scientific lab, targeted (broadly) at materials chemistry but with customisability and extensibility in mind.
 _datalab_ records data and metadata securely and makes it accessible and reusable by both humans and machines _via_ the web UI and API, respectively.
 _datalab_ can be self-hosted and managed deployments are also available.
 <!-- --8<-- [end:intro] -->

--- a/pydatalab/docs/deployment.md
+++ b/pydatalab/docs/deployment.md
@@ -157,7 +157,7 @@ You must somehow download the latest *datalab* changes to your server (ideally w
     you will need to prepare for the upgrade by running `mongodump` with the original database version
     and then `mongorestore` after upgrading.
 
-    If you are unsure, please ask for help on GitHub or Slack before attmepting this.
+    If you are unsure, please ask for help on GitHub or Slack before attempting this.
 
 ```shell
 cd datalab-deployment/datalab;

--- a/pydatalab/docs/plugins.md
+++ b/pydatalab/docs/plugins.md
@@ -144,7 +144,7 @@ As a rule of thumb, if you would want to *filter* the item list by it, it is a f
     create/edit forms for custom types, so custom fields are readable and
     writable through the API but do not appear in item detail pages.
 
-Eventually, such item types will allow for rich descriptions of unitful quantites, semantic annotations and URIs for fields, and cross-linking between items via custom relationships.
+Eventually, such item types will allow for rich descriptions of unitful quantities, semantic annotations and URIs for fields, and cross-linking between items via custom relationships.
 
 ## Plugin installation
 


### PR DESCRIPTION
Fixes 3 spelling mistakes in the docs, found with `codespell`.

Prose only. No code identifiers, dependency names or proper nouns changed, and anything that was a valid word rather than a misspelling was left alone.