### PR TITLE
Bump Debian version to trixie in app docker build

### DIFF
--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:22.22-bullseye-slim AS base
+FROM node:22.22-trixie-slim AS base
 SHELL ["/bin/bash", "--login", "-c"]
 
 WORKDIR /app
@@ -26,7 +26,7 @@ RUN apt update \
         libnotify-dev \
         libnss3 \
         libxss1 \
-        libasound2 \
+        libasound2t64 \
         libxtst6 \
         xauth \
         xvfb \
@@ -57,7 +57,7 @@ ENV VUE_APP_GIT_VERSION=${VUE_APP_GIT_VERSION}
 
 RUN /node_modules/.bin/vue-cli-service build
 
-FROM node:22.22-bullseye-slim AS production
+FROM node:22.22-trixie-slim AS production
 
 ENV PATH=$PATH:/node_modules/.bin
 COPY ./.docker/app_entrypoint.sh /app/


### PR DESCRIPTION
Bullseye is now out of support so install fails without cached versions.