### PR TITLE
Add post plot hooks for FAST plugin

### DIFF
--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -1564,6 +1564,55 @@
       "description": "The charge of the active ion species.",
       "title": "Active Ion Charge",
       "type": "number"
+    },
+    "theoretical_capacity": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The theoretical specific capacity of the active material, in mAh/g.",
+      "title": "Theoretical Capacity"
+    },
+    "nominal_capacity_unit": {
+      "default": "mAh",
+      "description": "The unit that `nominal_capacity` is given in.",
+      "enum": [
+        "mAh",
+        "Ah"
+      ],
+      "title": "Nominal Capacity Unit",
+      "type": "string"
+    },
+    "nominal_capacity": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The nominal capacity of the cell, computed as\n`theoretical_capacity * characteristic_mass`. See `set_nominal_capacity`.",
+      "title": "Nominal Capacity"
+    },
+    "nominal_capacity_mah": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "`nominal_capacity` normalized to mAh, regardless of the unit currently selected\non this item (`nominal_capacity_unit`). Read-only/derived: always recomputed on\nsave (see `set_nominal_capacity`). Prefer this field over `nominal_capacity`\nwhenever comparing or aggregating across cells, since `nominal_capacity_unit` can\ndiffer from item to item.",
+      "title": "Nominal Capacity Mah"
     }
   },
   "required": [

--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -1598,8 +1598,14 @@
         }
       ],
       "default": null,
-      "description": "The nominal capacity of the cell, computed as\n`theoretical_capacity * characteristic_mass`. See `set_nominal_capacity`.",
+      "description": "The nominal capacity of the cell. Computed as `theoretical_capacity *\ncharacteristic_mass` unless `nominal_capacity_manual` is set, in which case the\nuser-supplied value is kept as-is. See `set_nominal_capacity`.",
       "title": "Nominal Capacity"
+    },
+    "nominal_capacity_manual": {
+      "default": false,
+      "description": "Whether `nominal_capacity` was entered directly by a user rather than computed\nfrom `theoretical_capacity` and `characteristic_mass`. When set, `set_nominal_capacity`\nwill not overwrite `nominal_capacity`/`nominal_capacity_mah` on save.",
+      "title": "Nominal Capacity Manual",
+      "type": "boolean"
     },
     "nominal_capacity_mah": {
       "anyOf": [
@@ -1611,7 +1617,7 @@
         }
       ],
       "default": null,
-      "description": "`nominal_capacity` normalized to mAh, regardless of the unit currently selected\non this item (`nominal_capacity_unit`). Read-only/derived: always recomputed on\nsave (see `set_nominal_capacity`). Prefer this field over `nominal_capacity`\nwhenever comparing or aggregating across cells, since `nominal_capacity_unit` can\ndiffer from item to item.",
+      "description": "`nominal_capacity` normalized to mAh, regardless of the unit currently selected\non this item (`nominal_capacity_unit`). Prefer this field over `nominal_capacity`\nwhenever comparing or aggregating across cells, since `nominal_capacity_unit` can\ndiffer from item to item.",
       "title": "Nominal Capacity Mah"
     }
   },

--- a/pydatalab/src/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/src/pydatalab/apps/echem/blocks.py
@@ -1,7 +1,8 @@
 import hashlib
 import warnings
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import bokeh
 import pandas as pd
@@ -68,6 +69,30 @@ class CycleBlock(DataBlock):
         "win_size_1": 1001,
         "derivative_mode": None,
     }
+
+    post_plot_hooks: ClassVar[
+        list[Callable[["CycleBlock", pd.DataFrame, pd.DataFrame | None], None]]
+    ] = []
+    """Hooks called after plot_cycle completes, receiving (block, unfiltered_df, cycle_summary_df).
+
+    Plugins can append callables here to extract derived metrics into ``block.data["computed"]``
+    without monkey-patching. Each hook is called once per plot update with the primary
+    (non-comparison) DataFrames.
+
+    ``unfiltered_df`` is the full navani DataFrame re-parsed directly from the source file,
+    bypassing the BDF cache, so instrument-specific columns (e.g. ``unknown_colID_249``) that
+    are not part of the BDF schema are available. Note this incurs an extra file parse when
+    hooks are registered.
+
+    Example::
+
+        from pydatalab.apps.echem import CycleBlock
+
+        def my_hook(block, unfiltered_df, cycle_summary_df):
+            block.data["computed"] = {"my_metric": unfiltered_df["unknown_colID_249"].max()}
+
+        CycleBlock.post_plot_hooks.append(my_hook)
+    """
 
     def _get_characteristic_mass_g(self):
         doc = flask_mongo.db.items.find_one(
@@ -424,6 +449,8 @@ class CycleBlock(DataBlock):
 
         raw_dfs = {}
         cycle_summary_dfs = {}
+        raw_df = None
+        cycle_summary_df = None
 
         if self.data.get("mode") is None:
             self.data["mode"] = "single"
@@ -530,6 +557,27 @@ class CycleBlock(DataBlock):
             self.data["bokeh_plot_data"] = bokeh.embed.json_item(
                 layout, theme=bokeh_plots.DATALAB_BOKEH_THEME
             )
+
+        if raw_df is not None and self.post_plot_hooks:
+            # Re-parse from source to get the full unfiltered DataFrame, since the BDF cache
+            # only preserves BDF-schema columns and drops instrument-specific ones.
+            file_infos = [get_file_info_by_id(fid, update_if_live=False) for fid in file_ids]
+            locations = [Path(info["location"]) for info in file_infos]
+            try:
+                unfiltered_df = self._parse_echem_files(
+                    locations[0], locations if len(locations) > 1 else None
+                )
+            except Exception as exc:
+                warnings.warn(f"post_plot_hook source re-parse failed, hooks will not run: {exc}")
+                unfiltered_df = None
+
+            if unfiltered_df is not None:
+                for hook in self.post_plot_hooks:
+                    try:
+                        hook(self, unfiltered_df, cycle_summary_df)
+                    except Exception as exc:
+                        warnings.warn(f"post_plot_hook {hook!r} failed: {exc}")
+
         return
 
     @property

--- a/pydatalab/src/pydatalab/models/cells.py
+++ b/pydatalab/src/pydatalab/models/cells.py
@@ -11,6 +11,11 @@ from pydatalab.models.entries import EntryReference
 from pydatalab.models.items import Item
 from pydatalab.models.utils import CellStatus, Constituent
 
+# Conversion factor from nominal_capacity_unit to the base unit (mAh). Single source of
+# truth: used by `set_nominal_capacity`, so any downstream consumer normalizes
+# consistently regardless of which unit is currently selected on a given item.
+NOMINAL_CAPACITY_TO_MAH = {"mAh": 1, "Ah": 1e3}
+
 
 class CellComponent(Constituent): ...
 
@@ -72,6 +77,23 @@ class Cell(Item):
     status: CellStatus = Field(default=CellStatus.ACTIVE)
     """The status of the cells, indicating its current state."""
 
+    theoretical_capacity: float | None = None
+    """The theoretical specific capacity of the active material, in mAh/g."""
+
+    nominal_capacity_unit: Literal["mAh", "Ah"] = "mAh"
+    """The unit that `nominal_capacity` is given in."""
+
+    nominal_capacity: float | None = None
+    """The nominal capacity of the cell, computed as
+    `theoretical_capacity * characteristic_mass`. See `set_nominal_capacity`."""
+
+    nominal_capacity_mah: float | None = None
+    """`nominal_capacity` normalized to mAh, regardless of the unit currently selected
+    on this item (`nominal_capacity_unit`). Read-only/derived: always recomputed on
+    save (see `set_nominal_capacity`). Prefer this field over `nominal_capacity`
+    whenever comparing or aggregating across cells, since `nominal_capacity_unit` can
+    differ from item to item."""
+
     @field_validator("characteristic_molar_mass", mode="before")
     @classmethod
     def set_molar_mass(cls, v, info):
@@ -85,6 +107,22 @@ class Cell(Item):
                 except Exception:
                     return None
         return v
+
+    @model_validator(mode="after")
+    def set_nominal_capacity(self):
+        if self.theoretical_capacity is None or self.characteristic_mass is None:
+            self.nominal_capacity_mah = None
+            return self
+
+        # theoretical_capacity is in mAh/g; characteristic_mass is in mg (divide by
+        # 1000 to get grams).
+        nominal_capacity_mah = self.theoretical_capacity * self.characteristic_mass / 1000
+
+        self.nominal_capacity_mah = nominal_capacity_mah
+        self.nominal_capacity = (
+            nominal_capacity_mah / NOMINAL_CAPACITY_TO_MAH[self.nominal_capacity_unit]
+        )
+        return self
 
     @model_validator(mode="after")
     def add_missing_electrode_relationships(self):

--- a/pydatalab/src/pydatalab/models/cells.py
+++ b/pydatalab/src/pydatalab/models/cells.py
@@ -84,13 +84,18 @@ class Cell(Item):
     """The unit that `nominal_capacity` is given in."""
 
     nominal_capacity: float | None = None
-    """The nominal capacity of the cell, computed as
-    `theoretical_capacity * characteristic_mass`. See `set_nominal_capacity`."""
+    """The nominal capacity of the cell. Computed as `theoretical_capacity *
+    characteristic_mass` unless `nominal_capacity_manual` is set, in which case the
+    user-supplied value is kept as-is. See `set_nominal_capacity`."""
+
+    nominal_capacity_manual: bool = False
+    """Whether `nominal_capacity` was entered directly by a user rather than computed
+    from `theoretical_capacity` and `characteristic_mass`. When set, `set_nominal_capacity`
+    will not overwrite `nominal_capacity`/`nominal_capacity_mah` on save."""
 
     nominal_capacity_mah: float | None = None
     """`nominal_capacity` normalized to mAh, regardless of the unit currently selected
-    on this item (`nominal_capacity_unit`). Read-only/derived: always recomputed on
-    save (see `set_nominal_capacity`). Prefer this field over `nominal_capacity`
+    on this item (`nominal_capacity_unit`). Prefer this field over `nominal_capacity`
     whenever comparing or aggregating across cells, since `nominal_capacity_unit` can
     differ from item to item."""
 
@@ -110,6 +115,17 @@ class Cell(Item):
 
     @model_validator(mode="after")
     def set_nominal_capacity(self):
+        if self.nominal_capacity_manual:
+            # Trust the user-supplied value; just normalize it to mAh for comparison
+            # across items with different `nominal_capacity_unit`.
+            if self.nominal_capacity is None:
+                self.nominal_capacity_mah = None
+            else:
+                self.nominal_capacity_mah = (
+                    self.nominal_capacity * NOMINAL_CAPACITY_TO_MAH[self.nominal_capacity_unit]
+                )
+            return self
+
         if self.theoretical_capacity is None or self.characteristic_mass is None:
             self.nominal_capacity_mah = None
             return self

--- a/pydatalab/tests/test_models.py
+++ b/pydatalab/tests/test_models.py
@@ -472,6 +472,59 @@ def test_cell_relationship_deduplication():
     assert parthood[0].item_id == "test_cathode"
 
 
+def test_cell_nominal_capacity():
+    """`nominal_capacity` (and its mAh-normalized counterpart `nominal_capacity_mah`)
+    are derived from `theoretical_capacity` (mAh/g) * `characteristic_mass` (mg),
+    unit-aware with respect to `nominal_capacity_unit`."""
+    from pydatalab.models.cells import Cell
+
+    # Neither input supplied: no capacity can be computed.
+    cell = Cell(item_id="abcd-1-2-3")
+    assert cell.nominal_capacity is None
+    assert cell.nominal_capacity_mah is None
+
+    # Only one of the two inputs supplied: still no capacity can be computed.
+    cell = Cell(item_id="abcd-1-2-3", theoretical_capacity=200.0)
+    assert cell.nominal_capacity is None
+    assert cell.nominal_capacity_mah is None
+
+    cell = Cell(item_id="abcd-1-2-3", characteristic_mass=5.0)
+    assert cell.nominal_capacity is None
+    assert cell.nominal_capacity_mah is None
+
+    # Default unit (mAh): 200 mAh/g * 5 mg = 1 mAh.
+    cell = Cell(item_id="abcd-1-2-3", characteristic_mass=5.0, theoretical_capacity=200.0)
+    assert cell.nominal_capacity_unit == "mAh"
+    assert cell.nominal_capacity == pytest.approx(1.0)
+    assert cell.nominal_capacity_mah == pytest.approx(1.0)
+
+    # Requesting the result in Ah: same underlying quantity, different display unit.
+    cell = Cell(
+        item_id="abcd-1-2-3",
+        characteristic_mass=5.0,
+        theoretical_capacity=200.0,
+        nominal_capacity_unit="Ah",
+    )
+    assert cell.nominal_capacity == pytest.approx(0.001)
+    # nominal_capacity_mah is unit-independent and always mAh.
+    assert cell.nominal_capacity_mah == pytest.approx(1.0)
+
+    # A client-supplied nominal_capacity is not trusted: it is always recomputed
+    # from theoretical_capacity * characteristic_mass.
+    cell = Cell(
+        item_id="abcd-1-2-3",
+        characteristic_mass=5.0,
+        theoretical_capacity=200.0,
+        nominal_capacity=999,
+    )
+    assert cell.nominal_capacity == pytest.approx(1.0)
+
+    # Round-tripping through JSON (as happens on save/load) preserves the computed values.
+    cell = Cell(**json.loads(cell.model_dump_json()))
+    assert cell.nominal_capacity == pytest.approx(1.0)
+    assert cell.nominal_capacity_mah == pytest.approx(1.0)
+
+
 def test_sample_synthesis_relationship_deduplication():
     """Regression test for duplicated parent relationships on synthesis constituents.
 

--- a/pydatalab/tests/test_models.py
+++ b/pydatalab/tests/test_models.py
@@ -509,8 +509,8 @@ def test_cell_nominal_capacity():
     # nominal_capacity_mah is unit-independent and always mAh.
     assert cell.nominal_capacity_mah == pytest.approx(1.0)
 
-    # A client-supplied nominal_capacity is not trusted: it is always recomputed
-    # from theoretical_capacity * characteristic_mass.
+    # A client-supplied nominal_capacity is not trusted by default: it is always
+    # recomputed from theoretical_capacity * characteristic_mass.
     cell = Cell(
         item_id="abcd-1-2-3",
         characteristic_mass=5.0,
@@ -523,6 +523,52 @@ def test_cell_nominal_capacity():
     cell = Cell(**json.loads(cell.model_dump_json()))
     assert cell.nominal_capacity == pytest.approx(1.0)
     assert cell.nominal_capacity_mah == pytest.approx(1.0)
+
+
+def test_cell_nominal_capacity_manual_override():
+    """When `nominal_capacity_manual` is set, a user-supplied `nominal_capacity` is
+    kept as-is rather than being recomputed from `theoretical_capacity` and
+    `characteristic_mass`, but `nominal_capacity_mah` is still normalized from it."""
+    from pydatalab.models.cells import Cell
+
+    # Manual value is honoured even though mass/theoretical capacity would imply
+    # a different result.
+    cell = Cell(
+        item_id="abcd-1-2-3",
+        characteristic_mass=5.0,
+        theoretical_capacity=200.0,
+        nominal_capacity=5.0,
+        nominal_capacity_manual=True,
+    )
+    assert cell.nominal_capacity == pytest.approx(5.0)
+    assert cell.nominal_capacity_mah == pytest.approx(5.0)
+
+    # Manual value in a non-default unit is normalized to mAh.
+    cell = Cell(
+        item_id="abcd-1-2-3",
+        nominal_capacity=5.0,
+        nominal_capacity_unit="Ah",
+        nominal_capacity_manual=True,
+    )
+    assert cell.nominal_capacity == pytest.approx(5.0)
+    assert cell.nominal_capacity_mah == pytest.approx(5000.0)
+
+    # Manual flag with no supplied value: nothing to normalize.
+    cell = Cell(item_id="abcd-1-2-3", nominal_capacity_manual=True)
+    assert cell.nominal_capacity is None
+    assert cell.nominal_capacity_mah is None
+
+    # Round-tripping through JSON preserves the manual value rather than recomputing it.
+    cell = Cell(
+        item_id="abcd-1-2-3",
+        characteristic_mass=5.0,
+        theoretical_capacity=200.0,
+        nominal_capacity=5.0,
+        nominal_capacity_manual=True,
+    )
+    cell = Cell(**json.loads(cell.model_dump_json()))
+    assert cell.nominal_capacity == pytest.approx(5.0)
+    assert cell.nominal_capacity_mah == pytest.approx(5.0)
 
 
 def test_sample_synthesis_relationship_deduplication():

--- a/webapp/src/components/CellInformation.vue
+++ b/webapp/src/components/CellInformation.vue
@@ -93,6 +93,37 @@
             />
           </div>
         </div>
+        <div class="form-row py-4">
+          <div class="form-group col-lg-4 col-md-4 pr-3">
+            <label for="cell-theoretical-capacity">Theoretical capacity (mAh/g)</label>
+            <input
+              id="cell-theoretical-capacity"
+              v-model="TheoreticalCapacity"
+              class="form-control"
+              type="text"
+              :class="{ 'red-border': isNaN(TheoreticalCapacity) }"
+            />
+          </div>
+          <div class="form-group col-lg-4 col-md-4">
+            <label
+              for="cell-nominal-capacity"
+              title="Computed live as theoretical capacity × active mass."
+            >
+              Nominal capacity
+            </label>
+            <div class="input-group">
+              <div id="cell-nominal-capacity" class="form-control">
+                {{ NominalCapacityDisplay }}
+              </div>
+              <div class="input-group-append">
+                <select v-model="NominalCapacityUnit" class="form-control">
+                  <option value="mAh">mAh</option>
+                  <option value="Ah">Ah</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        </div>
         <div class="row">
           <div class="col">
             <label id="cell-description-label">Description</label>
@@ -175,11 +206,45 @@ export default {
     CharacteristicMass: createComputedSetterForItemField("characteristic_mass"),
     Collections: createComputedSetterForItemField("collections"),
     Status: createComputedSetterForItemField("status"),
+    TheoreticalCapacity: createComputedSetterForItemField("theoretical_capacity"),
+    NominalCapacityUnit: createComputedSetterForItemField("nominal_capacity_unit"),
     schema() {
       return this.$store.state.schemas[this.item?.type];
     },
     possibleItemStatuses() {
       return this.schema?.attributes?.schema?.["$defs"]?.CellStatus?.enum;
+    },
+    // Recomputed live from the store on every render — no save round-trip needed.
+    NominalCapacity() {
+      const nominalCapacityToMah = { mAh: 1, Ah: 1e3 };
+
+      // theoretical_capacity is always mAh/g.
+      const theoreticalCapacity = Number(this.TheoreticalCapacity);
+      const characteristicMass = Number(this.CharacteristicMass);
+      if (!Number.isFinite(theoreticalCapacity) || !Number.isFinite(characteristicMass)) {
+        return null;
+      }
+
+      const nominalCapacityUnit = this.NominalCapacityUnit || "mAh";
+
+      // characteristic_mass is stored in mg; divide by 1000 to get grams.
+      const mAh = (theoreticalCapacity * characteristicMass) / 1000;
+      return mAh / nominalCapacityToMah[nominalCapacityUnit];
+    },
+    NominalCapacityDisplay() {
+      return this.NominalCapacity === null ? "—" : this.NominalCapacity.toFixed(4);
+    },
+  },
+  watch: {
+    // Persist the live-computed value too, so it's saved without relying on a
+    // server round-trip (the backend validator recomputes it again on save).
+    NominalCapacity(value) {
+      if (value !== null && value !== this.item?.nominal_capacity) {
+        this.$store.commit("updateItemData", {
+          item_id: this.item_id,
+          item_data: { nominal_capacity: value },
+        });
+      }
     },
   },
 };

--- a/webapp/src/components/CellInformation.vue
+++ b/webapp/src/components/CellInformation.vue
@@ -105,16 +105,26 @@
             />
           </div>
           <div class="form-group col-lg-4 col-md-4">
-            <label
-              for="cell-nominal-capacity"
-              title="Computed live as theoretical capacity × active mass."
-            >
+            <label for="cell-nominal-capacity">
               Nominal capacity
+              <a
+                v-if="NominalCapacityManual"
+                href="#"
+                class="ml-1"
+                title="Reset to the value calculated from theoretical capacity × active mass."
+                @click.prevent="resetNominalCapacityToCalculated"
+              >
+                (reset to calculated)
+              </a>
             </label>
             <div class="input-group">
-              <div id="cell-nominal-capacity" class="form-control">
-                {{ NominalCapacityDisplay }}
-              </div>
+              <input
+                id="cell-nominal-capacity"
+                v-model="NominalCapacityInput"
+                class="form-control"
+                type="text"
+                :class="{ 'red-border': isNaN(NominalCapacityInput) }"
+              />
               <div class="input-group-append">
                 <select v-model="NominalCapacityUnit" class="form-control">
                   <option value="mAh">mAh</option>
@@ -122,6 +132,9 @@
                 </select>
               </div>
             </div>
+            <small v-if="NominalCapacityMismatchWarning" class="form-text text-warning">
+              {{ NominalCapacityMismatchWarning }}
+            </small>
           </div>
         </div>
         <div class="row">
@@ -208,14 +221,17 @@ export default {
     Status: createComputedSetterForItemField("status"),
     TheoreticalCapacity: createComputedSetterForItemField("theoretical_capacity"),
     NominalCapacityUnit: createComputedSetterForItemField("nominal_capacity_unit"),
+    NominalCapacityManual: createComputedSetterForItemField("nominal_capacity_manual"),
     schema() {
       return this.$store.state.schemas[this.item?.type];
     },
     possibleItemStatuses() {
       return this.schema?.attributes?.schema?.["$defs"]?.CellStatus?.enum;
     },
-    // Recomputed live from the store on every render — no save round-trip needed.
-    NominalCapacity() {
+    // The value that would be calculated from theoretical capacity × active mass,
+    // in the currently selected unit. Used both to auto-fill the field while it is
+    // not manually overridden, and to warn when a manual value diverges from it.
+    CalculatedNominalCapacity() {
       const nominalCapacityToMah = { mAh: 1, Ah: 1e3 };
 
       // theoretical_capacity is always mAh/g.
@@ -231,20 +247,59 @@ export default {
       const mAh = (theoreticalCapacity * characteristicMass) / 1000;
       return mAh / nominalCapacityToMah[nominalCapacityUnit];
     },
-    NominalCapacityDisplay() {
-      return this.NominalCapacity === null ? "—" : this.NominalCapacity.toFixed(4);
+    NominalCapacityInput: {
+      get() {
+        if (this.NominalCapacityManual) {
+          return this.item?.nominal_capacity;
+        }
+        return this.CalculatedNominalCapacity === null
+          ? null
+          : Number(this.CalculatedNominalCapacity.toFixed(4));
+      },
+      set(value) {
+        const numericValue = value === "" ? null : Number(value);
+        this.$store.commit("updateItemData", {
+          item_id: this.item_id,
+          item_data: { nominal_capacity: numericValue, nominal_capacity_manual: true },
+        });
+      },
+    },
+    NominalCapacityMismatchWarning() {
+      if (!this.NominalCapacityManual) {
+        return null;
+      }
+      const manualValue = Number(this.item?.nominal_capacity);
+      if (!Number.isFinite(manualValue) || this.CalculatedNominalCapacity === null) {
+        return null;
+      }
+      if (Math.abs(manualValue - this.CalculatedNominalCapacity) < 1e-6) {
+        return null;
+      }
+      return `Doesn't match the value calculated from theoretical capacity × active mass (${this.CalculatedNominalCapacity.toFixed(4)} ${this.NominalCapacityUnit || "mAh"}).`;
     },
   },
   watch: {
-    // Persist the live-computed value too, so it's saved without relying on a
-    // server round-trip (the backend validator recomputes it again on save).
-    NominalCapacity(value) {
-      if (value !== null && value !== this.item?.nominal_capacity) {
+    // While the field is not manually overridden, keep the persisted value in sync
+    // with the live-computed one, so it's saved without relying on a server
+    // round-trip (the backend validator recomputes it again on save regardless).
+    CalculatedNominalCapacity(value) {
+      if (!this.NominalCapacityManual && value !== null && value !== this.item?.nominal_capacity) {
         this.$store.commit("updateItemData", {
           item_id: this.item_id,
           item_data: { nominal_capacity: value },
         });
       }
+    },
+  },
+  methods: {
+    resetNominalCapacityToCalculated() {
+      this.$store.commit("updateItemData", {
+        item_id: this.item_id,
+        item_data: {
+          nominal_capacity_manual: false,
+          nominal_capacity: this.CalculatedNominalCapacity,
+        },
+      });
     },
   },
 };


### PR DESCRIPTION
Adds post plot hooks to the CycleBlock so the FAST plugin can extract kpi's

Adds nominal capacity to the cell model.